### PR TITLE
feat(android): add trip GPS health monitoring

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripGpsHealth.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripGpsHealth.kt
@@ -1,0 +1,54 @@
+package com.evchargebook.domain
+
+enum class TripGpsHealthStatus {
+    WAITING,
+    GOOD,
+    DEGRADED,
+    LOST,
+    LONG_GAP
+}
+
+data class TripGpsHealthSnapshot(
+    val status: TripGpsHealthStatus,
+    val secondsSinceLastCallback: Long?,
+    val secondsSinceLastAcceptedPoint: Long?,
+    val message: String
+)
+
+object TripGpsHealth {
+    const val DEGRADED_AFTER_SECONDS = 15L
+    const val LOST_AFTER_SECONDS = 30L
+    const val LONG_GAP_AFTER_SECONDS = 120L
+
+    fun evaluate(
+        nowEpochMillis: Long,
+        trackingStartedAtEpochMillis: Long,
+        lastCallbackAtEpochMillis: Long?,
+        lastAcceptedPointAtEpochMillis: Long?
+    ): TripGpsHealthSnapshot {
+        val callbackAge = lastCallbackAtEpochMillis?.let { ageSeconds(nowEpochMillis, it) }
+        val acceptedAge = lastAcceptedPointAtEpochMillis?.let { ageSeconds(nowEpochMillis, it) }
+        val effectiveAge = acceptedAge ?: callbackAge ?: ageSeconds(nowEpochMillis, trackingStartedAtEpochMillis)
+
+        val status = when {
+            lastCallbackAtEpochMillis == null && effectiveAge < DEGRADED_AFTER_SECONDS -> TripGpsHealthStatus.WAITING
+            effectiveAge >= LONG_GAP_AFTER_SECONDS -> TripGpsHealthStatus.LONG_GAP
+            effectiveAge >= LOST_AFTER_SECONDS -> TripGpsHealthStatus.LOST
+            effectiveAge >= DEGRADED_AFTER_SECONDS -> TripGpsHealthStatus.DEGRADED
+            else -> TripGpsHealthStatus.GOOD
+        }
+
+        val message = when (status) {
+            TripGpsHealthStatus.WAITING -> "正在等待首次定位"
+            TripGpsHealthStatus.GOOD -> "GPS 正常"
+            TripGpsHealthStatus.DEGRADED -> "GPS 更新变慢"
+            TripGpsHealthStatus.LOST -> "GPS 暂时中断"
+            TripGpsHealthStatus.LONG_GAP -> "GPS 已长时间中断"
+        }
+
+        return TripGpsHealthSnapshot(status, callbackAge, acceptedAge, message)
+    }
+
+    private fun ageSeconds(nowEpochMillis: Long, thenEpochMillis: Long): Long =
+        ((nowEpochMillis - thenEpochMillis).coerceAtLeast(0L) / 1000L)
+}

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripRouteGeometry.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripRouteGeometry.kt
@@ -2,7 +2,8 @@ package com.evchargebook.domain.trip
 
 data class TripGeoPoint(
     val latitude: Double,
-    val longitude: Double
+    val longitude: Double,
+    val capturedAtEpochMillis: Long? = null
 )
 
 data class TripRoutePoint(
@@ -12,16 +13,19 @@ data class TripRoutePoint(
 
 data class TripRouteGeometry(
     val points: List<TripRoutePoint>,
+    val segments: List<List<TripRoutePoint>>,
+    val gapCount: Int,
     val minLatitude: Double,
     val maxLatitude: Double,
     val minLongitude: Double,
     val maxLongitude: Double
 ) {
-    val isDrawable: Boolean get() = points.size >= 2
+    val isDrawable: Boolean get() = segments.any { it.size >= 2 }
 }
 
 object TripRouteGeometryBuilder {
     private const val DEFAULT_MAX_POINTS = 400
+    const val LONG_GAP_THRESHOLD_MS = 120_000L
 
     fun build(
         source: List<TripGeoPoint>,
@@ -32,7 +36,11 @@ object TripRouteGeometryBuilder {
         val finite = source.filter { it.latitude.isFinite() && it.longitude.isFinite() }
         if (finite.isEmpty()) return null
 
-        val sampled = downsample(finite, maxPoints)
+        val rawSegments = splitAtLongGaps(finite)
+        val sampledSegments = downsampleSegments(rawSegments, maxPoints)
+        val sampled = sampledSegments.flatten()
+        if (sampled.isEmpty()) return null
+
         val minLat = sampled.minOf { it.latitude }
         val maxLat = sampled.maxOf { it.latitude }
         val minLon = sampled.minOf { it.longitude }
@@ -40,15 +48,17 @@ object TripRouteGeometryBuilder {
         val latSpan = (maxLat - minLat).takeIf { it > 0.0 } ?: 1.0
         val lonSpan = (maxLon - minLon).takeIf { it > 0.0 } ?: 1.0
 
-        val normalized = sampled.map { point ->
-            TripRoutePoint(
-                x = ((point.longitude - minLon) / lonSpan).toFloat().coerceIn(0f, 1f),
-                y = (1.0 - (point.latitude - minLat) / latSpan).toFloat().coerceIn(0f, 1f)
-            )
-        }
+        fun normalize(point: TripGeoPoint) = TripRoutePoint(
+            x = ((point.longitude - minLon) / lonSpan).toFloat().coerceIn(0f, 1f),
+            y = (1.0 - (point.latitude - minLat) / latSpan).toFloat().coerceIn(0f, 1f)
+        )
+
+        val normalizedSegments = sampledSegments.map { segment -> segment.map(::normalize) }
 
         return TripRouteGeometry(
-            points = normalized,
+            points = normalizedSegments.flatten(),
+            segments = normalizedSegments,
+            gapCount = (normalizedSegments.size - 1).coerceAtLeast(0),
             minLatitude = minLat,
             maxLatitude = maxLat,
             minLongitude = minLon,
@@ -56,8 +66,41 @@ object TripRouteGeometryBuilder {
         )
     }
 
+    private fun splitAtLongGaps(source: List<TripGeoPoint>): List<List<TripGeoPoint>> {
+        if (source.isEmpty()) return emptyList()
+        val segments = mutableListOf<MutableList<TripGeoPoint>>()
+        var current = mutableListOf(source.first())
+        segments += current
+
+        source.zipWithNext().forEach { (previous, next) ->
+            val previousTime = previous.capturedAtEpochMillis
+            val nextTime = next.capturedAtEpochMillis
+            val isLongGap = previousTime != null && nextTime != null && nextTime - previousTime >= LONG_GAP_THRESHOLD_MS
+            if (isLongGap) {
+                current = mutableListOf()
+                segments += current
+            }
+            current += next
+        }
+        return segments.filter { it.isNotEmpty() }
+    }
+
+    private fun downsampleSegments(source: List<List<TripGeoPoint>>, maxPoints: Int): List<List<TripGeoPoint>> {
+        val totalPoints = source.sumOf { it.size }
+        if (totalPoints <= maxPoints) return source
+        if (source.size >= maxPoints) return source.take(maxPoints).map { listOf(it.first()) }
+
+        val baseBudget = maxPoints / source.size
+        val remainder = maxPoints % source.size
+        return source.mapIndexed { index, segment ->
+            val budget = baseBudget + if (index < remainder) 1 else 0
+            downsample(segment, budget.coerceAtLeast(1))
+        }
+    }
+
     private fun downsample(source: List<TripGeoPoint>, maxPoints: Int): List<TripGeoPoint> {
         if (source.size <= maxPoints) return source
+        if (maxPoints <= 1) return listOf(source.first())
 
         val lastIndex = source.lastIndex
         return List(maxPoints) { outputIndex ->

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -22,12 +22,18 @@ import com.evchargebook.MainActivity
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.TripGpsHealth
+import com.evchargebook.domain.TripGpsHealthSnapshot
+import com.evchargebook.domain.TripGpsHealthStatus
 import com.evchargebook.domain.TripRules
 import com.evchargebook.domain.TripSamplingRules
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -41,10 +47,20 @@ class TripTrackingService : Service() {
     private val tripDao by lazy { AppDatabase.getInstance(applicationContext).tripDao() }
     private var currentTripId: Long? = null
     private var lastPoint: TripPointEntity? = null
+    private var healthMonitorJob: Job? = null
+
+    @Volatile private var trackingStartedAtEpochMillis: Long = 0L
+    @Volatile private var lastCallbackAtEpochMillis: Long? = null
+    @Volatile private var lastAcceptedPointAtEpochMillis: Long? = null
+    @Volatile private var lastAcceptedProvider: String? = null
+    @Volatile private var rejectedPointCount: Int = 0
 
     private val locationListener = LocationListener { location ->
         val tripId = currentTripId ?: return@LocationListener
-        serviceScope.launch { pointMutex.withLock { handleLocation(tripId, location) } }
+        lastCallbackAtEpochMillis = System.currentTimeMillis()
+        serviceScope.launch {
+            pointMutex.withLock { handleLocation(tripId, location) }
+        }
     }
 
     override fun onCreate() {
@@ -68,6 +84,7 @@ class TripTrackingService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
+        healthMonitorJob?.cancel()
         runCatching { locationManager.removeUpdates(locationListener) }
         serviceScope.cancel()
         super.onDestroy()
@@ -76,12 +93,17 @@ class TripTrackingService : Service() {
     private fun beginTracking(tripId: Long) {
         if (currentTripId == tripId) return
         currentTripId = tripId
+        trackingStartedAtEpochMillis = System.currentTimeMillis()
+        lastCallbackAtEpochMillis = null
+        lastAcceptedPointAtEpochMillis = null
+        lastAcceptedProvider = null
+        rejectedPointCount = 0
 
         val foregroundStarted = runCatching {
             ServiceCompat.startForeground(
                 this,
                 NOTIFICATION_ID,
-                buildNotification(),
+                buildNotification(currentHealthSnapshot()),
                 if (Build.VERSION.SDK_INT >= 29) ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION else 0
             )
         }.isSuccess
@@ -101,7 +123,12 @@ class TripTrackingService : Service() {
                 return@launch
             }
             lastPoint = tripDao.getPoints(tripId).lastOrNull()
+            lastPoint?.let {
+                lastAcceptedPointAtEpochMillis = it.capturedAtEpochMillis
+                lastAcceptedProvider = it.provider
+            }
             requestLocationUpdatesOrInterrupt(tripId)
+            startHealthMonitor()
         }
     }
 
@@ -140,14 +167,31 @@ class TripTrackingService : Service() {
         }
     }
 
+    private fun startHealthMonitor() {
+        healthMonitorJob?.cancel()
+        healthMonitorJob = serviceScope.launch {
+            while (isActive && currentTripId != null) {
+                updateNotification()
+                delay(HEALTH_REFRESH_INTERVAL_MS)
+            }
+        }
+    }
+
     private suspend fun handleLocation(tripId: Long, location: Location) {
-        if (!isBasicLocationValid(location)) return
+        if (!isBasicLocationValid(location)) {
+            rejectedPointCount += 1
+            updateNotification()
+            return
+        }
         val session = tripDao.getSession(tripId) ?: return
         if (session.status != TripStatus.RECORDING) return
 
         val capturedAt = location.time.takeIf { it > 0 } ?: System.currentTimeMillis()
         val previous = lastPoint
-        if (previous != null && capturedAt <= previous.capturedAtEpochMillis) return
+        if (previous != null && capturedAt <= previous.capturedAtEpochMillis) {
+            rejectedPointCount += 1
+            return
+        }
 
         val segmentDistance = previous?.let { previousPoint ->
             val result = FloatArray(1)
@@ -158,7 +202,11 @@ class TripTrackingService : Service() {
         val speed = location.speed.takeIf { location.hasSpeed() }?.toDouble()
         val accuracy = location.accuracy.takeIf { location.hasAccuracy() }?.toDouble()
         val decision = TripSamplingRules.decide(deltaSeconds, segmentDistance, speed, accuracy)
-        if (!decision.accept) return
+        if (!decision.accept) {
+            rejectedPointCount += 1
+            updateNotification()
+            return
+        }
 
         val newMovingSeconds = TripSamplingRules.movingSeconds(session.movingSeconds ?: 0, deltaSeconds, decision.moving)
         val newStoppedSeconds = TripSamplingRules.stoppedSeconds(session.stoppedSeconds ?: 0, deltaSeconds, decision.moving)
@@ -180,6 +228,8 @@ class TripTrackingService : Service() {
         )
         val pointId = tripDao.insertPoint(point)
         lastPoint = point.copy(id = pointId)
+        lastAcceptedPointAtEpochMillis = System.currentTimeMillis()
+        lastAcceptedProvider = location.provider
 
         val elapsed = ((capturedAt - session.startedAtEpochMillis) / 1000).coerceAtLeast(0)
         tripDao.updateSession(
@@ -200,6 +250,7 @@ class TripTrackingService : Service() {
                 maxAltitudeMeters = mergeMax(session.maxAltitudeMeters, altitude)
             )
         )
+        updateNotification()
     }
 
     private fun stopFromNotification() {
@@ -228,6 +279,8 @@ class TripTrackingService : Service() {
     }
 
     private fun stopTrackingAndSelf() {
+        healthMonitorJob?.cancel()
+        healthMonitorJob = null
         runCatching { locationManager.removeUpdates(locationListener) }
         currentTripId = null
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
@@ -240,10 +293,25 @@ class TripTrackingService : Service() {
         return true
     }
 
-    private fun buildNotification() = NotificationCompat.Builder(this, CHANNEL_ID)
+    private fun currentHealthSnapshot(): TripGpsHealthSnapshot = TripGpsHealth.evaluate(
+        nowEpochMillis = System.currentTimeMillis(),
+        trackingStartedAtEpochMillis = trackingStartedAtEpochMillis.takeIf { it > 0L } ?: System.currentTimeMillis(),
+        lastCallbackAtEpochMillis = lastCallbackAtEpochMillis,
+        lastAcceptedPointAtEpochMillis = lastAcceptedPointAtEpochMillis
+    )
+
+    private fun updateNotification() {
+        if (currentTripId == null) return
+        val snapshot = currentHealthSnapshot()
+        runCatching {
+            getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, buildNotification(snapshot))
+        }
+    }
+
+    private fun buildNotification(snapshot: TripGpsHealthSnapshot) = NotificationCompat.Builder(this, CHANNEL_ID)
         .setSmallIcon(android.R.drawable.ic_menu_mylocation)
-        .setContentTitle("EV Charge Book 正在记录行程")
-        .setContentText("定位仅用于本次主动开始的行程")
+        .setContentTitle(notificationTitle(snapshot.status))
+        .setContentText(notificationText(snapshot))
         .setOngoing(true)
         .setOnlyAlertOnce(true)
         .setContentIntent(PendingIntent.getActivity(this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
@@ -254,9 +322,32 @@ class TripTrackingService : Service() {
         )
         .build()
 
+    private fun notificationTitle(status: TripGpsHealthStatus): String = when (status) {
+        TripGpsHealthStatus.WAITING, TripGpsHealthStatus.GOOD -> "EV Charge Book 正在记录行程"
+        TripGpsHealthStatus.DEGRADED -> "EV Charge Book · GPS 更新变慢"
+        TripGpsHealthStatus.LOST -> "EV Charge Book · GPS 暂时中断"
+        TripGpsHealthStatus.LONG_GAP -> "EV Charge Book · GPS 长时间中断"
+    }
+
+    private fun notificationText(snapshot: TripGpsHealthSnapshot): String {
+        val ageText = snapshot.secondsSinceLastAcceptedPoint?.let { "最近有效定位 ${formatAge(it)}前" } ?: snapshot.message
+        val providerText = when (lastAcceptedProvider) {
+            LocationManager.GPS_PROVIDER -> "GPS"
+            LocationManager.NETWORK_PROVIDER -> "网络定位"
+            null -> null
+            else -> lastAcceptedProvider
+        }
+        return listOfNotNull(ageText, providerText, rejectedPointCount.takeIf { it > 0 }?.let { "已过滤 $it 点" }).joinToString(" · ")
+    }
+
+    private fun formatAge(seconds: Long): String = when {
+        seconds < 60 -> "${seconds}秒"
+        else -> "${seconds / 60}分${seconds % 60}秒"
+    }
+
     private fun createNotificationChannel() {
         val manager = getSystemService(NotificationManager::class.java)
-        manager.createNotificationChannel(NotificationChannel(CHANNEL_ID, "行程记录", NotificationManager.IMPORTANCE_LOW).apply { description = "用户主动开启行程后显示持续定位状态" })
+        manager.createNotificationChannel(NotificationChannel(CHANNEL_ID, "行程记录", NotificationManager.IMPORTANCE_LOW).apply { description = "用户主动开启行程后显示持续定位与 GPS 健康状态" })
     }
 
     companion object {
@@ -267,6 +358,7 @@ class TripTrackingService : Service() {
         private const val NOTIFICATION_ID = 2201
         private const val SAMPLE_INTERVAL_MS = 4_000L
         private const val SAMPLE_DISTANCE_METERS = 8f
+        private const val HEALTH_REFRESH_INTERVAL_MS = 10_000L
 
         fun start(context: Context, tripId: Long) {
             val intent = Intent(context, TripTrackingService::class.java).setAction(ACTION_START).putExtra(EXTRA_TRIP_ID, tripId)

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -154,6 +154,7 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
     val vehicle = vehicles.firstOrNull { it.id == trip.vehicleId }
     val firstPoint = points.firstOrNull()
     val lastPoint = points.lastOrNull()
+    val wholeTripAverageMps = if (trip.elapsedSeconds > 0) trip.distanceMeters / trip.elapsedSeconds else null
     Scaffold(topBar = { TopAppBar(title = { Text("行程详情") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
@@ -167,10 +168,17 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
                 }
             }
             item {
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    TripMetric("距离", formatDistance(trip.distanceMeters), Modifier.weight(1f))
-                    TripMetric("总耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
-                    TripMetric("平均速度", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                        TripMetric("距离", formatDistance(trip.distanceMeters), Modifier.weight(1f))
+                        TripMetric("总耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
+                        TripMetric("全程均速", wholeTripAverageMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                    }
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                        TripMetric("行驶均速", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                        TripMetric("最高速度", trip.maxSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                        TripMetric("移动时间", trip.movingSeconds?.let(::formatDuration) ?: "--", Modifier.weight(1f))
+                    }
                 }
             }
             if (points.size >= 2) item { TripRoutePreview(points) }
@@ -209,7 +217,9 @@ private fun SectionHeading(title: String, subtitle: String) {
 
 @Composable
 private fun TripRoutePreview(points: List<TripPointEntity>) {
-    val geometry = remember(points) { TripRouteGeometryBuilder.build(points.map { TripGeoPoint(it.latitude, it.longitude) }) }
+    val geometry = remember(points) {
+        TripRouteGeometryBuilder.build(points.map { TripGeoPoint(it.latitude, it.longitude, it.capturedAtEpochMillis) })
+    }
     if (geometry == null || !geometry.isDrawable) return
     val routeColor = MaterialTheme.colorScheme.primary
     val startColor = MaterialTheme.colorScheme.tertiary
@@ -217,14 +227,25 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
 
     Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainerLow) {
         Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text("轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Text("${geometry.points.size} 点", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("${geometry.points.size} 点 · ${geometry.segments.size} 段", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
             Canvas(Modifier.fillMaxWidth().height(240.dp)) {
                 val p = 16.dp.toPx(); val w = (size.width - p * 2).coerceAtLeast(1f); val h = (size.height - p * 2).coerceAtLeast(1f)
-                val offsets = geometry.points.map { Offset(p + it.x * w, p + it.y * h) }
-                offsets.zipWithNext().forEach { (from, to) -> drawLine(routeColor, from, to, strokeWidth = 4.dp.toPx(), cap = StrokeCap.Round) }
-                drawCircle(startColor, 6.dp.toPx(), offsets.first()); drawCircle(endColor, 6.dp.toPx(), offsets.last())
+                fun offset(point: com.evchargebook.domain.trip.TripRoutePoint) = Offset(p + point.x * w, p + point.y * h)
+                geometry.segments.forEach { segment ->
+                    segment.map(::offset).zipWithNext().forEach { (from, to) ->
+                        drawLine(routeColor, from, to, strokeWidth = 4.dp.toPx(), cap = StrokeCap.Round)
+                    }
+                }
+                drawCircle(startColor, 6.dp.toPx(), offset(geometry.points.first()))
+                drawCircle(endColor, 6.dp.toPx(), offset(geometry.points.last()))
             }
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text("起点", style = MaterialTheme.typography.labelMedium, color = startColor); Text("终点", style = MaterialTheme.typography.labelMedium, color = endColor) }
+            if (geometry.gapCount > 0) {
+                Text("检测到 ${geometry.gapCount} 处超过 2 分钟的 GPS 缺口，缺失区间不会用实线伪造连接。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
+            }
             Text("基于真实 WGS84 轨迹点绘制，不做道路吸附或虚构路线。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }

--- a/android/app/src/test/java/com/evchargebook/domain/TripGpsHealthBoundaryTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripGpsHealthBoundaryTest.kt
@@ -1,0 +1,21 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripGpsHealthBoundaryTest {
+    @Test
+    fun `threshold boundaries are deterministic`() {
+        fun statusAt(seconds: Long): TripGpsHealthStatus = TripGpsHealth.evaluate(
+            nowEpochMillis = seconds * 1000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = seconds * 1000L,
+            lastAcceptedPointAtEpochMillis = 0L
+        ).status
+
+        assertEquals(TripGpsHealthStatus.GOOD, statusAt(14))
+        assertEquals(TripGpsHealthStatus.DEGRADED, statusAt(15))
+        assertEquals(TripGpsHealthStatus.LOST, statusAt(30))
+        assertEquals(TripGpsHealthStatus.LONG_GAP, statusAt(120))
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripGpsHealthTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripGpsHealthTest.kt
@@ -1,0 +1,62 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripGpsHealthTest {
+    @Test
+    fun `waiting before first callback`() {
+        val snapshot = TripGpsHealth.evaluate(
+            nowEpochMillis = 10_000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = null,
+            lastAcceptedPointAtEpochMillis = null
+        )
+        assertEquals(TripGpsHealthStatus.WAITING, snapshot.status)
+    }
+
+    @Test
+    fun `good when accepted point is fresh`() {
+        val snapshot = TripGpsHealth.evaluate(
+            nowEpochMillis = 20_000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = 19_000L,
+            lastAcceptedPointAtEpochMillis = 18_000L
+        )
+        assertEquals(TripGpsHealthStatus.GOOD, snapshot.status)
+        assertEquals(2L, snapshot.secondsSinceLastAcceptedPoint)
+    }
+
+    @Test
+    fun `degraded after fifteen seconds without accepted point`() {
+        val snapshot = TripGpsHealth.evaluate(
+            nowEpochMillis = 30_000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = 29_000L,
+            lastAcceptedPointAtEpochMillis = 15_000L
+        )
+        assertEquals(TripGpsHealthStatus.DEGRADED, snapshot.status)
+    }
+
+    @Test
+    fun `lost after thirty seconds without accepted point`() {
+        val snapshot = TripGpsHealth.evaluate(
+            nowEpochMillis = 60_000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = 59_000L,
+            lastAcceptedPointAtEpochMillis = 30_000L
+        )
+        assertEquals(TripGpsHealthStatus.LOST, snapshot.status)
+    }
+
+    @Test
+    fun `long gap after two minutes`() {
+        val snapshot = TripGpsHealth.evaluate(
+            nowEpochMillis = 180_000L,
+            trackingStartedAtEpochMillis = 0L,
+            lastCallbackAtEpochMillis = 179_000L,
+            lastAcceptedPointAtEpochMillis = 60_000L
+        )
+        assertEquals(TripGpsHealthStatus.LONG_GAP, snapshot.status)
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripRouteGeometryTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripRouteGeometryTest.kt
@@ -19,6 +19,8 @@ class TripRouteGeometryTest {
         assertNotNull(geometry)
         geometry!!
         assertEquals(3, geometry.points.size)
+        assertEquals(1, geometry.segments.size)
+        assertEquals(0, geometry.gapCount)
         assertTrue(geometry.isDrawable)
         assertEquals(0f, geometry.points.first().x, 0.0001f)
         assertEquals(1f, geometry.points.first().y, 0.0001f)
@@ -47,5 +49,36 @@ class TripRouteGeometryTest {
 
         assertEquals(1, geometry.points.size)
         assertTrue(!geometry.isDrawable)
+    }
+
+    @Test
+    fun `long GPS gap creates disconnected route segments`() {
+        val geometry = TripRouteGeometryBuilder.build(
+            listOf(
+                TripGeoPoint(31.2000, 121.4000, 0L),
+                TripGeoPoint(31.2010, 121.4010, 4_000L),
+                TripGeoPoint(31.2500, 121.4500, 180_000L),
+                TripGeoPoint(31.2510, 121.4510, 184_000L)
+            )
+        )!!
+
+        assertEquals(2, geometry.segments.size)
+        assertEquals(1, geometry.gapCount)
+        assertEquals(2, geometry.segments[0].size)
+        assertEquals(2, geometry.segments[1].size)
+        assertTrue(geometry.isDrawable)
+    }
+
+    @Test
+    fun `gap below threshold stays continuous`() {
+        val geometry = TripRouteGeometryBuilder.build(
+            listOf(
+                TripGeoPoint(31.2000, 121.4000, 0L),
+                TripGeoPoint(31.2010, 121.4010, 119_999L)
+            )
+        )!!
+
+        assertEquals(1, geometry.segments.size)
+        assertEquals(0, geometry.gapCount)
     }
 }


### PR DESCRIPTION
## Summary

Implements the first Trip GPS reliability hardening slice after the 2026-08-27 real-device Trip #7 report, and syncs the product/architecture documents to the resulting priority change.

### GPS health / lock-screen observability

- new `TripGpsHealth` domain model
- deterministic thresholds:
  - <15s fresh / waiting
  - >=15s degraded
  - >=30s lost
  - >=120s long gap
- foreground trip notification refreshes in place every 10 seconds
- notification shows latest health state, age of latest accepted point, provider (`gps` / network fallback), and rejected-point count
- health updates after accepted/rejected points and on heartbeat timer
- no Room migration in this first slice
- JVM tests for states and exact boundaries

### Route continuity

- route geometry accepts capture timestamps
- gaps >=120 seconds split the route into disconnected geometry segments
- preview renders only within trusted segments
- long gaps are explicitly reported in the UI and are not connected with a fabricated solid line
- JVM tests cover gap and non-gap boundaries

### Speed semantics

Trip detail now separates:

- whole-trip average = recorded distance / total elapsed time
- moving average = recorded distance / moving time
- max recorded speed = filtered `Location.speed` peak
- moving time

Important clarification:

- current peak / instantaneous speed is primarily sourced from Android `Location.speed`, not simple point-to-point straight-line distance/time
- total distance is still accumulated from accepted geographic points, so average-speed quality inherits GPS distance quality
- very short real speed peaks can be missed when no valid Location fix lands inside the peak window

### Documentation sync

- `PROJECT_MASTER.md` -> v2.1.0
- `ROADMAP.md` -> v2.6.0
- `LOCATION_TRIP.md` -> v1.3.0

The docs now make the execution order explicit:

1. long-gap distance correction
2. GPS / Network dedupe + quality policy
3. Trip completeness / persistent diagnostics
4. lock-screen long-drive physical verification
5. segmented speed + continuous route coloring
6. resume v0.4 sync expansion

### OBD-II boundary

OBD-II is recorded as **P3 optional exploration**, not a current product dependency.

The first allowed PoC is deliberately narrow:

- external Bluetooth/BLE/Wi-Fi OBD-II adapter
- query standard Vehicle Speed support
- read OBD Vehicle Speed
- compare with GNSS `Location.speed`

Explicitly out of current scope:

- private CAN ID reverse engineering
- private BMS PID reverse engineering
- single-model protocol maintenance
- making OBD mandatory for Trip

### Privacy

The ongoing notification never exposes latitude, longitude, home/work address, or other precise location text.

### Validation

Android Build Run #184 completed successfully on the implementation code baseline:

- Build/Test ✅
- Debug APK ✅

The final PR head adds documentation synchronization only; runtime scope is unchanged.

Refs #26.