### PR TITLE
style(android): add restrained EV cockpit visual layer

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package com.evchargebook.ui.dashboard
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -98,34 +99,87 @@ private fun EnergySummary(state: MainUiState) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.primaryContainer
+        color = MaterialTheme.colorScheme.inverseSurface
     ) {
         Column(Modifier.padding(MaterialTheme.spacing.lg)) {
-            Text("本月充电", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimaryContainer)
-            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "ENERGY / MONTH",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.58f)
+                    )
+                    Spacer(Modifier.height(MaterialTheme.spacing.xxs))
+                    Text(
+                        state.vehicle?.let { "${it.brand} ${it.model}" } ?: "EV Charge Book",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.82f)
+                    )
+                }
+                Surface(
+                    color = MaterialTheme.colorScheme.inversePrimary.copy(alpha = 0.14f),
+                    shape = MaterialTheme.shapes.small,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.inversePrimary.copy(alpha = 0.36f))
+                ) {
+                    Row(
+                        Modifier.padding(horizontal = MaterialTheme.spacing.sm, vertical = MaterialTheme.spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Surface(
+                            modifier = Modifier.size(7.dp),
+                            color = MaterialTheme.colorScheme.inversePrimary,
+                            shape = MaterialTheme.shapes.extraLarge
+                        ) {}
+                        Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                        Text("本月", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inversePrimary)
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(MaterialTheme.spacing.lg))
             Row(verticalAlignment = Alignment.Bottom) {
                 Text(
                     one(state.monthEnergy),
-                    style = MaterialTheme.typography.headlineMedium,
+                    style = MaterialTheme.typography.displayMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                    color = MaterialTheme.colorScheme.inverseOnSurface
                 )
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text("kWh", style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onPrimaryContainer)
+                Text(
+                    "kWh",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.inversePrimary
+                )
             }
-            Spacer(Modifier.height(MaterialTheme.spacing.sm))
-            LinearProgressIndicator(
-                progress = { equivalent.coerceIn(0.0, 1.0).toFloat() },
-                modifier = Modifier.fillMaxWidth().height(6.dp),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
-            )
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             Text(
-                if (capacity > 0) "约 ${one(equivalent)} 次满充等效" else "完善车辆资料后显示满充等效",
+                "¥ ${two(state.monthCost)} · ${state.chargingCount} 次充电",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
+                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.72f)
             )
+
+            Spacer(Modifier.height(MaterialTheme.spacing.lg))
+            LinearProgressIndicator(
+                progress = { equivalent.coerceIn(0.0, 1.0).toFloat() },
+                modifier = Modifier.fillMaxWidth().height(5.dp),
+                color = MaterialTheme.colorScheme.inversePrimary,
+                trackColor = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.10f)
+            )
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    if (capacity > 0) "≈ ${one(equivalent)} 次满充" else "补全车辆电池容量后显示",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.58f)
+                )
+                if (capacity > 0) {
+                    Text(
+                        "${one(capacity)} kWh / 次",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.58f)
+                    )
+                }
+            }
         }
     }
 }
