### PR TITLE
docs: prioritize Trip GPS reliability and segmented speed visualization

### DIFF
--- a/docs/LOCATION_TRIP.md
+++ b/docs/LOCATION_TRIP.md
@@ -1,7 +1,7 @@
 # EV Charge Book Location / Map / Trip Tracking Design
 
-版本: v1.1.0
-更新时间: 2026-08-26
+版本: v1.2.0
+更新时间: 2026-08-27
 状态: Authority Subdocument
 
 ## 1. 目标
@@ -16,6 +16,10 @@
 4. 用户必须明确启动记录；v0.2 不做无感后台自动追踪。
 5. 位置信息属于敏感数据，权限、通知和数据保留必须透明。
 6. 记录可靠性优先于采样频率，必须控制耗电和数据库体积。
+7. 不能用两端 GPS 点直连来伪造缺失路线；GPS gap 必须显式表达。
+8. 在没有道路类型/限速/交通数据前，速度颜色只能表达本车速度分布，不能宣称真实拥堵等级。
+
+详细可靠性与速度可视化方案见 `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`。
 
 ---
 
@@ -55,11 +59,11 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
   -> 请求精确定位权限
   -> 启动 location foreground service
   -> 持续采样 Location
-  -> 批量写入 Room TripPoint
+  -> 写入 Room TripPoint
   -> 实时更新耗时 / 距离 / 当前速度
   -> 用户点击“结束行程”
   -> 计算 TripSession 汇总
