### PR TITLE
chore(ci): use organization Android workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -8,27 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Grant permission
-        run: chmod +x ./gradlew
-
-      - name: Build APK
-        run: ./gradlew assembleDebug
-        working-directory: android
-
-      - name: Upload APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: ev-charge-book-debug-apk
-          path: android/**/build/outputs/apk/**/*.apk
+    uses: Assembles-J/.github/.github/workflows/android-build.yml@main
+    with:
+      java-version: '17'
+      working-directory: android
+      gradle-task: assembleDebug
+      artifact-name: ev-charge-book-debug-apk
+      artifact-path: android/**/build/outputs/apk/**/*.apk


### PR DESCRIPTION
## Summary

Attempted to replace the local Android build implementation with the reusable workflow maintained in `Assembles-J/.github`.

## Result

Closed without merge after CI exposed a pre-existing repository scaffold gap: the current `android/` tree does not yet contain a Gradle wrapper or a complete buildable Gradle project. The previous local workflow also assumed a wrapper that is not present.

Organization-level reusable workflow support is working; EV-Charge-Book should adopt it after the Android project scaffold is completed.