@@ -150,7 +204,7 @@ private fun MetricTile(
         modifier = modifier,
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surface,
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
         Column(Modifier.padding(MaterialTheme.spacing.md)) {
             Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
@@ -176,7 +230,7 @@ private fun RecentRecord(record: ChargingRecordEntity) {
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
         Row(
             Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
@@ -37,6 +37,9 @@ private val Surface = Color(0xFFFFFFFF)
 private val Line = Color(0xFFE4E7EC)
 private val Energy = Color(0xFF176B52)
 private val EnergySoft = Color(0xFFE5F3ED)
+private val Electric = Color(0xFF45E6A8)
+private val Cockpit = Color(0xFF11171B)
+private val CockpitInk = Color(0xFFF4F8F6)
 
 private val BrandLight = lightColorScheme(
     primary = Energy,
@@ -47,6 +50,8 @@ private val BrandLight = lightColorScheme(
     onSecondary = Color.White,
     secondaryContainer = Color(0xFFEDF1EF),
     onSecondaryContainer = Color(0xFF29332F),
+    tertiary = Electric,
+    onTertiary = Color(0xFF073B2B),
     background = Canvas,
     onBackground = Ink,
     surface = Surface,
@@ -55,6 +60,9 @@ private val BrandLight = lightColorScheme(
     onSurfaceVariant = MutedInk,
     outline = Line,
     outlineVariant = Color(0xFFEEF0F3),
+    inverseSurface = Cockpit,
+    inverseOnSurface = CockpitInk,
+    inversePrimary = Electric,
     error = Color(0xFFB42318)
 )
 
@@ -67,6 +75,8 @@ private val BrandDark = darkColorScheme(
     onSecondary = Color(0xFF25332E),
     secondaryContainer = Color(0xFF2A3430),
     onSecondaryContainer = Color(0xFFDDE7E2),
+    tertiary = Electric,
+    onTertiary = Color(0xFF063B2B),
     background = Color(0xFF101214),
     onBackground = Color(0xFFF1F3F5),
     surface = Color(0xFF171A1D),
@@ -75,6 +85,9 @@ private val BrandDark = darkColorScheme(
     onSurfaceVariant = Color(0xFFB9C0C8),
     outline = Color(0xFF353B42),
     outlineVariant = Color(0xFF252A2F),
+    inverseSurface = Color(0xFFF1F3F5),
+    inverseOnSurface = Color(0xFF15191C),
+    inversePrimary = Color(0xFF176B52),
     error = Color(0xFFFFB4AB)
 )
 

--- a/docs/.keep-cockpit-note
+++ b/docs/.keep-cockpit-note
@@ -1,1 +1,0 @@
-cockpit visual enhancement marker

--- a/docs/.keep-cockpit-note
+++ b/docs/.keep-cockpit-note
@@ -1,0 +1,1 @@
+cockpit visual enhancement marker

--- a/docs/COCKPIT_VISUAL_DIRECTION.md
+++ b/docs/COCKPIT_VISUAL_DIRECTION.md
@@ -1,0 +1,9 @@
+# Cockpit Visual Direction
+
+This refinement keeps the app restrained while adding a stronger EV identity.
+
+- Use one dark cockpit surface on the dashboard for the primary energy summary.
+- Use electric mint only as a focused status/data accent.
+- Keep records, forms, settings and lists neutral and low-noise.
+- Prefer large numeric hierarchy and thin progress/status details over gradients, glow, glassmorphism or decorative card stacks.
+- The goal is a modern EV instrument-panel feeling, not a gaming or cyberpunk theme.


### PR DESCRIPTION
## Summary

This is a focused visual-enhancement follow-up after PR #24 was merged.

The app is now clean and consistent, but the Dashboard still feels slightly too much like a neutral utility app. This PR adds a stronger EV identity without reverting to gradients, glassmorphism, oversized cards, or decorative clutter.

## What changed

- Add an electric-mint accent token and explicit cockpit/inverse surface colors
- Redesign the Dashboard monthly energy summary as a single dark cockpit surface
- Increase numeric hierarchy for monthly kWh
- Add restrained status detailing and electric accent progress treatment
- Keep records, forms, settings and secondary pages neutral and low-noise
- Add `docs/COCKPIT_VISUAL_DIRECTION.md` to constrain future AI/Codex styling

## Intent

Target feeling: modern EV instrument panel / Tesla-Rivian-adjacent restraint.

Avoid: gaming UI, cyberpunk, neon everywhere, gradients, glow effects, glass panels, or card stacks.

## Build note

The previously reported `AddRecordScreen.kt` unresolved `dp` error was from an older workflow head. The current branch already imports `androidx.compose.ui.unit.dp`; this PR is based on the post-fix branch state.

## Scope

Visual/theme layer only. No business logic, database, Bluetooth, trip, location, or repository behavior changes.