-  -> 保存并展示轨迹地图
+  -> 保存并展示轨迹
 ```
 
 持续记录时显示常驻通知，并提供“结束记录”动作。
@@ -68,7 +72,7 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 
 ## 4. 采样策略
 
-初始建议:
+当前目标:
 
 - 行驶中目标间隔: 2-5 秒
 - 最小位移参考: 5-10 米
@@ -83,11 +87,24 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 - 控制 Room 数据量
 - 降低 GPS 抖动造成的假距离
 
-结束行程后可在后续版本增加轨迹简化用于地图展示；原始点是否长期保留由数据保留策略决定。
+结束行程后可增加轨迹简化用于地图展示；原始点是否长期保留由数据保留策略决定。
+
+### GPS gap 不是普通降频
+
+静止降频只能解释短间隔缺点，不能解释十分钟级位置空洞。
+
+真实行程已经观察到 12 分钟和 15 分钟级 GPS gap，因此后续必须记录：
+
+- lastLocationCallbackAt
+- lastAcceptedPointAt
+- lastGpsPointAt / lastNetworkPointAt
+- accepted / rejected point count
+- longest gap
+- service lifecycle / re-delivery evidence
 
 ---
 
-## 5. 时间与停车口径
+## 5. 时间与速度口径
 
 Trip 至少区分:
 
@@ -102,7 +119,26 @@ Trip 至少区分:
 
 阈值需要真机数据调优，不写死成产品事实。
 
-平均速度 UI 必须标注使用“全程平均”还是“行驶平均”。
+### 速度 UI
+
+必须区分：
+
+1. 全程平均速度：total distance / elapsed time
+2. 行驶平均速度：total distance / moving time
+3. 分段平均速度：segment distance / segment duration
+4. 最高速度：经异常过滤后的 max speed
+
+后续新增 `TripSpeedSegment` 派生模型，不新增 Room 表即可完成首版。
+
+分段速度颜色采用连续渐变，语义为本车速度分布：
+
+- 深红：极低速
+- 红：低速
+- 黄：较慢
+- 绿：正常/快速
+- 蓝：高速
+
+在未接道路类型 / 限速 / map matching / 实时交通数据前，不展示“严重拥堵 / 拥堵 / 畅通”等交通事实标签。
 
 ---
 
@@ -115,6 +151,7 @@ Trip 至少区分:
 - 手机重启
 - 地库/隧道无 GPS
 - foreground service 异常退出
+- foreground service 仍存活但 LocationManager 长时间无 callback
 
 TripSession 使用 `RECORDING / INTERRUPTED / COMPLETED` 状态。
 
@@ -129,13 +166,21 @@ App 启动时发现未正常结束的 Trip:
 
 同一时刻同一设备默认只允许一个活动 Trip。
 
+注意：`COMPLETED` 只表示最终正常收口，不代表中间 GPS 连续。因此 GPS continuity 必须独立统计。
+
 ---
 
-## 7. 速度与海拔
+## 7. GPS / Network Provider 质量
 
-速度优先保存系统 Location speed（m/s），展示转换为 km/h。
+当前允许 GPS + Network provider fallback。
 
-max speed 必须过滤明显异常点。
+后续原则：
+
+- GPS 高质量点优先作为主轨迹事实
+- Network point 作为 fallback / continuity evidence
+- 不默认将 GPS 与 Network 视为同等质量
+- provider switch 必须可观察
+- network 漂移点不能制造假距离或假速度
 
 GPS 海拔:
 
@@ -146,7 +191,40 @@ GPS 海拔:
 
 ---
 
-## 8. 自动化演进
+## 8. 后台与通知
+
+当前前台定位服务持续显示 ongoing notification。
+
+未来增强：
+
+- 行程时长
+- 已记录距离
+- GPS health：GOOD / DEGRADED / LOST / LONG_GAP
+- 最近有效定位时间
+- “结束行程”快捷动作
+
+GPS 长时间无有效点时更新同一条 ongoing notification，不重复刷通知。
+
+该方向与 Issue #26 的后台活动可见性方案保持一致。
+
+---
+
+## 9. GPS Gap 可视化
+
+禁止将长时间缺失的两个 GPS 点直接画成可信实线。
+
+建议：
+
+```text
+已知轨迹 ━━━━━ · · · · · ━━━━━ 已知轨迹
+               GPS 缺失
+```
+
+无 basemap 阶段即可做断开/虚线表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+
+---
+
+## 10. 自动化演进
 
 v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
@@ -160,7 +238,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 9. 地点与充电记录
+## 11. 地点与充电记录
 
 新增充电记录支持:
 
@@ -174,7 +252,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 10. 隐私
+## 12. 隐私
 
 - 首次启用解释定位用途
 - 默认本地保存
@@ -190,23 +268,52 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 11. 验收目标
+## 13. 验收目标
 
-- [ ] 获取当前位置
-- [ ] 充电记录可绑定当前位置
-- [ ] 用户手动开始/结束行程
-- [ ] 锁屏后 foreground service 持续记录
-- [ ] 经纬度 / GPS 海拔 / 速度 / 精度 / 时间
-- [ ] elapsed / moving / stopped time
-- [ ] 距离 / 平均速度 / 最高速度
-- [ ] MapLibre 显示路线
-- [ ] Trip 绑定具体 Vehicle
-- [ ] 中断行程恢复
-- [ ] 删除 Trip 同步处理 TripPoint
+Core 已完成：
+
+- [x] 获取当前位置
+- [x] 充电记录可绑定当前位置
+- [x] 用户手动开始/结束行程
+- [x] 经纬度 / GPS 海拔 / 速度 / 精度 / 时间
+- [x] elapsed / moving / stopped time
+- [x] 距离 / 平均速度 / 最高速度
+- [x] Trip 绑定具体 Vehicle
+- [x] 中断行程恢复
+- [x] 删除 Trip 同步处理 TripPoint
+
+P0 reliability follow-up：
+
+- [ ] 锁屏后长行程持续记录可诊断
+- [ ] GPS health / last callback / longest gap
+- [ ] accepted / rejected point counters
+- [ ] service restart / re-delivery evidence
+- [ ] GPS/Network provider quality diagnostics
+- [ ] GPS LOST / LONG_GAP ongoing notification
+
+P1 speed visualization：
+
+- [ ] 全程平均 / 行驶平均明确区分
+- [ ] TripSpeedSegment 派生模型
+- [ ] 连续速度颜色映射
+- [ ] GPS gap 虚线/断开渲染
+
+Optional：
+
+- [ ] MapLibre 显示真实 basemap 路线
 
 ---
 
-## 12. 变更记录
+## 14. 变更记录
+
+### v1.2.0
+
+- 基于真实 Trip #7 将十分钟级 GPS gap 提升为 P0 reliability 问题
+- 增加 GPS callback / provider / service lifecycle 可诊断设计
+- 明确 COMPLETED 不等于 GPS continuity 完整
+- 增加全程平均 / 行驶平均 / 分段平均速度三种口径
+- 增加连续速度颜色方案及交通语义边界
+- 明确 GPS gap 不得以实线伪造
 
 ### v1.1.0
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # EV Charge Book Roadmap
 
-版本: v2.4.0
-更新时间: 2026-08-26
+版本: v2.5.0
+更新时间: 2026-08-27
 
 ## 0. 路线原则
 
@@ -88,7 +88,7 @@ Optional, non-blocking:
 
 ### Trip (#15)
 
-状态: Accepted / Issue Closed
+状态: Core Accepted; Reliability Follow-up Required
 
 - [x] TripSession / TripPoint + migration
 - [x] manual start/stop
@@ -102,11 +102,24 @@ Optional, non-blocking:
 - [x] provider failure -> INTERRUPTED instead of crash
 - [x] latest physical functional verification accepted
 
+真实长行程 follow-up：
+
+- [ ] P0 GPS callback / accepted point heartbeat
+- [ ] P0 longest GPS gap / provider switch / rejected point diagnostics
+- [ ] P0 service lifecycle / restart / re-delivery evidence
+- [ ] P0 GPS LOST / LONG_GAP notification state
+- [ ] P1 全程平均 / 行驶平均速度明确区分
+- [ ] P1 TripSpeedSegment 派生模型
+- [ ] P1 连续速度颜色映射
+- [ ] P1 GPS gap 虚线/断开渲染
+
+详细设计：`docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
+
 ---
 
 ## v0.3 - Local Analytics & Reliability
 
