### PR TITLE
style(android): extend cockpit visual language to trip screens

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
@@ -95,41 +96,134 @@ private fun ActiveTripPanel(
     onOpenDetail: (Long) -> Unit
 ) {
     val interrupted = activeTrip?.status == TripStatus.INTERRUPTED
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = if (activeTrip == null) MaterialTheme.colorScheme.surfaceContainerLow else MaterialTheme.colorScheme.primaryContainer
-    ) {
-        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-            if (activeTrip == null) {
+    if (activeTrip == null) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerLow
+        ) {
+            Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                Text("READY / TRIP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
                 Text("准备出发", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
                 Text(selectedVehicle?.let { "${it.brand} ${it.model}" } ?: "请先选择车辆", style = MaterialTheme.typography.bodyLarge)
                 Text("开始后会持续记录真实 GPS 轨迹；没有有效定位点时不会虚构距离。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Button(onClick = onStart, enabled = selectedVehicle != null, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.PlayArrow, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("开始行程")
-                }
-            } else {
-                Text(if (interrupted) "行程已中断" else "行程进行中", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                Text(activeVehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${activeTrip.vehicleId}", style = MaterialTheme.typography.bodyLarge)
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
-                    TripMetric("距离", if (activeTrip.distanceMeters > 0) formatDistance(activeTrip.distanceMeters) else "--", Modifier.weight(1f))
-                    TripMetric("耗时", formatDuration(activeTrip.elapsedSeconds), Modifier.weight(1f))
-                    TripMetric("状态", statusText(activeTrip.status), Modifier.weight(1f))
-                }
-                if (interrupted) {
-                    Text("定位服务曾被中断，恢复会继续同一条行程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-                    Button(onClick = { onResume(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
-                        Icon(Icons.Default.Refresh, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("恢复记录")
-                    }
-                }
-                OutlinedButton(onClick = { onOpenDetail(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.Route, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("查看实时轨迹")
-                }
-                TextButton(onClick = onStop, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.Stop, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(if (interrupted) "结束这条行程" else "结束行程")
+                    Icon(Icons.Default.PlayArrow, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("开始行程")
                 }
             }
         }
+        return
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        if (interrupted) "TRIP / INTERRUPTED" else "TRIP / LIVE",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (interrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.inversePrimary
+                    )
+                    Spacer(Modifier.height(MaterialTheme.spacing.xxs))
+                    Text(
+                        activeVehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${activeTrip.vehicleId}",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.inverseOnSurface
+                    )
+                }
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = if (interrupted) MaterialTheme.colorScheme.error.copy(alpha = 0.16f) else MaterialTheme.colorScheme.inversePrimary.copy(alpha = 0.14f)
+                ) {
+                    Row(Modifier.padding(horizontal = MaterialTheme.spacing.sm, vertical = MaterialTheme.spacing.xs), verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            Modifier.size(7.dp)
+                                .let { modifier -> if (interrupted) modifier else modifier }
+                        )
+                        Text(
+                            if (interrupted) "需恢复" else "记录中",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (interrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.inversePrimary
+                        )
+                    }
+                }
+            }
+
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom) {
+                Text(
+                    if (activeTrip.distanceMeters > 0) formatPrimaryDistance(activeTrip.distanceMeters) else "--",
+                    fontSize = 46.sp,
+                    lineHeight = 50.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface
+                )
+                if (activeTrip.distanceMeters > 0) {
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text(
+                        if (activeTrip.distanceMeters >= 1000.0) "km" else "m",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.inversePrimary
+                    )
+                }
+            }
+            Text("当前行程距离", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.64f))
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.12f))
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+                CockpitMetric("耗时", formatDuration(activeTrip.elapsedSeconds), Modifier.weight(1f))
+                CockpitMetric("状态", statusText(activeTrip.status), Modifier.weight(1f))
+                CockpitMetric("开始", formatClock(activeTrip.startedAtEpochMillis), Modifier.weight(1f))
+            }
+
+            if (interrupted) {
+                Text("定位服务曾被中断。恢复会继续同一条行程，不会新建重复记录。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.72f))
+                Button(onClick = { onResume(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
+                    Icon(Icons.Default.Refresh, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("恢复记录")
+                }
+            }
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                OutlinedButton(
+                    onClick = { onOpenDetail(activeTrip.id) },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.inverseOnSurface)
+                ) {
+                    Icon(Icons.Default.Route, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("实时轨迹")
+                }
+                Button(
+                    onClick = onStop,
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.inversePrimary,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                ) {
+                    Icon(Icons.Default.Stop, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text(if (interrupted) "结束行程" else "结束")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CockpitMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(label.uppercase(Locale.ROOT), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.54f))
+        Spacer(Modifier.height(MaterialTheme.spacing.xxs))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
     }
 }
 
@@ -160,19 +254,7 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
-            item {
-                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
-                    Text(vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                    Text("${formatTime(trip.startedAtEpochMillis)} · ${statusText(trip.status)}", color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-            }
-            item {
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    TripMetric("距离", formatDistance(trip.distanceMeters), Modifier.weight(1f))
-                    TripMetric("总耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
-                    TripMetric("平均速度", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
-                }
-            }
+            item { TripDetailHero(trip, vehicle) }
             if (points.size >= 2) item { TripRoutePreview(points) }
             item {
                 SectionHeading("轨迹数据", "${points.size} 个有效 GPS 点")
@@ -185,7 +267,10 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
                 item { SectionHeading("最近轨迹点", "用于排查 GPS 质量，不作为主视觉") }
                 items(points.takeLast(6).reversed(), key = { it.id }) { point ->
                     Row(Modifier.fillMaxWidth().padding(vertical = MaterialTheme.spacing.xs), horizontalArrangement = Arrangement.SpaceBetween) {
-                        Column { Text(SimpleDateFormat("HH:mm:ss", Locale.SIMPLIFIED_CHINESE).format(Date(point.capturedAtEpochMillis)), fontWeight = FontWeight.SemiBold); Text("${formatCoordinate(point.latitude)}, ${formatCoordinate(point.longitude)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                        Column {
+                            Text(SimpleDateFormat("HH:mm:ss", Locale.SIMPLIFIED_CHINESE).format(Date(point.capturedAtEpochMillis)), fontWeight = FontWeight.SemiBold)
+                            Text("${formatCoordinate(point.latitude)}, ${formatCoordinate(point.longitude)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
                         point.horizontalAccuracyMeters?.let { Text("±${it.toInt()} m", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
                     }
                 }
@@ -195,16 +280,46 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
 }
 
 @Composable
-private fun TripMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+private fun TripDetailHero(trip: TripSessionEntity, vehicle: VehicleEntity?) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            Text("TRIP / SUMMARY", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.inversePrimary)
+            Text(
+                vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.inverseOnSurface
+            )
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom) {
+                Text(
+                    formatPrimaryDistance(trip.distanceMeters),
+                    fontSize = 42.sp,
+                    lineHeight = 46.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface
+                )
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text(if (trip.distanceMeters >= 1000.0) "km" else "m", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.inversePrimary)
+            }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+                CockpitMetric("耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
+                CockpitMetric("均速", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                CockpitMetric("最高", trip.maxSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+            }
+            Text("${formatTime(trip.startedAtEpochMillis)} · ${statusText(trip.status)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = 0.64f))
+        }
     }
 }
 
 @Composable
 private fun SectionHeading(title: String, subtitle: String) {
-    Column { Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+    Column {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
 }
 
 @Composable
@@ -217,22 +332,43 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
 
     Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainerLow) {
         Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text("轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Text("${geometry.points.size} 点", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("${geometry.points.size} 点", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
             Canvas(Modifier.fillMaxWidth().height(240.dp)) {
-                val p = 16.dp.toPx(); val w = (size.width - p * 2).coerceAtLeast(1f); val h = (size.height - p * 2).coerceAtLeast(1f)
+                val p = 16.dp.toPx()
+                val w = (size.width - p * 2).coerceAtLeast(1f)
+                val h = (size.height - p * 2).coerceAtLeast(1f)
                 val offsets = geometry.points.map { Offset(p + it.x * w, p + it.y * h) }
                 offsets.zipWithNext().forEach { (from, to) -> drawLine(routeColor, from, to, strokeWidth = 4.dp.toPx(), cap = StrokeCap.Round) }
-                drawCircle(startColor, 6.dp.toPx(), offsets.first()); drawCircle(endColor, 6.dp.toPx(), offsets.last())
+                drawCircle(startColor, 6.dp.toPx(), offsets.first())
+                drawCircle(endColor, 6.dp.toPx(), offsets.last())
             }
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text("起点", style = MaterialTheme.typography.labelMedium, color = startColor); Text("终点", style = MaterialTheme.typography.labelMedium, color = endColor) }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("起点", style = MaterialTheme.typography.labelMedium, color = startColor)
+                Text("终点", style = MaterialTheme.typography.labelMedium, color = endColor)
+            }
             Text("基于真实 WGS84 轨迹点绘制，不做道路吸附或虚构路线。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
 
 private fun formatTime(epochMillis: Long) = SimpleDateFormat("M月d日 HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))
-private fun formatDuration(seconds: Long): String { val h = seconds / 3600; val m = (seconds % 3600) / 60; val s = seconds % 60; return if (h > 0) "${h}小时${m}分" else if (m > 0) "${m}分${s}秒" else "${s}秒" }
+private fun formatClock(epochMillis: Long) = SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))
+private fun formatDuration(seconds: Long): String {
+    val h = seconds / 3600
+    val m = (seconds % 3600) / 60
+    val s = seconds % 60
+    return if (h > 0) "${h}小时${m}分" else if (m > 0) "${m}分${s}秒" else "${s}秒"
+}
 private fun formatDistance(meters: Double) = if (meters >= 1000.0) String.format(Locale.US, "%.2f km", meters / 1000.0) else String.format(Locale.US, "%.0f m", meters)
+private fun formatPrimaryDistance(meters: Double) = if (meters >= 1000.0) String.format(Locale.US, "%.2f", meters / 1000.0) else String.format(Locale.US, "%.0f", meters)
 private fun formatSpeed(mps: Double) = String.format(Locale.US, "%.1f km/h", mps * 3.6)
 private fun formatCoordinate(value: Double) = String.format(Locale.US, "%.6f", value)
-private fun statusText(status: String) = when (status) { TripStatus.RECORDING -> "进行中"; TripStatus.INTERRUPTED -> "已中断，可恢复"; TripStatus.COMPLETED -> "已完成"; else -> status }
+private fun statusText(status: String) = when (status) {
+    TripStatus.RECORDING -> "进行中"
+    TripStatus.INTERRUPTED -> "已中断，可恢复"
+    TripStatus.COMPLETED -> "已完成"
+    else -> status
+}


### PR DESCRIPTION
## Summary

Extend the restrained EV cockpit visual direction from the Dashboard into Trip without changing trip tracking behavior.

## What changed

- Active trip becomes a dark cockpit panel when recording
- Distance becomes the primary large-format metric
- Elapsed time, state and start time become compact instrument-style secondary metrics
- Active state uses restrained electric accent treatment
- Trip detail gets a matching dark summary panel with distance, duration, average speed and max speed
- Historical trip rows and GPS diagnostic data remain neutral and low-noise
- Existing route preview remains based only on saved WGS84 points

## Design intent

The screen should feel closer to a modern EV instrument panel while remaining a native Android utility, not a gaming/cyberpunk UI.

## Safety

UI-only change in `TripScreen.kt`. No changes to `TripTrackingService`, permissions, repositories, GPS sampling, persistence, Bluetooth or business rules.

## Acceptance focus

- active trip is immediately legible while driving/stopped
- interrupted trip still exposes Resume clearly
- Stop and live route actions remain reachable
- completed trip details retain all existing facts and GPS diagnostics
- no synthetic distance, map matching or route fabrication is introduced
