### PR TITLE
style(android): extend cockpit language across core app UI

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -107,6 +109,8 @@ fun AddRecordScreen(
     Scaffold(topBar = { TopAppBar(title = { Text("记录充电") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            ChargeInputCockpit(startSoc, endSoc, energy, cost)
+
             FormSection("时间与地点", "先记录事实，详细备注可以之后再补。") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     OutlinedButton(onClick = { DatePickerDialog(context, { _, y, m, d -> calendar.set(y, m, d); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.CalendarMonth, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(dateText) }
@@ -154,9 +158,7 @@ fun AddRecordScreen(
                     AddNumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
                     AddNumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
                 }
-                anomalyWarnings.forEach { warning ->
-                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-                }
+                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
             }
 
             FormSection("车辆与备注", "里程有助于后续估算每百公里补能成本。") {
@@ -189,6 +191,44 @@ fun AddRecordScreen(
 }
 
 @Composable
+private fun ChargeInputCockpit(startSoc: String, endSoc: String, energy: String, cost: String) {
+    val start = startSoc.toIntOrNull()
+    val end = endSoc.toIntOrNull()
+    val energyValue = energy.toDoubleOrNull()
+    val costValue = cost.toDoubleOrNull()
+    val delta = if (start != null && end != null && end >= start) end - start else null
+    val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(7.dp), color = MaterialTheme.colorScheme.inversePrimary, shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("CHARGE / NEW", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                InputMetric("SOC", delta?.let { "+$it%" } ?: "--", Modifier.weight(1f))
+                InputMetric("补能", energyValue?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+                InputMetric("均价", unitPrice?.let { "¥ ${formatTwo(it)}" } ?: "--", Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun InputMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .48f))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
+    }
+}
+
+@Composable
 private fun FormSection(title: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
         Text(title, style = MaterialTheme.typography.titleMedium)
@@ -210,3 +250,5 @@ private fun SingleChoiceSegment(options: List<String>, selected: String, onSelec
 @Composable private fun AddNumberField(value: String, onChange: (String) -> Unit, label: String, suffix: String, modifier: Modifier, keyboardType: KeyboardType) { OutlinedTextField(value, onChange, label = { Text(label) }, suffix = { Text(suffix) }, keyboardOptions = KeyboardOptions(keyboardType = keyboardType), modifier = modifier, singleLine = true) }
 private fun formatKm(value: Double) = if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
 private fun formatCoordinate(value: Double) = String.format(Locale.US, "%.6f", value)
+private fun formatOne(value: Double) = String.format(Locale.US, "%.1f", value)
+private fun formatTwo(value: Double) = String.format(Locale.US, "%.2f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
@@ -59,6 +62,7 @@ fun RecordEditScreen(
     Scaffold(topBar = { TopAppBar(title = { Text("编辑充电记录") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            EditChargeSummary(startSoc, endSoc, energy, cost)
             EditSection("时间与地点") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     OutlinedButton(onClick = { DatePickerDialog(context, { _, y, m, d -> calendar.set(y, m, d); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show() }, modifier = Modifier.weight(1f)) { Icon(Icons.Default.CalendarMonth, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(dateText) }
@@ -79,9 +83,7 @@ fun RecordEditScreen(
                     NumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
                     NumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
                 }
-                anomalyWarnings.forEach { warning ->
-                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-                }
+                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
             }
             EditSection("车辆与备注") {
                 NumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
@@ -105,6 +107,44 @@ fun RecordEditScreen(
             }, modifier = Modifier.fillMaxWidth()) { Text("保存修改") }
             Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
+    }
+}
+
+@Composable
+private fun EditChargeSummary(startSoc: String, endSoc: String, energy: String, cost: String) {
+    val start = startSoc.toIntOrNull()
+    val end = endSoc.toIntOrNull()
+    val energyValue = energy.toDoubleOrNull()
+    val costValue = cost.toDoubleOrNull()
+    val delta = if (start != null && end != null && end >= start) end - start else null
+    val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(7.dp), color = MaterialTheme.colorScheme.inversePrimary, shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("CHARGE / EDIT", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                EditMetric("SOC", delta?.let { "+$it%" } ?: "--", Modifier.weight(1f))
+                EditMetric("补能", energyValue?.let { String.format(Locale.US, "%.1f kWh", it) } ?: "--", Modifier.weight(1f))
+                EditMetric("均价", unitPrice?.let { String.format(Locale.US, "¥ %.2f", it) } ?: "--", Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .48f))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.ui.components.EmptyState
@@ -57,25 +58,13 @@ fun RecordsScreen(
                 contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
             ) {
+                item { LedgerCockpit(records) }
                 item {
-                    Surface(
-                        color = MaterialTheme.colorScheme.primaryContainer,
-                        shape = MaterialTheme.shapes.medium
-                    ) {
-                        Row(
-                            Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Column {
-                                Text("累计支出", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                                Text("¥ ${two(records.sumOf { it.cost })}", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                            }
-                            Column(horizontalAlignment = Alignment.End) {
-                                Text("记录", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                                Text("${records.size} 笔", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                            }
-                        }
-                    }
+                    Text(
+                        "最近记录",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
                 }
                 items(records, key = { it.id }) { record ->
                     RecordItem(record, onEdit = { onEdit(record) }) { pendingDelete = record }
@@ -96,6 +85,78 @@ fun RecordsScreen(
                 }
             },
             dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("取消") } }
+        )
+    }
+}
+
+@Composable
+private fun LedgerCockpit(records: List<ChargingRecordEntity>) {
+    val totalCost = records.sumOf { it.cost }
+    val totalEnergy = records.sumOf { it.energyKwh }
+    val averagePrice = if (totalEnergy > 0.0) totalCost / totalEnergy else 0.0
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(
+            Modifier.padding(MaterialTheme.spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(8.dp),
+                    color = MaterialTheme.colorScheme.inversePrimary,
+                    shape = MaterialTheme.shapes.extraSmall
+                ) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text(
+                    "CHARGE / LEDGER",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .62f)
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                Text(
+                    "累计支出",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .66f)
+                )
+                Text(
+                    "¥ ${two(totalCost)}",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface
+                )
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                CockpitValue("补能", "${one(totalEnergy)} kWh", Modifier.weight(1f))
+                CockpitValue("记录", "${records.size} 笔", Modifier.weight(1f))
+                CockpitValue("均价", "¥ ${two(averagePrice)}", Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CockpitValue(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .52f)
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.inverseOnSurface
         )
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.material.icons.filled.Payments
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.evchargebook.domain.ChargerCategory
 import com.evchargebook.domain.ChargingEstimateConfidence
 import com.evchargebook.domain.ChargingIntervalSample
@@ -61,14 +63,27 @@ fun StatsScreen(state: MainUiState) {
 
 @Composable
 private fun MonthSummary(state: MainUiState) {
-    Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.primaryContainer) {
-        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Text("本月充电支出", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = .72f))
-            Text("¥ ${two(state.monthCost)}", style = MaterialTheme.typography.displaySmall, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onPrimaryContainer)
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(8.dp), color = MaterialTheme.colorScheme.inversePrimary, shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("ENERGY / MONTH", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .60f))
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                Text("本月充电支出", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .62f))
+                Text("¥ ${two(state.monthCost)}", style = MaterialTheme.typography.displaySmall, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
             Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
-                StatValue("补能", "${one(state.monthEnergy)} kWh", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
-                StatValue("次数", "${state.chargingCount} 次", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
-                StatValue("均价", "¥ ${two(state.averagePrice)}", Modifier.weight(1f), MaterialTheme.colorScheme.onPrimaryContainer)
+                StatValue("补能", "${one(state.monthEnergy)} kWh", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
+                StatValue("次数", "${state.chargingCount} 次", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
+                StatValue("均价", "¥ ${two(state.averagePrice)}", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
@@ -11,34 +11,134 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.evchargebook.bluetooth.BluetoothPromptSettings
 import com.evchargebook.bluetooth.PairedBluetoothDevice
 import com.evchargebook.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BluetoothPromptScreen(settings: BluetoothPromptSettings, devices: List<PairedBluetoothDevice>, onSave: (Boolean, String?, String?) -> Unit, onBack: () -> Unit) {
+fun BluetoothPromptScreen(
+    settings: BluetoothPromptSettings,
+    devices: List<PairedBluetoothDevice>,
+    onSave: (Boolean, String?, String?) -> Unit,
+    onBack: () -> Unit
+) {
     val enabled = settings.enabled && settings.deviceAddress != null
-    Scaffold(topBar = { TopAppBar(title = { Text("车载蓝牙提示") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
-        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("车载蓝牙提示") },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+        ) {
+            item { BluetoothStatusCockpit(settings, enabled, onSave) }
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) { Icon(Icons.Default.Bluetooth, null, tint = MaterialTheme.colorScheme.primary); Spacer(Modifier.width(MaterialTheme.spacing.sm)); Column(Modifier.weight(1f)) { Text("连接后提醒开始行程", style = MaterialTheme.typography.titleMedium); Text("只监听你选中的已配对设备，不读取车辆数据，也不会自动开始行程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }; Switch(checked = enabled, onCheckedChange = { checked -> onSave(checked, settings.deviceAddress, settings.deviceName) }, enabled = settings.deviceAddress != null) }
-                    if (settings.deviceAddress == null) Text("先选择一个已配对设备后才能启用。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                    Text("已配对设备", style = MaterialTheme.typography.titleMedium)
+                    Text("选择车辆蓝牙；连接时 App 会提醒你确认是否开始行程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
-            item { HorizontalDivider(); Text("已配对设备", style = MaterialTheme.typography.titleMedium) }
-            if (devices.isEmpty()) item { Text("没有可用设备。请先到系统蓝牙设置完成配对，然后返回这里。", color = MaterialTheme.colorScheme.onSurfaceVariant) }
+            if (devices.isEmpty()) {
+                item {
+                    Surface(
+                        Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.large,
+                        color = MaterialTheme.colorScheme.surfaceContainerLow
+                    ) {
+                        Text(
+                            "没有可用设备。请先到系统蓝牙设置完成配对，然后返回这里。",
+                            modifier = Modifier.padding(MaterialTheme.spacing.md),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
             items(devices, key = { it.address }) { device ->
                 val selected = device.address == settings.deviceAddress
-                ListItem(
-                    headlineContent = { Text(device.name) },
-                    supportingContent = { Text(if (selected) "已选择 · ${device.address}" else device.address) },
-                    trailingContent = { RadioButton(selected = selected, onClick = { onSave(true, device.address, device.name) }) },
-                    modifier = Modifier.fillMaxWidth().clickable { onSave(true, device.address, device.name) }
-                )
-                HorizontalDivider()
+                Surface(
+                    modifier = Modifier.fillMaxWidth().clickable { onSave(true, device.address, device.name) },
+                    shape = MaterialTheme.shapes.medium,
+                    color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerLow
+                ) {
+                    Row(
+                        Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(device.name, style = MaterialTheme.typography.titleMedium)
+                            Text(
+                                if (selected) "当前目标 · ${device.address}" else device.address,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = .70f) else MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        RadioButton(selected = selected, onClick = { onSave(true, device.address, device.name) })
+                    }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun BluetoothStatusCockpit(
+    settings: BluetoothPromptSettings,
+    enabled: Boolean,
+    onSave: (Boolean, String?, String?) -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(8.dp), color = if (enabled) MaterialTheme.colorScheme.inversePrimary else MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .28f), shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text(
+                    if (enabled) "BLUETOOTH / ARMED" else "BLUETOOTH / READY",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .60f)
+                )
+                Spacer(Modifier.weight(1f))
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = { checked -> onSave(checked, settings.deviceAddress, settings.deviceName) },
+                    enabled = settings.deviceAddress != null
+                )
+            }
+
+            Icon(Icons.Default.Bluetooth, null, tint = MaterialTheme.colorScheme.inversePrimary)
+
+            Text(
+                settings.deviceName ?: "尚未选择车辆蓝牙",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                when {
+                    settings.deviceAddress == null -> "先在下方选择一个已配对设备。"
+                    enabled -> "连接到此设备后，会提醒你确认是否开始行程。"
+                    else -> "设备已选择，但连接提醒当前关闭。"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .62f)
+            )
+            Text(
+                "不会读取车辆数据，也不会自动开始行程。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .46f)
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.VehicleCatalogEntity
@@ -16,28 +18,82 @@ import com.evchargebook.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VehicleCatalogScreen(items: List<VehicleCatalogEntity>, onSelect: (VehicleCatalogEntity) -> Unit, onCustom: () -> Unit, onBack: () -> Unit) {
+fun VehicleCatalogScreen(
+    items: List<VehicleCatalogEntity>,
+    onSelect: (VehicleCatalogEntity) -> Unit,
+    onCustom: () -> Unit,
+    onBack: () -> Unit
+) {
     var query by remember { mutableStateOf("") }
-    val filtered = remember(items, query) { items.filter { "${it.brand} ${it.series} ${it.modelName} ${it.trimName.orEmpty()}".contains(query.trim(), ignoreCase = true) } }
+    val filtered = remember(items, query) {
+        items.filter { "${it.brand} ${it.series} ${it.modelName} ${it.trimName.orEmpty()}".contains(query.trim(), ignoreCase = true) }
+    }
+
     Scaffold(
-        topBar = { TopAppBar(title = { Text("选择车型") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) },
-        bottomBar = { Surface(tonalElevation = 1.dp) { TextButton(onClick = onCustom, modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs)) { Text("没有找到？自定义添加车辆") } } }
-    ) { padding ->
-        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm)) {
-            item {
-                OutlinedTextField(value = query, onValueChange = { query = it }, leadingIcon = { Icon(Icons.Default.Search, null) }, placeholder = { Text("搜索品牌、车系或配置") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
-                Spacer(Modifier.height(MaterialTheme.spacing.sm))
-                Text(if (query.isBlank()) "车型库 ${items.size} 条" else "找到 ${filtered.size} 条结果", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Spacer(Modifier.height(MaterialTheme.spacing.sm))
+        topBar = {
+            TopAppBar(
+                title = { Text("选择车型") },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }
+            )
+        },
+        bottomBar = {
+            Surface(tonalElevation = 1.dp) {
+                FilledTonalButton(
+                    onClick = onCustom,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs)
+                ) { Text("没有找到？自定义添加车辆") }
             }
-            if (filtered.isEmpty()) item { Text("没有匹配车型。你可以修改关键词，或使用下方自定义添加。", color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(vertical = MaterialTheme.spacing.lg)) }
-            items(filtered, key = { it.catalogId }) { item ->
-                ListItem(
-                    headlineContent = { Text("${item.brand} ${item.modelName}") },
-                    supportingContent = { Text("${item.trimName ?: item.series} · ${item.powertrainType}\n${item.batteryCapacityKwh ?: "-"} kWh · ${item.rangeKm ?: "-"} km") },
-                    modifier = Modifier.fillMaxWidth().clickable { onSelect(item) }
-                )
-                HorizontalDivider()
+        }
+    ) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding)) {
+            Surface(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.surfaceContainerLow
+            ) {
+                Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Surface(Modifier.size(7.dp), color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.extraSmall) {}
+                        Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                        Text("VEHICLE / CATALOG", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { query = it },
+                        leadingIcon = { Icon(Icons.Default.Search, null) },
+                        placeholder = { Text("搜索品牌、车系或配置") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true
+                    )
+                    Text(
+                        if (query.isBlank()) "车型库 ${items.size} 条" else "找到 ${filtered.size} 条结果",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs)
+            ) {
+                if (filtered.isEmpty()) {
+                    item { Text("没有匹配车型。你可以修改关键词，或使用下方自定义添加。", color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(vertical = MaterialTheme.spacing.lg)) }
+                }
+                items(filtered, key = { it.catalogId }) { item ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().clickable { onSelect(item) }.padding(vertical = MaterialTheme.spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text("${item.brand} ${item.modelName}", style = MaterialTheme.typography.titleMedium)
+                            Text("${item.trimName ?: item.series} · ${item.powertrainType}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text("${item.batteryCapacityKwh ?: "-"} kWh · ${item.rangeKm ?: "-"} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                        Icon(Icons.Default.ChevronRight, null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
@@ -8,13 +8,24 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import com.evchargebook.ui.theme.spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VehicleEditScreen(initialBrand: String, initialModel: String, initialBatteryCapacity: String, initialRange: String, title: String = "编辑车辆", onSave: (String, String, Double, Int) -> Unit, onBack: () -> Unit) {
+fun VehicleEditScreen(
+    initialBrand: String,
+    initialModel: String,
+    initialBatteryCapacity: String,
+    initialRange: String,
+    title: String = "编辑车辆",
+    onSave: (String, String, Double, Int) -> Unit,
+    onBack: () -> Unit
+) {
     var brand by remember { mutableStateOf(initialBrand) }
     var model by remember { mutableStateOf(initialModel) }
     var battery by remember { mutableStateOf(initialBatteryCapacity) }
@@ -24,6 +35,8 @@ fun VehicleEditScreen(initialBrand: String, initialModel: String, initialBattery
     Scaffold(topBar = { TopAppBar(title = { Text(title) }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
+            VehiclePreviewCockpit(brand, model, battery, range, title == "添加车辆")
+
             Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                 Text("车辆信息", style = MaterialTheme.typography.titleMedium)
                 Text("用于区分账本数据，并参与电池容量与续航相关的展示。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -53,3 +66,40 @@ fun VehicleEditScreen(initialBrand: String, initialModel: String, initialBattery
         }
     }
 }
+
+@Composable
+private fun VehiclePreviewCockpit(brand: String, model: String, battery: String, range: String, adding: Boolean) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(7.dp), color = MaterialTheme.colorScheme.inversePrimary, shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text(if (adding) "VEHICLE / NEW" else "VEHICLE / EDIT", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+            }
+            Text(
+                listOf(brand.trim(), model.trim()).filter { it.isNotEmpty() }.joinToString(" ").ifBlank { "车辆预览" },
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+                PreviewMetric("电池", battery.toDoubleOrNull()?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+                PreviewMetric("续航", range.toIntOrNull()?.let { "$it km" } ?: "--", Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .48f))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
+    }
+}
+
+private fun formatOne(value: Double) = String.format(java.util.Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.ui.theme.spacing
@@ -47,57 +48,25 @@ fun VehicleScreen(
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.xs),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
         ) {
-            item {
-                Text(
-                    "当前车辆",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            items(vehicles, key = { it.id }) { item ->
-                VehicleRow(
-                    vehicle = item,
-                    selected = item.id == vehicle?.id,
-                    canArchive = vehicles.size > 1,
-                    onSelect = { onSelect(item.id) },
-                    onEdit = { if (item.id == vehicle?.id) onEdit() else onSelect(item.id) },
-                    onArchive = { archiveCandidate = item }
-                )
+            vehicle?.let { current -> item { CurrentVehicleCockpit(current, onEdit) } }
+
+            if (vehicles.size > 1) {
+                item { SettingsSectionTitle("切换车辆") }
+                items(vehicles.filter { it.id != vehicle?.id }, key = { it.id }) { item ->
+                    VehicleRow(
+                        vehicle = item,
+                        canArchive = true,
+                        onSelect = { onSelect(item.id) },
+                        onArchive = { archiveCandidate = item }
+                    )
+                }
             }
 
             item { SettingsSectionTitle("连接与数据") }
-            item {
-                SettingsRow(
-                    icon = Icons.Default.Bluetooth,
-                    title = "车载蓝牙",
-                    subtitle = "连接指定设备时提醒开始行程",
-                    onClick = onBluetoothPrompt
-                )
-            }
-            item {
-                SettingsRow(
-                    icon = Icons.Default.UploadFile,
-                    title = "导出备份",
-                    subtitle = "完整 JSON，可用于恢复车辆、充电记录和行程",
-                    onClick = onExportBackup
-                )
-            }
-            item {
-                SettingsRow(
-                    icon = Icons.Default.TableView,
-                    title = "导出分析 CSV",
-                    subtitle = "当前车辆充电账本，可用于 Excel / Python 分析",
-                    onClick = onExportCsv
-                )
-            }
-            item {
-                SettingsRow(
-                    icon = Icons.Default.Download,
-                    title = "恢复备份",
-                    subtitle = "从本地 JSON 备份恢复数据",
-                    onClick = onImportBackup
-                )
-            }
+            item { SettingsRow(Icons.Default.Bluetooth, "车载蓝牙", "连接指定设备时提醒开始行程", onBluetoothPrompt) }
+            item { SettingsRow(Icons.Default.UploadFile, "导出备份", "完整 JSON，可用于恢复车辆、充电记录和行程", onExportBackup) }
+            item { SettingsRow(Icons.Default.TableView, "导出分析 CSV", "当前车辆充电账本，可用于 Excel / Python 分析", onExportCsv) }
+            item { SettingsRow(Icons.Default.Download, "恢复备份", "从本地 JSON 备份恢复数据", onImportBackup) }
         }
     }
 
@@ -106,60 +75,76 @@ fun VehicleScreen(
             onDismissRequest = { archiveCandidate = null },
             title = { Text("归档 ${candidate.brand} ${candidate.model}？") },
             text = { Text("车辆将不再出现在切换列表中，但历史充电记录仍会保留。") },
-            confirmButton = {
-                TextButton(onClick = { onArchive(candidate); archiveCandidate = null }) { Text("归档") }
-            },
+            confirmButton = { TextButton(onClick = { onArchive(candidate); archiveCandidate = null }) { Text("归档") } },
             dismissButton = { TextButton(onClick = { archiveCandidate = null }) { Text("取消") } }
         )
     }
 }
 
 @Composable
-private fun VehicleRow(
-    vehicle: VehicleEntity,
-    selected: Boolean,
-    canArchive: Boolean,
-    onSelect: () -> Unit,
-    onEdit: () -> Unit,
-    onArchive: () -> Unit
-) {
+private fun CurrentVehicleCockpit(vehicle: VehicleEntity, onEdit: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(Modifier.size(8.dp), color = MaterialTheme.colorScheme.inversePrimary, shape = MaterialTheme.shapes.extraSmall) {}
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("VEHICLE / ACTIVE", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .60f))
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                Text("${vehicle.brand} ${vehicle.model}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
+                Text("当前车辆", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
+                VehicleMetric("电池", "${one(vehicle.batteryCapacityKwh)} kWh", Modifier.weight(1f))
+                VehicleMetric("标称续航", "${vehicle.rangeKm} km", Modifier.weight(1f))
+            }
+
+            OutlinedButton(
+                onClick = onEdit,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.inverseOnSurface),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .22f))
+            ) {
+                Icon(Icons.Default.Edit, null)
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("编辑当前车辆")
+            }
+        }
+    }
+}
+
+@Composable
+private fun VehicleMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .52f))
+        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
+    }
+}
+
+@Composable
+private fun VehicleRow(vehicle: VehicleEntity, canArchive: Boolean, onSelect: () -> Unit, onArchive: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onSelect),
-        color = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
+        color = MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
-        border = BorderStroke(
-            1.dp,
-            if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.25f) else MaterialTheme.colorScheme.outlineVariant
-        )
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
-        Column(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Column(Modifier.weight(1f)) {
-                    Text("${vehicle.brand} ${vehicle.model}", style = MaterialTheme.typography.titleMedium)
-                    Spacer(Modifier.height(MaterialTheme.spacing.xxs))
-                    Text(
-                        "${one(vehicle.batteryCapacityKwh)} kWh · ${vehicle.rangeKm} km",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                if (selected) {
-                    Surface(
-                        color = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                        shape = MaterialTheme.shapes.small
-                    ) {
-                        Text("当前", Modifier.padding(horizontal = MaterialTheme.spacing.xs, vertical = MaterialTheme.spacing.xxs), style = MaterialTheme.typography.labelLarge)
-                    }
-                }
+        Row(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text("${vehicle.brand} ${vehicle.model}", style = MaterialTheme.typography.titleMedium)
+                Text("${one(vehicle.batteryCapacityKwh)} kWh · ${vehicle.rangeKm} km", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            if (selected || canArchive) {
-                Spacer(Modifier.height(MaterialTheme.spacing.sm))
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
-                    if (selected) TextButton(onClick = onEdit) { Icon(Icons.Default.Edit, null); Spacer(Modifier.width(4.dp)); Text("编辑") }
-                    if (canArchive) TextButton(onClick = onArchive) { Icon(Icons.Default.Archive, null); Spacer(Modifier.width(4.dp)); Text("归档") }
-                }
-            }
+            TextButton(onClick = onSelect) { Text("切换") }
+            if (canArchive) IconButton(onClick = onArchive) { Icon(Icons.Default.Archive, "归档车辆") }
         }
     }
 }
@@ -182,10 +167,7 @@ private fun SettingsRow(
         shape = MaterialTheme.shapes.medium,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     ) {
-        Row(
-            Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Row(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md), verticalAlignment = Alignment.CenterVertically) {
             Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
             Spacer(Modifier.width(MaterialTheme.spacing.sm))
             Column(Modifier.weight(1f)) {


### PR DESCRIPTION
## Summary

Continue the restrained EV cockpit visual system across the non-Trip UI while keeping utility surfaces readable and native.

## What changed

- Records
  - dark `CHARGE / LEDGER` summary
  - total spend as the primary metric, with energy / record count / average price as secondary metrics
  - recent records remain neutral and dense
- Stats
  - `ENERGY / MONTH` cockpit summary for monthly spend and energy metrics
  - detailed analytics, comparisons and interval evidence remain low-noise
- Vehicle
  - `VEHICLE / ACTIVE` cockpit panel for the current car
  - alternate vehicles moved into a simpler switch list
  - data/export settings remain neutral
- Bluetooth
  - explicit `BLUETOOTH / ARMED|READY` status panel
  - clearer selected target and enable-state semantics
  - paired-device list remains lightweight
- Add Record
  - live `CHARGE / NEW` summary showing SOC delta, entered energy and derived unit price while typing
  - existing location, common-place, anomaly and validation behavior preserved
- Edit Record
  - matching `CHARGE / EDIT` live summary so edit and create flows feel like one system
- Vehicle Edit / Add
  - live `VEHICLE / NEW|EDIT` preview for name, capacity and range
- Vehicle Catalog
  - cleaner search-first selection flow with compact catalog status and row-level navigation affordance

## Design rule

Cockpit surfaces are reserved for current state / primary metrics. Lists, forms, diagnostics and settings remain low-noise. No gradients, glow, glassmorphism or gaming-style decoration.

## Scope / safety

UI/UX layer only. No database schema, repository, GPS service, Bluetooth behavior, backup format or business-rule changes.

## Trip coordination

This PR deliberately does not touch `TripScreen.kt` because PR #36 is actively changing GPS health, route gaps and speed semantics. The Trip cockpit pass should be rebased/reapplied after that business work settles.

## Acceptance focus

- dark-mode readability
- small-screen layout with long Chinese strings
- Add/Edit Record live summary handles partial input safely
- vehicle catalog search remains responsive and custom-add fallback remains reachable
- no loss of validation, anomaly warnings, backup/export or Bluetooth configuration behavior