-状态: **Feature Complete Candidate / CI finalizing**
+状态: **Feature Complete Candidate / Reliability Follow-up**
 
 ### Analytics
 
@@ -142,15 +155,21 @@ Optional, non-blocking:
 
 ### Data anomaly hints
 
-Implemented; cumulative CI pending:
-
 - [x] extreme unit price warning
 - [x] energy > 135% battery capacity warning
 - [x] nearly-flat SOC with meaningful energy warning
 - [x] Add/Edit live warnings
 - [x] warnings never block save or mutate raw facts
 - [x] JVM rules tests
-- [ ] latest cumulative Android CI Green
+
+### Reliability priority change after real Trip data
+
+真实 Trip #7 观察到 12-15 分钟级 GPS gap。该问题优先级高于 MapLibre 和更丰富的统计展示。
+
+- [ ] P0 GPS health / continuity diagnostics
+- [ ] P0 lock-screen/background reliability evidence
+- [ ] P0 notification shows GPS health and last valid fix
+- [ ] P1 segmented speed analysis and colored route preview
 
 ### Non-blocking follow-up
 
@@ -165,7 +184,7 @@ No heavy charting framework and no new ChargingPlace Room table until real usage
 
 ## v0.4 - Cloud & Catalog Sync
 
-状态: Next Major Phase / Not Started
+状态: Next Major Phase / Deferred until Trip P0 reliability is observable
 
 Candidate scope:
 
@@ -183,16 +202,29 @@ Cloud sync must not become the only recovery path. Existing local JSON backup re
 ## 当前执行顺序
 
 ```text
-anomaly-warning cumulative CI
+Trip P0 GPS reliability diagnostics
+  -> notification GPS health / last valid fix
+  -> provider / service lifecycle evidence
+  -> Trip P1 segmented speed + colored route preview
   -> v0.3 code/document closeout
   -> Privacy Zone only when route export/share starts
   -> v0.4 sync/catalog design
-  -> implement smallest useful cloud sync slice
 ```
+
+MapLibre 继续保持低优先级；没有必要为了彩色速度轨迹先引入地图 SDK。
 
 ---
 
 ## 变更记录
+
+### v2.5.0
+
+- based on real Trip #7, promoted 12-15 minute GPS gaps to P0 reliability work
+- added GPS callback / provider / service lifecycle diagnostics before more feature expansion
+- added segmented speed / continuous color visualization as P1
+- clarified speed colors describe this vehicle's speed, not real traffic congestion
+- clarified long GPS gaps must not be rendered as trustworthy solid routes
+- deferred v0.4 execution until Trip P0 reliability becomes observable
 
 ### v2.4.0
 

