### PR TITLE
refactor(android): finish secondary-screen visual alignment

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingRecordRules
@@ -92,13 +93,8 @@ fun AddRecordScreen(
     val odometerValue = odometer.toDoubleOrNull()
     val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometerValue)
 
-    Scaffold(
-        topBar = { TopAppBar(title = { Text("记录充电") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }
-    ) { padding ->
-        Column(
-            Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
-        ) {
+    Scaffold(topBar = { TopAppBar(title = { Text("记录充电") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             FormSection("时间与地点", "先记录事实，详细备注可以之后再补。") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
@@ -166,6 +162,7 @@ private fun FormSection(title: String, subtitle: String, content: @Composable Co
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SingleChoiceSegment(options: List<String>, selected: String, onSelect: (String) -> Unit) {
     SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -24,12 +24,7 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RecordEditScreen(
-    record: ChargingRecordEntity,
-    records: List<ChargingRecordEntity>,
-    onSave: (ChargingRecordEntity) -> Unit,
-    onBack: () -> Unit
-) {
+fun RecordEditScreen(record: ChargingRecordEntity, records: List<ChargingRecordEntity>, onSave: (ChargingRecordEntity) -> Unit, onBack: () -> Unit) {
     val context = LocalContext.current
     val calendar = remember { Calendar.getInstance().apply { timeInMillis = record.chargeTimeEpochMillis } }
     var chargeTime by remember { mutableLongStateOf(record.chargeTimeEpochMillis) }
@@ -42,37 +37,42 @@ fun RecordEditScreen(
     var odometer by remember { mutableStateOf(record.odometerKm?.toString().orEmpty()) }
     var chargerType by remember { mutableStateOf(record.chargerType ?: "公共慢充") }
     var error by remember { mutableStateOf<String?>(null) }
-    val dateText = remember(chargeTime) { SimpleDateFormat("yyyy年M月d日", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
+    val dateText = remember(chargeTime) { SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
     val timeText = remember(chargeTime) { SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
-    val previousOdometer = remember(records, record.id, record.vehicleId, chargeTime) {
-        ChargingRecordRules.previousOdometerKm(records, record.vehicleId, chargeTime, record.id)
-    }
-    val odometerValue = odometer.toDoubleOrNull()
-    val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometerValue)
+    val previousOdometer = remember(records, record.id, record.vehicleId, chargeTime) { ChargingRecordRules.previousOdometerKm(records, record.vehicleId, chargeTime, record.id) }
+    val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometer.toDoubleOrNull())
 
-    Scaffold(topBar = { TopAppBar(title = { Text("编辑充电记录") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回记录") } }) }) { padding ->
-        Column(Modifier.fillMaxSize().padding(padding).padding(MaterialTheme.spacing.md).verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-            Text("补全本次充电信息", style = MaterialTheme.typography.titleLarge)
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                OutlinedButton(onClick = { DatePickerDialog(context, { _, year, month, day -> calendar.set(year, month, day); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.CalendarMonth, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(dateText) }
-                OutlinedButton(onClick = { TimePickerDialog(context, { _, hour, minute -> calendar.set(Calendar.HOUR_OF_DAY, hour); calendar.set(Calendar.MINUTE, minute); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.Schedule, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(timeText) }
+    Scaffold(topBar = { TopAppBar(title = { Text("编辑充电记录") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            EditSection("时间与地点") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    OutlinedButton(onClick = { DatePickerDialog(context, { _, y, m, d -> calendar.set(y, m, d); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.CalendarMonth, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(dateText) }
+                    OutlinedButton(onClick = { TimePickerDialog(context, { _, h, minute -> calendar.set(Calendar.HOUR_OF_DAY, h); calendar.set(Calendar.MINUTE, minute); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.Schedule, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(timeText) }
+                }
+                OutlinedTextField(location, { location = it }, label = { Text("充电地点") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
             }
-            OutlinedTextField(location, { location = it }, label = { Text("充电地点") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
-            Text("充电方式", style = MaterialTheme.typography.titleSmall)
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) { listOf("家充", "公共慢充", "公共快充").forEach { type -> FilterChip(selected = chargerType == type, onClick = { chargerType = type }, label = { Text(type) }) } }
-            Text("车辆里程（可选）", style = MaterialTheme.typography.titleSmall)
-            NumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth())
-            previousOdometer?.let { Text("上一条有效里程：${formatEditKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-            odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
-            Text("电池与费用", style = MaterialTheme.typography.titleSmall)
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                NumberField(startSoc, { startSoc = it }, "起始 SOC", "%", Modifier.weight(1f))
-                NumberField(endSoc, { endSoc = it }, "结束 SOC", "%", Modifier.weight(1f))
+            EditSection("充电数据") {
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                    val options = listOf("家充", "公共慢充", "公共快充")
+                    options.forEachIndexed { index, option -> SegmentedButton(selected = chargerType == option, onClick = { chargerType = option }, shape = SegmentedButtonDefaults.itemShape(index, options.size)) { Text(option) } }
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    NumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                    NumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    NumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
+                    NumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
+                }
             }
-            NumberField(energy, { energy = it }, "充电量", "kWh", Modifier.fillMaxWidth())
-            NumberField(cost, { cost = it }, "总费用", "元", Modifier.fillMaxWidth())
-            OutlinedTextField(remark, { remark = it }, label = { Text("备注（可选）") }, modifier = Modifier.fillMaxWidth(), minLines = 2)
-            error?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium) }
+            EditSection("车辆与备注") {
+                NumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
+                previousOdometer?.let { Text("上一条有效里程 ${formatEditKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+                OutlinedTextField(remark, { remark = it }, label = { Text("备注") }, placeholder = { Text("可选") }, modifier = Modifier.fillMaxWidth(), minLines = 2)
+            }
+            error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
             Button(onClick = {
                 val start = startSoc.toIntOrNull(); val end = endSoc.toIntOrNull(); val energyValue = energy.toDoubleOrNull(); val costValue = cost.toDoubleOrNull(); val odometerKm = odometer.toDoubleOrNull()
                 error = when {
@@ -84,13 +84,13 @@ fun RecordEditScreen(
                     odometer.isNotBlank() && (odometerKm == null || odometerKm < 0) -> "里程需要是大于等于 0 的数字"
                     else -> null
                 }
-                if (error == null) onSave(record.copy(location = location, remark = remark, startSoc = start!!, endSoc = end!!, energyKwh = energyValue!!, cost = costValue!!, chargerType = chargerType, chargeTimeEpochMillis = chargeTime, odometerKm = odometerKm))
+                if (error == null) onSave(record.copy(location = location.trim().takeIf { it.isNotEmpty() }, remark = remark.trim().takeIf { it.isNotEmpty() }, startSoc = start!!, endSoc = end!!, energyKwh = energyValue!!, cost = costValue!!, chargerType = chargerType, chargeTimeEpochMillis = chargeTime, odometerKm = odometerKm))
             }, modifier = Modifier.fillMaxWidth()) { Text("保存修改") }
+            Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
     }
 }
 
-@Composable private fun NumberField(value: String, onChange: (String) -> Unit, label: String, suffix: String, modifier: Modifier) {
-    OutlinedTextField(value = value, onValueChange = onChange, label = { Text(label) }, suffix = { Text(suffix) }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), modifier = modifier, singleLine = true)
-}
+@Composable private fun EditSection(title: String, content: @Composable ColumnScope.() -> Unit) { Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { Text(title, style = MaterialTheme.typography.titleMedium); content() } }
+@Composable private fun NumberField(value: String, onChange: (String) -> Unit, label: String, suffix: String, modifier: Modifier, keyboardType: KeyboardType) { OutlinedTextField(value, onChange, label = { Text(label) }, suffix = { Text(suffix) }, keyboardOptions = KeyboardOptions(keyboardType = keyboardType), modifier = modifier, singleLine = true) }
 private fun formatEditKm(value: Double) = if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
@@ -23,166 +23,214 @@ import java.util.Date
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Composable fun StatsScreen(state: MainUiState) {
-    Scaffold(topBar = { TopAppBar(title = { Column { Text("能耗分析"); Text("所有数据均来自本地充电记录", style = MaterialTheme.typography.labelMedium) } }) }) { padding ->
-        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+@Composable
+fun StatsScreen(state: MainUiState) {
+    Scaffold(topBar = { TopAppBar(title = { Text("统计") }) }) { padding ->
+        LazyColumn(
+            Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+        ) {
             item { MonthSummary(state) }
             MonthlyChargingComparison.compare(state.monthlyTrend)?.let { comparison -> item { MonthComparisonCard(comparison) } }
-            if (state.monthlyTrend.isNotEmpty()) item { MonthlyTrendCard(state) }
-            if (state.chargingRecords.isNotEmpty()) item { ChargerTypeCard(state) }
-            if (state.chargingPlaceSummary.isNotEmpty()) item { CommonPlacesCard(state) }
-            item { Text("累计账本", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) }
-            item { Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { StatTile("累计费用", "¥ ${two(state.totalCost)}", Icons.Default.Payments, Modifier.weight(1f)); StatTile("累计补能", "${one(state.totalEnergy)} kWh", Icons.Default.Bolt, Modifier.weight(1f)) } }
+            if (state.monthlyTrend.isNotEmpty()) item { AnalyticsSection("最近 6 个月", "费用、补能与平均电价") { MonthlyTrendContent(state) } }
+            if (state.chargingRecords.isNotEmpty()) item { AnalyticsSection("充电方式", "当前车辆的充电结构") { ChargerTypeContent(state) } }
+            if (state.chargingPlaceSummary.isNotEmpty()) item { AnalyticsSection("常用地点", "按已保存地点文本统计") { CommonPlacesContent(state) } }
+            item { SectionHeading("累计账本", "从第一条记录至今") }
+            item {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    StatTile("累计费用", "¥ ${two(state.totalCost)}", Icons.Default.Payments, Modifier.weight(1f))
+                    StatTile("累计补能", "${one(state.totalEnergy)} kWh", Icons.Default.Bolt, Modifier.weight(1f))
+                }
+            }
             item { StatTile("平均充电单价", "¥ ${two(state.averagePrice)} / kWh", Icons.Default.BarChart, Modifier.fillMaxWidth()) }
             item { IntervalAnalyticsCard(state) }
             if (state.intervalSamples.isNotEmpty()) item { IntervalDetailSection(state) }
-            item { OutlinedCard(Modifier.fillMaxWidth()) { Column(Modifier.padding(MaterialTheme.spacing.md)) { Text("数据正在积累", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Spacer(Modifier.height(MaterialTheme.spacing.xs)); Text("记录更多带里程、地点与真实行程的数据后，这里会继续完善地点复用与更长期趋势分析。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) } } }
-        }
-    }
-}
-
-@Composable private fun MonthSummary(state: MainUiState) {
-    Card(Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)) {
-        Column(Modifier.padding(MaterialTheme.spacing.lg)) {
-            Text("本月充电支出", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onTertiaryContainer)
-            Text("¥ ${two(state.monthCost)}", style = MaterialTheme.typography.displayMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onTertiaryContainer)
-            Spacer(Modifier.height(MaterialTheme.spacing.md))
-            HorizontalDivider(color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.24f))
-            Spacer(Modifier.height(MaterialTheme.spacing.md))
-            Row { Text("${one(state.monthEnergy)} kWh", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onTertiaryContainer); Spacer(Modifier.width(MaterialTheme.spacing.md)); Text("${state.chargingCount} 次记录", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onTertiaryContainer) }
-        }
-    }
-}
-
-@Composable private fun MonthComparisonCard(comparison: com.evchargebook.domain.MonthlyComparison) {
-    OutlinedCard(Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Text("本月 vs 上月", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text("${comparison.previous.year}年${comparison.previous.month}月 → ${comparison.current.year}年${comparison.current.month}月", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                ComparisonValue("费用", "¥ ${two(comparison.current.cost)}", comparison.costChangeRate, Modifier.weight(1f))
-                ComparisonValue("补能", "${one(comparison.current.energyKwh)} kWh", comparison.energyChangeRate, Modifier.weight(1f))
-                ComparisonValue("次数", "${comparison.current.chargingCount} 次", comparison.countChangeRate, Modifier.weight(1f))
-            }
-            if (comparison.costChangeRate == null || comparison.energyChangeRate == null || comparison.countChangeRate == null) Text("上月对应指标为 0，暂无可靠百分比基线；保留绝对值对比，不显示无意义的无限增长率。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-    }
-}
-
-@Composable private fun ComparisonValue(label: String, value: String, changeRate: Double?, modifier: Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-        Text(changeRate?.let(::signedPercent) ?: "暂无可比基线", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-}
-
-@Composable private fun MonthlyTrendCard(state: MainUiState) {
-    OutlinedCard(Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Text("最近 6 个月", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text("自然月费用与补能趋势；空月份保留为 0。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            state.monthlyTrend.forEachIndexed { index, bucket ->
-                if (index > 0) HorizontalDivider()
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Column { Text("${bucket.year}年${bucket.month}月", fontWeight = FontWeight.SemiBold); Text("${bucket.chargingCount} 次充电", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                    Column { Text("¥ ${two(bucket.cost)}", fontWeight = FontWeight.SemiBold); Text("${one(bucket.energyKwh)} kWh", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                    Text(bucket.averagePricePerKwh?.let { "¥ ${two(it)}/kWh" } ?: "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            item {
+                Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                    Column(Modifier.padding(MaterialTheme.spacing.md)) {
+                        Text("数据仍在积累", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        Spacer(Modifier.height(MaterialTheme.spacing.xs))
+                        Text("更多带里程、地点和真实行程的记录，会让长期趋势和区间估算更可靠。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
                 }
             }
         }
     }
 }
 
-@Composable private fun ChargerTypeCard(state: MainUiState) {
-    OutlinedCard(Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Text("充电方式结构", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text("次数占比、补能量和费用均来自当前车辆的本地账本。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            state.chargerTypeSummary.forEachIndexed { index, item ->
-                if (index > 0) HorizontalDivider()
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Column { Text(chargerCategoryText(item.category), fontWeight = FontWeight.SemiBold); Text("${item.chargingCount} 次 · ${percent(item.countShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                    Column { Text("${one(item.energyKwh)} kWh"); Text("电量 ${percent(item.energyShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                    Column { Text("¥ ${two(item.cost)}"); Text("费用 ${percent(item.costShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                }
+@Composable
+private fun MonthSummary(state: MainUiState) {
+    Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.primaryContainer) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Text("本月充电支出", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = .72f))
+            Text("¥ ${two(state.monthCost)}", style = MaterialTheme.typography.displaySmall, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+                StatValue("补能", "${one(state.monthEnergy)} kWh", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
+                StatValue("次数", "${state.chargingCount} 次", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
+                StatValue("均价", "¥ ${two(state.averagePrice)}", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
             }
         }
     }
 }
 
-@Composable private fun CommonPlacesCard(state: MainUiState) {
+@Composable
+private fun MonthComparisonCard(comparison: com.evchargebook.domain.MonthlyComparison) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        SectionHeading("本月 vs 上月", "${comparison.previous.year}年${comparison.previous.month}月 → ${comparison.current.year}年${comparison.current.month}月")
+        Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            ComparisonValue("费用", "¥ ${two(comparison.current.cost)}", comparison.costChangeRate, Modifier.weight(1f))
+            ComparisonValue("补能", "${one(comparison.current.energyKwh)} kWh", comparison.energyChangeRate, Modifier.weight(1f))
+            ComparisonValue("次数", "${comparison.current.chargingCount} 次", comparison.countChangeRate, Modifier.weight(1f))
+        }
+        if (comparison.costChangeRate == null || comparison.energyChangeRate == null || comparison.countChangeRate == null) {
+            Text("上月为 0 的指标不显示无意义的增长率。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ComparisonValue(label: String, value: String, changeRate: Double?, modifier: Modifier) {
+    Surface(modifier, shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.padding(MaterialTheme.spacing.md)) {
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(changeRate?.let(::signedPercent) ?: "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun AnalyticsSection(title: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        SectionHeading(title, subtitle)
+        Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+            Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm), content = content)
+        }
+    }
+}
+
+@Composable
+private fun MonthlyTrendContent(state: MainUiState) {
+    state.monthlyTrend.forEachIndexed { index, bucket ->
+        if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Column { Text("${bucket.year}年${bucket.month}月", fontWeight = FontWeight.SemiBold); Text("${bucket.chargingCount} 次", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Column { Text("¥ ${two(bucket.cost)}", fontWeight = FontWeight.SemiBold); Text("${one(bucket.energyKwh)} kWh", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Text(bucket.averagePricePerKwh?.let { "¥ ${two(it)}/kWh" } ?: "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ChargerTypeContent(state: MainUiState) {
+    state.chargerTypeSummary.forEachIndexed { index, item ->
+        if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Column { Text(chargerCategoryText(item.category), fontWeight = FontWeight.SemiBold); Text("${item.chargingCount} 次 · ${percent(item.countShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Column { Text("${one(item.energyKwh)} kWh"); Text("电量 ${percent(item.energyShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Column { Text("¥ ${two(item.cost)}"); Text("费用 ${percent(item.costShare)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+        }
+    }
+}
+
+@Composable
+private fun CommonPlacesContent(state: MainUiState) {
     val topPlaces = state.chargingPlaceSummary.take(5)
-    OutlinedCard(Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Text("常用充电地点", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text("由已保存的地点文本派生；只折叠空白，不模糊合并相似地址。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            topPlaces.forEachIndexed { index, place ->
-                if (index > 0) HorizontalDivider()
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Column(Modifier.weight(1.4f)) {
-                        Text(place.displayName, fontWeight = FontWeight.SemiBold)
-                        Text("${place.chargingCount} 次 · 最近 ${shortDate(place.latestChargeTimeEpochMillis)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    topPlaces.forEachIndexed { index, place ->
+        if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Column(Modifier.weight(1.4f)) { Text(place.displayName, fontWeight = FontWeight.SemiBold); Text("${place.chargingCount} 次 · ${shortDate(place.latestChargeTimeEpochMillis)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Column(Modifier.weight(1f)) { Text("${one(place.energyKwh)} kWh"); Text("¥ ${two(place.cost)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Text(place.averagePricePerKwh?.let { "¥ ${two(it)}/kWh" } ?: "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun IntervalAnalyticsCard(state: MainUiState) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Icon(Icons.Default.Route, null, tint = MaterialTheme.colorScheme.primary)
+            SectionHeading("里程区间估算", "基于相邻充电记录，不等同 BMS 表显电耗")
+        }
+        Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+            Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                if (state.intervalSampleCount == 0 || state.intervalEnergyPer100Km == null || state.intervalCostPer100Km == null) {
+                    Text("至少需要两条有效且递增的里程记录。", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                } else {
+                    Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                        StatValue("补入电量", "${one(state.intervalEnergyPer100Km)} kWh/100km", Modifier.weight(1f))
+                        StatValue("费用", "¥ ${two(state.intervalCostPer100Km)}/100km", Modifier.weight(1f))
                     }
-                    Column(Modifier.weight(1f)) {
-                        Text("${one(place.energyKwh)} kWh")
-                        Text("¥ ${two(place.cost)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("${state.intervalSampleCount} 个有效区间 · ${one(state.intervalDistanceKm)} km 样本", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (state.invalidIntervalCount > 0) Text("已排除 ${state.invalidIntervalCount} 个异常区间。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
+                }
+                if (state.tripCoverageIntervalCount > 0 && state.tripCoverageRatio != null) {
+                    HorizontalDivider()
+                    Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                        StatValue("轨迹覆盖", percent(state.tripCoverageRatio), Modifier.weight(1f))
+                        StatValue("Trip 距离", "${one(state.tripCoverageDistanceKm)} km", Modifier.weight(1f))
                     }
-                    Text(place.averagePricePerKwh?.let { "¥ ${two(it)}/kWh" } ?: "--", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("${state.tripCoverageIntervalCount} 个区间有完整 Trip 证据。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
-            if (state.chargingPlaceSummary.size > topPlaces.size) Text("当前展示前 ${topPlaces.size} 个地点，共 ${state.chargingPlaceSummary.size} 个已记录地点。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
 
-@Composable private fun IntervalAnalyticsCard(state: MainUiState) {
-    OutlinedCard(Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { Icon(Icons.Default.Route, null, tint = MaterialTheme.colorScheme.primary); Column { Text("里程区间账本估算", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold); Text("同一车辆相邻带里程的充电记录", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) } }
-            if (state.intervalSampleCount == 0 || state.intervalEnergyPer100Km == null || state.intervalCostPer100Km == null) Text("至少需要两条有效且递增的里程记录，才能形成第一个区间样本。", color = MaterialTheme.colorScheme.onSurfaceVariant)
-            else {
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { StatValue("补入电量", "${one(state.intervalEnergyPer100Km)} kWh/100km", Modifier.weight(1f)); StatValue("费用", "¥ ${two(state.intervalCostPer100Km)}/100km", Modifier.weight(1f)) }
-                Text("${state.intervalSampleCount} 个有效区间 · ${one(state.intervalDistanceKm)} km 样本距离", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                if (state.invalidIntervalCount > 0) Text("已排除 ${state.invalidIntervalCount} 个里程倒退、零距离或异常区间。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-            }
-            if (state.tripCoverageIntervalCount > 0 && state.tripCoverageRatio != null) {
-                HorizontalDivider(); Text("Trip 辅助证据", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { StatValue("轨迹覆盖", percent(state.tripCoverageRatio), Modifier.weight(1f)); StatValue("Trip 距离", "${one(state.tripCoverageDistanceKm)} km", Modifier.weight(1f)) }
-                Text("${state.tripCoverageIntervalCount} 个区间有完整 Trip 证据；对应里程表区间 ${one(state.tripCoverageOdometerKm)} km。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                val difference = state.tripCoverageOdometerKm - state.tripCoverageDistanceKm
-                if (kotlin.math.abs(difference) >= 1.0) Text("Trip 与里程表相差 ${one(kotlin.math.abs(difference))} km。该差异仅用于发现漏记、GPS 漂移或边界问题，不自动修正任何原始数据。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-            }
-            Text("说明：这是按充电账本补入电量/费用与相邻里程计算的区间估算，不等同于车辆 BMS 或表显真实电耗。Trip 只作为辅助证据。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-    }
-}
-
-@Composable private fun IntervalDetailSection(state: MainUiState) {
-    val recordsById = state.chargingRecords.associateBy { it.id }; val coverageByCurrentRecord = state.tripCoverageIntervals.associateBy { it.currentRecordId }
+@Composable
+private fun IntervalDetailSection(state: MainUiState) {
+    val recordsById = state.chargingRecords.associateBy { it.id }
+    val coverageByCurrentRecord = state.tripCoverageIntervals.associateBy { it.currentRecordId }
     val recent = state.intervalSamples.sortedByDescending { recordsById[it.currentRecordId]?.chargeTimeEpochMillis ?: Long.MIN_VALUE }.take(8)
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-        Text("最近区间明细", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        SectionHeading("最近区间明细", "${state.intervalSamples.size} 个有效区间")
         recent.forEach { sample -> IntervalDetailCard(sample, coverageByCurrentRecord[sample.currentRecordId], recordsById[sample.previousRecordId]?.chargeTimeEpochMillis, recordsById[sample.currentRecordId]?.chargeTimeEpochMillis) }
-        if (state.intervalSamples.size > recent.size) Text("当前仅展示最近 ${recent.size} 个区间，共 ${state.intervalSamples.size} 个有效区间。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
-@Composable private fun IntervalDetailCard(sample: ChargingIntervalSample, coverage: ChargingTripCoverageInterval?, previousTime: Long?, currentTime: Long?) {
-    OutlinedCard(Modifier.fillMaxWidth()) {
+@Composable
+private fun IntervalDetailCard(sample: ChargingIntervalSample, coverage: ChargingTripCoverageInterval?, previousTime: Long?, currentTime: Long?) {
+    Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
         Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
             Text(if (previousTime != null && currentTime != null) "${shortDate(previousTime)} → ${shortDate(currentTime)}" else "充电区间 #${sample.previousRecordId} → #${sample.currentRecordId}", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-            Text("区间里程 ${one(sample.distanceKm)} km · 本次补入 ${one(sample.replenishedEnergyKwh)} kWh · ¥ ${two(sample.replenishmentCost)}")
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) { StatValue("补入电量", "${one(sample.energyPer100Km)} kWh/100km", Modifier.weight(1f)); StatValue("费用", "¥ ${two(sample.costPer100Km)}/100km", Modifier.weight(1f)) }
-            Text("估算可信度：${confidenceText(sample.confidence)} · 两次充电结束 SOC 相差 ${sample.endSocDeltaPoints} 个百分点", style = MaterialTheme.typography.bodySmall, color = if (sample.confidence == ChargingEstimateConfidence.LOW) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant)
-            if (sample.confidence != ChargingEstimateConfidence.HIGH) Text("结束 SOC 差异较大时，本次补入电量不能很好代表上一里程区间的电量消耗；仅降低解读可信度，不修正原始数值。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            coverage?.let { HorizontalDivider(); Text("Trip 证据：${it.completedTripCount} 条 · ${one(it.completedTripDistanceKm)} km · 覆盖 ${percent(it.coverageRatio)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant); if (kotlin.math.abs(it.distanceDifferenceKm) >= 1.0) Text("与里程表相差 ${one(kotlin.math.abs(it.distanceDifferenceKm))} km，仅提示，不修正。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+            Text("${one(sample.distanceKm)} km · 补入 ${one(sample.replenishedEnergyKwh)} kWh · ¥ ${two(sample.replenishmentCost)}")
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                StatValue("补入电量", "${one(sample.energyPer100Km)} kWh/100km", Modifier.weight(1f))
+                StatValue("费用", "¥ ${two(sample.costPer100Km)}/100km", Modifier.weight(1f))
+            }
+            Text("可信度 ${confidenceText(sample.confidence)} · 结束 SOC 差 ${sample.endSocDeltaPoints} 个百分点", style = MaterialTheme.typography.bodySmall, color = if (sample.confidence == ChargingEstimateConfidence.LOW) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onSurfaceVariant)
+            coverage?.let { Text("Trip ${it.completedTripCount} 条 · ${one(it.completedTripDistanceKm)} km · 覆盖 ${percent(it.coverageRatio)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
         }
     }
 }
 
-@Composable private fun StatTile(label: String, value: String, icon: androidx.compose.ui.graphics.vector.ImageVector, modifier: Modifier) { ElevatedCard(modifier) { Column(Modifier.padding(MaterialTheme.spacing.md)) { Icon(icon, null, tint = MaterialTheme.colorScheme.primary); Spacer(Modifier.height(MaterialTheme.spacing.sm)); Text(label, style = MaterialTheme.typography.labelMedium); Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) } } }
-@Composable private fun StatValue(label: String, value: String, modifier: Modifier) { Column(modifier) { Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant); Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold) } }
+@Composable
+private fun StatTile(label: String, value: String, icon: androidx.compose.ui.graphics.vector.ImageVector, modifier: Modifier) {
+    Surface(modifier, shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.padding(MaterialTheme.spacing.md)) {
+            Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.height(MaterialTheme.spacing.sm))
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun StatValue(label: String, value: String, modifier: Modifier, contentColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = contentColor.copy(alpha = .68f))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = contentColor)
+    }
+}
+
+@Composable
+private fun SectionHeading(title: String, subtitle: String) {
+    Column { Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+}
+
 private fun chargerCategoryText(value: ChargerCategory) = when (value) { ChargerCategory.HOME -> "家充"; ChargerCategory.PUBLIC_SLOW -> "公共慢充"; ChargerCategory.PUBLIC_FAST -> "公共快充"; ChargerCategory.OTHER -> "其他/未分类" }
 private fun confidenceText(value: ChargingEstimateConfidence) = when (value) { ChargingEstimateConfidence.HIGH -> "高"; ChargingEstimateConfidence.MEDIUM -> "中"; ChargingEstimateConfidence.LOW -> "低" }
 private fun one(value: Double) = String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
@@ -1,10 +1,15 @@
 package com.evchargebook.ui.vehicle
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.evchargebook.bluetooth.BluetoothPromptSettings
 import com.evchargebook.bluetooth.PairedBluetoothDevice
@@ -13,17 +18,27 @@ import com.evchargebook.ui.theme.spacing
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BluetoothPromptScreen(settings: BluetoothPromptSettings, devices: List<PairedBluetoothDevice>, onSave: (Boolean, String?, String?) -> Unit, onBack: () -> Unit) {
-    Scaffold(topBar = { TopAppBar(title = { Text("车载蓝牙提示") }, navigationIcon = { TextButton(onClick = onBack) { Text("返回") } }) }) { padding ->
-        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            item { Text("仅在你指定的已配对设备连接时提醒你。不会扫描附近设备、读取车辆数据或自动开始行程。", color = MaterialTheme.colorScheme.onSurfaceVariant) }
-            item { SwitchPreference("启用连接提示", settings.enabled && settings.deviceAddress != null) { enabled -> onSave(enabled, settings.deviceAddress, settings.deviceName) } }
-            item { Text("选择已配对设备", style = MaterialTheme.typography.titleMedium) }
-            if (devices.isEmpty()) item { Text("没有可用的已配对设备。请先在系统蓝牙设置中完成配对。", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+    val enabled = settings.enabled && settings.deviceAddress != null
+    Scaffold(topBar = { TopAppBar(title = { Text("车载蓝牙提示") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) { Icon(Icons.Default.Bluetooth, null, tint = MaterialTheme.colorScheme.primary); Spacer(Modifier.width(MaterialTheme.spacing.sm)); Column(Modifier.weight(1f)) { Text("连接后提醒开始行程", style = MaterialTheme.typography.titleMedium); Text("只监听你选中的已配对设备，不读取车辆数据，也不会自动开始行程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }; Switch(checked = enabled, onCheckedChange = { checked -> onSave(checked, settings.deviceAddress, settings.deviceName) }, enabled = settings.deviceAddress != null) }
+                    if (settings.deviceAddress == null) Text("先选择一个已配对设备后才能启用。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            item { HorizontalDivider(); Text("已配对设备", style = MaterialTheme.typography.titleMedium) }
+            if (devices.isEmpty()) item { Text("没有可用设备。请先到系统蓝牙设置完成配对，然后返回这里。", color = MaterialTheme.colorScheme.onSurfaceVariant) }
             items(devices, key = { it.address }) { device ->
-                ListItem(headlineContent = { Text(device.name) }, supportingContent = { Text(device.address) }, trailingContent = { RadioButton(selected = device.address == settings.deviceAddress, onClick = { onSave(true, device.address, device.name) }) }, modifier = Modifier.fillMaxWidth())
+                val selected = device.address == settings.deviceAddress
+                ListItem(
+                    headlineContent = { Text(device.name) },
+                    supportingContent = { Text(if (selected) "已选择 · ${device.address}" else device.address) },
+                    trailingContent = { RadioButton(selected = selected, onClick = { onSave(true, device.address, device.name) }) },
+                    modifier = Modifier.fillMaxWidth().clickable { onSave(true, device.address, device.name) }
+                )
+                HorizontalDivider()
             }
         }
     }
 }
-
-@Composable private fun SwitchPreference(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) { Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text(label, modifier = Modifier.weight(1f)); Switch(checked = checked, onCheckedChange = onCheckedChange) } }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
@@ -1,8 +1,12 @@
 package com.evchargebook.ui.vehicle
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -14,11 +18,26 @@ import com.evchargebook.ui.theme.spacing
 fun VehicleCatalogScreen(items: List<VehicleCatalogEntity>, onSelect: (VehicleCatalogEntity) -> Unit, onCustom: () -> Unit, onBack: () -> Unit) {
     var query by remember { mutableStateOf("") }
     val filtered = remember(items, query) { items.filter { "${it.brand} ${it.series} ${it.modelName} ${it.trimName.orEmpty()}".contains(query.trim(), ignoreCase = true) } }
-    Scaffold(topBar = { TopAppBar(title = { Text("选择车型") }, navigationIcon = { TextButton(onClick = onBack) { Text("返回") } }) }, bottomBar = { Surface { OutlinedButton(onClick = onCustom, modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md)) { Text("没有找到？自定义添加车辆") } } }) { padding ->
-        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            item { OutlinedTextField(value = query, onValueChange = { query = it }, label = { Text("搜索品牌、车系或配置") }, modifier = Modifier.fillMaxWidth(), singleLine = true) }
-            if (filtered.isEmpty()) item { Text("没有匹配车型，可使用下方自定义添加。", color = MaterialTheme.colorScheme.onSurfaceVariant) }
-            items(filtered, key = { it.catalogId }) { item -> ListItem(headlineContent = { Text("${item.brand} ${item.modelName}") }, supportingContent = { Text("${item.trimName ?: item.series} · ${item.powertrainType} · ${item.batteryCapacityKwh ?: "-"} kWh / ${item.rangeKm ?: "-"} km") }, modifier = Modifier.fillMaxWidth(), trailingContent = { TextButton(onClick = { onSelect(item) }) { Text("选择") } }) }
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("选择车型") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) },
+        bottomBar = { Surface(tonalElevation = 1.dp) { TextButton(onClick = onCustom, modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs)) { Text("没有找到？自定义添加车辆") } } }
+    ) { padding ->
+        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm)) {
+            item {
+                OutlinedTextField(value = query, onValueChange = { query = it }, leadingIcon = { Icon(Icons.Default.Search, null) }, placeholder = { Text("搜索品牌、车系或配置") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
+                Spacer(Modifier.height(MaterialTheme.spacing.sm))
+                Text(if (query.isBlank()) "车型库 ${items.size} 条" else "找到 ${filtered.size} 条结果", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(Modifier.height(MaterialTheme.spacing.sm))
+            }
+            if (filtered.isEmpty()) item { Text("没有匹配车型。你可以修改关键词，或使用下方自定义添加。", color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(vertical = MaterialTheme.spacing.lg)) }
+            items(filtered, key = { it.catalogId }) { item ->
+                ListItem(
+                    headlineContent = { Text("${item.brand} ${item.modelName}") },
+                    supportingContent = { Text("${item.trimName ?: item.series} · ${item.powertrainType}\n${item.batteryCapacityKwh ?: "-"} kWh · ${item.rangeKm ?: "-"} km") },
+                    modifier = Modifier.fillMaxWidth().clickable { onSelect(item) }
+                )
+                HorizontalDivider()
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.ui.theme.spacing
 

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
@@ -1,61 +1,55 @@
 package com.evchargebook.ui.vehicle
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.input.KeyboardType
+import com.evchargebook.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VehicleEditScreen(
-    initialBrand: String,
-    initialModel: String,
-    initialBatteryCapacity: String,
-    initialRange: String,
-    title: String = "编辑车辆",
-    onSave: (String, String, Double, Int) -> Unit,
-    onBack: () -> Unit
-) {
+fun VehicleEditScreen(initialBrand: String, initialModel: String, initialBatteryCapacity: String, initialRange: String, title: String = "编辑车辆", onSave: (String, String, Double, Int) -> Unit, onBack: () -> Unit) {
     var brand by remember { mutableStateOf(initialBrand) }
     var model by remember { mutableStateOf(initialModel) }
     var battery by remember { mutableStateOf(initialBatteryCapacity) }
     var range by remember { mutableStateOf(initialRange) }
+    var error by remember { mutableStateOf<String?>(null) }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(title) },
-                navigationIcon = {
-                    TextButton(onClick = onBack) { Text("返回") }
-                }
-            )
-        }
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            OutlinedTextField(brand, { brand = it }, label = { Text("品牌") })
-            OutlinedTextField(model, { model = it }, label = { Text("车型") })
-            OutlinedTextField(battery, { battery = it }, label = { Text("电池容量 kWh") })
-            OutlinedTextField(range, { range = it }, label = { Text("标称续航 km") })
-
-            Button(
-                onClick = {
-                    onSave(
-                        brand,
-                        model,
-                        battery.toDoubleOrNull() ?: 0.0,
-                        range.toIntOrNull() ?: 0
-                    )
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("保存")
+    Scaffold(topBar = { TopAppBar(title = { Text(title) }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                Text("车辆信息", style = MaterialTheme.typography.titleMedium)
+                Text("用于区分账本数据，并参与电池容量与续航相关的展示。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedTextField(brand, { brand = it }, label = { Text("品牌") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
+                OutlinedTextField(model, { model = it }, label = { Text("车型") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
             }
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                Text("电池与续航", style = MaterialTheme.typography.titleMedium)
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    OutlinedTextField(battery, { battery = it }, label = { Text("电池容量") }, suffix = { Text("kWh") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), modifier = Modifier.weight(1f), singleLine = true)
+                    OutlinedTextField(range, { range = it.filter(Char::isDigit) }, label = { Text("标称续航") }, suffix = { Text("km") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number), modifier = Modifier.weight(1f), singleLine = true)
+                }
+            }
+            error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            Button(onClick = {
+                val capacity = battery.toDoubleOrNull(); val rangeKm = range.toIntOrNull()
+                error = when {
+                    brand.isBlank() -> "请输入车辆品牌"
+                    model.isBlank() -> "请输入车型"
+                    capacity == null || capacity <= 0 -> "电池容量需要大于 0"
+                    rangeKm == null || rangeKm <= 0 -> "标称续航需要大于 0"
+                    else -> null
+                }
+                if (error == null) onSave(brand.trim(), model.trim(), capacity!!, rangeKm!!)
+            }, modifier = Modifier.fillMaxWidth()) { Text(if (title == "添加车辆") "添加车辆" else "保存车辆") }
+            Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #23. This PR completes the secondary-screen UI pass so the app no longer jumps between the new restrained visual system and older card/form patterns.

## Scope

- Stats: compact ledger-style hierarchy
- Add Record: grouped time/location, charging data, vehicle/notes sections
- Record Edit: mirrors Add Record structure and segmented charger-type selection
- Vehicle Edit: compact native form with validation and consistent back affordance
- Bluetooth Prompt: clearer enable state, selected device status and low-noise device list
- Vehicle Catalog: search-first dense list with cleaner selection affordance

## Visual principles

- typography and spacing before decoration
- standard 16dp horizontal content rhythm
- low elevation / restrained borders
- one obvious primary action
- native Material 3 controls
- no hero headers on utility screens
- no loose chip clouds when a segmented choice is clearer

## Safety

UI-layer refactor only. Existing database/repository contracts, Bluetooth behavior, location capture, trip tracking, validation rules and save callbacks are preserved.

## Acceptance focus

- all edit/selection pages visually match Dashboard / Records / Vehicle / Trip
- add/edit charging records preserve validation and values
- vehicle add/edit prevents obviously invalid blank/zero data
- Bluetooth configuration still saves the selected paired device
- model search and custom-vehicle fallback remain reachable
- back navigation remains explicit on every overlay page