--- a/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
+++ b/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
@@ -1,0 +1,268 @@
+# Trip GPS Reliability & Speed Visualization Plan
+
+版本: v1.0.0
+更新时间: 2026-08-27
+状态: Design / Future Implementation
+
+## 1. 背景
+
+2026-08-27 的真实 Trip #7 数据暴露出两个需要优先处理的问题：
+
+1. 单一全程平均速度无法表达高速、城市道路、拥堵/低速等不同区段的驾驶特征。
+2. 行程中出现多段明显 GPS 空洞，最长可达十分钟级，不能继续只靠最终 COMPLETED 状态判断记录是否可靠。
+
+该文档只定义后续实现方向，不修改现有原始 Trip 数据口径。
+
+---
+
+## 2. 真实数据证据
+
+Trip #7：
+
+- distanceMeters: 42643.19 m
+- elapsedSeconds: 4137 s
+- movingSeconds: 4090 s
+- stoppedSeconds: 20 s
+- averageSpeedMps: 10.4262 m/s（约 37.5 km/h）
+- maxSpeedMps: 25.92 m/s（约 93.3 km/h）
+- status: COMPLETED
+
+但 TripPoint 中存在多段长时间缺口，例如：
+
+- Point 64 -> 65 约 749 秒（12 分 29 秒）
+- Point 70 -> 71 约 917 秒（15 分 17 秒）
+
+因此：
+
+- `COMPLETED` 只能说明 Trip 最终正常收口，不代表中间 GPS 连续。
+- 需要独立的 GPS health / continuity 指标。
+
+---
+
+## 3. P0 - GPS 后台可靠性与可诊断性
+
+### 3.1 目标
+
+下一次出现断点时，必须能区分：
+
+- Foreground Service 被系统杀/重启
+- LocationManager 长时间没有回调
+- GPS provider 不可用
+- network provider fallback
+- Location 被业务过滤
+- 权限或系统定位状态异常
+
+### 3.2 需要记录的运行时状态
+
+建议先以轻量内存状态 + Trip 级派生摘要实现，是否落库后续再决定。
+
+至少包括：
+
+- lastLocationCallbackAt
+- lastAcceptedPointAt
+- lastGpsPointAt
+- lastNetworkPointAt
+- acceptedPointCount
+- rejectedPointCount
+- rejectedByAccuracyCount
+- rejectedByJumpCount
+- providerSwitchCount
+- serviceStartCount / serviceRestartCount（若能可靠识别）
+- longestLocationGapSeconds
+
+### 3.3 GPS Health 状态
+
+UI / Notification 使用统一派生状态：
+
+- GOOD：最近有效定位 <= 10s
+- DEGRADED：10-30s
+- LOST：> 30s
+- LONG_GAP：> 120s
+
+阈值为初始建议，必须通过真机数据调优，不能作为固定业务事实。
+
+### 3.4 Notification
+
+Foreground notification 后续至少展示：
+
+- 正在记录行程
+- 已记录时长
+- 已记录距离
+- GPS 状态
+- 最近有效定位时间
+- 结束行程动作
+
+当 GPS LOST / LONG_GAP 时更新同一条 ongoing notification，不重复刷通知。
+
+### 3.5 Service 生命周期
+
+当前服务已使用 location foreground service + `START_REDELIVER_INTENT`。
+
+后续需要明确记录：
+
+- onCreate / onStartCommand / onDestroy
+- start reason / restored intent
+- 是否发生 service re-delivery
+
+目的不是永久日志堆积，而是能解释真实行程中的 GPS 空洞。
+
+### 3.6 GPS / Network provider 融合
+
+当前允许 GPS + Network provider 同时进入 TripPoint。
+
+后续原则：
+
+- GPS 高质量点优先作为主轨迹事实
+- Network point 作为 fallback / continuity evidence
+- 不默认把 GPS 与 Network 视为同等质量
+- provider 切换需可观察
+- 避免 network 漂移点制造假距离或假速度
+
+---
+
+## 4. P1 - 分段速度模型
+
+### 4.1 三种速度必须区分
+
+Trip UI 至少区分：
+
+1. 全程平均速度：总距离 / elapsed time
+2. 行驶平均速度：总距离 / moving time
+3. 分段平均速度：某一区段内的有效距离 / 时间
+
+现有 `averageSpeedMps` 当前更接近 moving-average 口径，后续 UI 必须明确命名，避免用户把它理解成全程平均。
+
+### 4.2 TripSpeedSegment
+
+先做派生模型，不新增 Room 表：
+
+```text
+TripPoint[]
+  -> TripSpeedSegmentBuilder
+  -> TripSpeedSegment[]
+  -> UI renderer
+```
+
+推荐区段切分优先按时间/距离混合：
+
+- 20-30 秒，或
+- 200-300 米
+
+具体阈值通过真实数据调优。
+
+每个 segment 至少包含：
+
+- start/end timestamp
+- distance
+- duration
+- averageSpeedKmh
+- min/max speed（可选）
+- GPS quality / gap flag
+
+---
+
+## 5. P1 - 速度颜色映射
+
+### 5.1 初始视觉语义
+
+在未接道路类型/限速/交通数据前，不使用“严重拥堵 / 畅通”等交通事实词。
+
+先使用本车速度语义：
+
+- 深红：极低速
+- 红：低速
+- 黄：较慢
+- 绿：正常/快速
+- 蓝：高速
+
+### 5.2 连续颜色而不是四档硬切
+
+建议采用连续渐变：
+
+- 0-5 km/h：深红
+- 5-15 km/h：红
+- 15-30 km/h：红 -> 黄
+- 30-50 km/h：黄 -> 绿
+- 50-70 km/h：绿
+- 70-90 km/h：绿 -> 蓝
+- 90+ km/h：蓝 / 深蓝
+
+最终颜色阈值属于 UI 配置，不写入原始 TripPoint。
+
+### 5.3 交通语义边界
+
+在没有道路类型 / 限速 / map matching / 实时交通数据前：
+
+- 8 km/h 可能只是停车场
+- 15 km/h 可能只是小区道路
+- 40 km/h 在城市道路可能畅通，在高速可能拥堵
+
+因此彩色轨迹代表“本车实际速度分布”，不是“道路拥堵等级”。
+
+---
+
+## 6. GPS Gap 可视化
+
+禁止把长时间缺失的两端 GPS 点直接连成实线路线。
+
+建议：
+
+```text
+已知轨迹 ━━━━━ · · · · · ━━━━━ 已知轨迹
+               GPS 缺失
+```
+
+规则：
+
+- gap 超过阈值后，renderer 标记为 disconnected segment
+- 无 basemap 阶段可用虚线/断开提示
+- MapLibre 阶段使用独立 dashed polyline
+- 不做假 map matching，不补造路径
+
+---
+
+## 7. 验收标准
+
+### P0 GPS Reliability
+
+- [ ] 能显示最近有效定位时间
+- [ ] 能识别 >30s GPS gap
+- [ ] 能统计最长 GPS gap
+- [ ] 能区分 accepted / rejected point
+- [ ] 能区分 GPS / Network provider
+- [ ] 能判断 service 是否发生 restart / re-delivery（若 Android 生命周期允许可靠识别）
+- [ ] GPS 长时间丢失时 ongoing notification 明确提示
+- [ ] 真实锁屏行程完成后能解释轨迹断点原因
+
+### P1 Speed Segmentation
+
+- [ ] UI 区分全程平均 / 行驶平均 / 最高速度
+- [ ] TripSpeedSegment 为派生模型，不改原始点
+- [ ] 分段平均速度有 JVM tests
+- [ ] 轨迹支持连续颜色映射
+- [ ] 长 GPS gap 不画成可信实线
+- [ ] 未接交通数据前不宣称“真实拥堵等级”
+
+---
+
+## 8. 实施顺序
+
+```text
+P0: GPS callback / service lifecycle telemetry
+  -> GPS health state
+  -> notification health display
+  -> provider quality / gap diagnostics
+
+P1: TripSpeedSegmentBuilder
+  -> 全程/行驶平均速度口径
+  -> SpeedColorScale
+  -> 彩色 route preview
+  -> GPS gap dashed/disconnected rendering
+
+P2: MapLibre renderer
+  -> true basemap
+  -> colored polyline
+  -> dashed GPS gaps
+```
+
+MapLibre 仍为低优先级，不应阻塞 P0 GPS reliability。


### PR DESCRIPTION
## Summary

Documents the follow-up work discovered from the 2026-08-27 real-device Trip #7 export.

### P0 — GPS reliability / observability

Real Trip #7 completed normally but contains multiple long GPS gaps, including approximately:

- Point 64 -> 65: ~749s / 12m29s
- Point 70 -> 71: ~917s / 15m17s

`COMPLETED` therefore cannot be treated as evidence that GPS continuity was healthy.

This PR promotes the following work ahead of MapLibre/cloud expansion:

- location callback / accepted-point heartbeat
- longest GPS gap tracking
- GPS vs Network provider diagnostics
- rejected point counters
- foreground service lifecycle / restart / re-delivery evidence
- GPS GOOD / DEGRADED / LOST / LONG_GAP status
- ongoing notification showing GPS health and last valid fix

### P1 — segmented speed visualization

Defines three explicit speed concepts:

- whole-trip average
- moving average
- segment average

Adds a future `TripSpeedSegment` derived model and continuous red -> yellow -> green -> blue route color scale.

Important semantic boundary: until road class / speed limit / map matching / traffic data exist, the colors represent **this vehicle's observed speed**, not authoritative congestion/traffic state.

### GPS gap rendering

Long gaps must not be connected by a trustworthy solid line. Future preview/MapLibre renderers should use disconnected/dashed segments and clearly indicate missing GPS evidence.

## Files

- new `docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
- update `docs/LOCATION_TRIP.md` to v1.2.0
- update `docs/ROADMAP.md` to v2.5.0

## Scope

Documentation only. No Android runtime behavior or database schema changes in this PR.

MapLibre remains low priority; P0 GPS reliability should be observable before further route visualization work.