### PR TITLE
docs: align Trip speed, GPS reliability and OBD roadmap

### DIFF
--- a/docs/LOCATION_TRIP.md
+++ b/docs/LOCATION_TRIP.md
@@ -1,6 +1,6 @@
 # EV Charge Book Location / Map / Trip Tracking Design
 
-版本: v1.2.0
+版本: v1.3.0
 更新时间: 2026-08-27
 状态: Authority Subdocument
 
@@ -18,6 +18,7 @@
 6. 记录可靠性优先于采样频率，必须控制耗电和数据库体积。
 7. 不能用两端 GPS 点直连来伪造缺失路线；GPS gap 必须显式表达。
 8. 在没有道路类型/限速/交通数据前，速度颜色只能表达本车速度分布，不能宣称真实拥堵等级。
+9. 速度值必须保留来源语义；GNSS、位置差分和未来 OBD 不得混成一个无来源数字。
 
 详细可靠性与速度可视化方案见 `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`。
 
@@ -93,7 +94,7 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 
 静止降频只能解释短间隔缺点，不能解释十分钟级位置空洞。
 
-真实行程已经观察到 12 分钟和 15 分钟级 GPS gap，因此后续必须记录：
+真实行程已经观察到 12 分钟和 15 分钟级 GPS gap，因此必须逐步补齐：
 
 - lastLocationCallbackAt
 - lastAcceptedPointAt
@@ -102,9 +103,11 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 - longest gap
 - service lifecycle / re-delivery evidence
 
+PR #36 第一阶段已经实现运行时 GPS health 与 ongoing notification，并在长 gap 时把轨迹拆成多个可信 segment。
+
 ---
 
-## 5. 时间与速度口径
+## 5. 时间、距离与速度口径
 
 Trip 至少区分:
 
@@ -119,14 +122,44 @@ Trip 至少区分:
 
 阈值需要真机数据调优，不写死成产品事实。
 
-### 速度 UI
+### 5.1 当前距离如何计算
+
+当前 `distanceMeters` 来自连续 accepted GPS point 之间的地理直线距离累计。
+
+因此它不是道路里程，也不是车辆轮速里程；在以下场景会存在偏差：
+
+- 道路连续弯曲但采样点较稀
+- GPS 漂移
+- GPS / Network provider 切换
+- 长时间 GPS gap 后直接把 gap 两端连接
+
+产品规则：长时间 gap 两端不能继续作为“可信连续距离”直接累计。该规则属于 P0 reliability follow-up；在落地前，平均速度必须被视为基于已记录 GPS 距离的派生值，而不是车辆仪表级事实。
+
+### 5.2 当前速度到底来自哪里
+
+当前存在两个完全不同的概念：
+
+1. `Location.speed`：Android Location 提供的定位时刻速度，当前用于 TripPoint `speedMps`，也是最高速度的主要来源。
+2. `point-to-point distance / time`：可作为轨迹区段速度的派生/校验证据，但不应该冒充瞬时速度。
+
+因此：
+
+- 当前“最高速度”不是简单用两点直线距离除时间得到的。
+- 当前“全程均速 / 行驶均速”依赖累计 `distanceMeters`，所以会受到 GPS 距离质量影响。
+- 未来“分段速度”不能只用一个单点 `Location.speed`，也不能只用两点直线距离；应结合连续可信点、speed accuracy、provider 与 gap 状态。
+
+短时速度峰值存在漏采可能。例如真实峰值只持续约 4 秒，而采样目标同样是 2-5 秒，则可能在峰值时没有产生有效 Location fix。产品上应区分“最高已记录 GNSS 速度”和“车辆真实最高速度”，不能把未采到的峰值推算出来。
+
+### 5.3 速度 UI
 
 必须区分：
 
-1. 全程平均速度：total distance / elapsed time
-2. 行驶平均速度：total distance / moving time
-3. 分段平均速度：segment distance / segment duration
-4. 最高速度：经异常过滤后的 max speed
+1. 全程平均速度：total recorded distance / elapsed time
+2. 行驶平均速度：total recorded distance / moving time
+3. 分段平均速度：可信 segment 内的综合速度
+4. 最高已记录速度：经异常过滤后的 Location.speed 峰值
+
+PR #36 已把详情页原先模糊的“平均速度”拆成全程均速 / 行驶均速 / 最高速度 / 移动时间。
 
 后续新增 `TripSpeedSegment` 派生模型，不新增 Room 表即可完成首版。
 
@@ -142,7 +175,49 @@ Trip 至少区分:
 
 ---
 
-## 6. 中断与恢复
+## 6. 速度数据源演进
+
+保持简单的可替换接口思想，不提前做复杂基础设施：
+
+```text
+VehicleSpeedSource
+├── GnssSpeedSource       当前默认，来自 Location.speed
+├── DerivedSpeedSource    GPS 点距离/时间，只做分段派生与校验
+└── ObdSpeedSource        P3 可选，外接 OBD-II 设备
+```
+
+数据来源原则：
+
+- GNSS speed 与 derived speed 必须可区分。
+- future OBD speed 必须保留 `source=OBD`，不得覆盖原始 GNSS 事实。
+- 多来源可以互相校验，但首版不做“智能融合成唯一真值”。
+
+### OBD-II 边界
+
+OBD-II 作为 P3 可选增强方向，优先只验证标准 Vehicle Speed 数据是否可读。
+
+可行的最小实验：
+
+```text
+车辆 OBD-II 口
+  -> Bluetooth/BLE/Wi-Fi adapter
+  -> 查询标准支持能力
+  -> 读取 Vehicle Speed
+  -> 与 GNSS speed 对照
+```
+
+当前不进入产品主线的内容：
+
+- 厂商私有 CAN ID 逆向
+- 私有 BMS PID 逆向
+- 为单一车型维护复杂协议表
+- 以 OBD 作为 Trip 必需依赖
+
+如果未来 OBD 验证出稳定价值，再逐步考虑 SOC / 电压 / 电流 / 电池温度等车辆事实；这些不应阻塞当前 GPS Trip 产品完善。
+
+---
+
+## 7. 中断与恢复
 
 真实设备必须考虑:
 
@@ -170,7 +245,7 @@ App 启动时发现未正常结束的 Trip:
 
 ---
 
-## 7. GPS / Network Provider 质量
+## 8. GPS / Network Provider 质量
 
 当前允许 GPS + Network provider fallback。
 
@@ -180,6 +255,7 @@ App 启动时发现未正常结束的 Trip:
 - Network point 作为 fallback / continuity evidence
 - 不默认将 GPS 与 Network 视为同等质量
 - provider switch 必须可观察
+- 时间非常接近的 GPS / Network point 需要去重/择优，避免重复计距离
 - network 漂移点不能制造假距离或假速度
 
 GPS 海拔:
@@ -191,40 +267,47 @@ GPS 海拔:
 
 ---
 
-## 8. 后台与通知
+## 9. 后台与通知
 
 当前前台定位服务持续显示 ongoing notification。
 
-未来增强：
+PR #36 已增加：
 
-- 行程时长
-- 已记录距离
-- GPS health：GOOD / DEGRADED / LOST / LONG_GAP
+- GPS health：WAITING / GOOD / DEGRADED / LOST / LONG_GAP
 - 最近有效定位时间
-- “结束行程”快捷动作
+- 最近 accepted provider
+- rejected point count
+- 同一条通知周期刷新，不刷屏
+- 不显示经纬度或精确地址
 
-GPS 长时间无有效点时更新同一条 ongoing notification，不重复刷通知。
+后续继续补：
+
+- service restart / re-delivery evidence
+- provider counters
+- longest gap / cumulative gap summary
 
 该方向与 Issue #26 的后台活动可见性方案保持一致。
 
 ---
 
-## 9. GPS Gap 可视化
+## 10. GPS Gap 可视化
 
 禁止将长时间缺失的两个 GPS 点直接画成可信实线。
 
-建议：
+PR #36 已按 `>=120s` gap 将路线几何拆成多个可信 segment；预览只绘制 segment 内部连续轨迹。
 
 ```text
-已知轨迹 ━━━━━ · · · · · ━━━━━ 已知轨迹
-               GPS 缺失
+已知轨迹 ━━━━━     ━━━━━ 已知轨迹
+             GPS 缺失
 ```
 
-无 basemap 阶段即可做断开/虚线表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+无 basemap 阶段即可做断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+
+下一步必须让距离聚合与可视化语义一致：长 gap 两端不能继续直接累计直线距离。
 
 ---
 
-## 10. 自动化演进
+## 11. 自动化演进
 
 v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
@@ -238,7 +321,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 11. 地点与充电记录
+## 12. 地点与充电记录
 
 新增充电记录支持:
 
@@ -252,7 +335,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 12. 隐私
+## 13. 隐私
 
 - 首次启用解释定位用途
 - 默认本地保存
@@ -268,7 +351,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 13. 验收目标
+## 14. 验收目标
 
 Core 已完成：
 
@@ -284,19 +367,27 @@ Core 已完成：
 
 P0 reliability follow-up：
 
-- [ ] 锁屏后长行程持续记录可诊断
-- [ ] GPS health / last callback / longest gap
-- [ ] accepted / rejected point counters
+- [x] 运行时 GPS health / accepted point heartbeat
+- [x] GPS LOST / LONG_GAP ongoing notification
+- [x] long gap 路线断开，不画可信实线
+- [ ] 长 gap 两端不参与可信距离累计
+- [ ] GPS/Network 去重与择优
+- [ ] longest gap / provider counters / rejected reason 持久摘要
 - [ ] service restart / re-delivery evidence
-- [ ] GPS/Network provider quality diagnostics
-- [ ] GPS LOST / LONG_GAP ongoing notification
+- [ ] 锁屏长行程真机复验
 
 P1 speed visualization：
 
-- [ ] 全程平均 / 行驶平均明确区分
+- [x] 全程平均 / 行驶平均明确区分
 - [ ] TripSpeedSegment 派生模型
 - [ ] 连续速度颜色映射
-- [ ] GPS gap 虚线/断开渲染
+- [ ] 短时峰值与 segment speed 分开展示
+
+P3 optional vehicle data：
+
+- [ ] OBD-II Vehicle Speed 最小 PoC
+- [ ] GNSS vs OBD 对照验证
+- [ ] 证明稳定价值后再评估更多车辆数据
 
 Optional：
 
@@ -304,7 +395,16 @@ Optional：
 
 ---
 
-## 14. 变更记录
+## 15. 变更记录
+
+### v1.3.0
+
+- 明确 Location.speed 是当前瞬时/最高速度主要来源，不等同于点间直线速度
+- 明确平均速度仍受 GPS 累计距离质量影响
+- 将短时速度峰值漏采作为真实采样限制记录
+- 固定 GNSS / Derived / OBD 三类速度来源语义
+- OBD-II 放入 P3 可选增强，只先验证标准 Vehicle Speed，不进入私有 CAN/BMS 逆向
+- 同步 PR #36 GPS health、通知、gap 断线及速度 UI 已实现范围
 
 ### v1.2.0
 

--- a/docs/PROJECT_MASTER.md
+++ b/docs/PROJECT_MASTER.md
@@ -1,7 +1,7 @@
 # EV Charge Book 项目总纲（PROJECT MASTER）
 
-版本: v2.0.1
-更新时间: 2026-08-26
+版本: v2.1.0
+更新时间: 2026-08-27
 状态: Authority Document / Single Source of Truth
 
 ## 1. 项目定位
@@ -34,6 +34,7 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - ROADMAP.md
 - DEVELOPMENT.md
 - LOCATION_TRIP.md
+- TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
 - VEHICLE_CATALOG_MULTI_VEHICLE.md
 - DATA_QUALITY_BACKUP.md
 - SYNC_PROTOCOL.md
@@ -58,6 +59,8 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - 外部供应商可替换
 - 云同步不能成为唯一恢复路径
 - 无网络和云端故障不能阻塞本地记账 / Trip
+- GPS 缺失不得通过假路线或假距离静默补齐
+- 速度必须保留来源语义，不把 GNSS / 派生值 / future OBD 混成无来源真值
 
 ---
 
@@ -67,7 +70,7 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 
 ---
 
-## 5. v0.2 状态: Core Accepted
+## 5. v0.2 状态: Core Accepted / Reliability Hardening
 
 已完成并经过当前真机功能验证：
 
@@ -86,126 +89,131 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - stationary throttling
 - TripRouteGeometry + 无底图真实轨迹预览
 
-Trip #15 与 Bluetooth #21 已按最新真机功能反馈关闭。
+Trip #15 与 Bluetooth #21 已按此前真机功能反馈关闭，但真实长行程数据暴露出新的 reliability follow-up，不重新打开旧基础功能验收结论。
+
+### 真实 Trip #7 新结论
+
+2026-08-27 导出的真实 Trip #7 出现约 12 分 29 秒和 15 分 17 秒的 GPS gap。
+
+因此：
+
+- `COMPLETED` 只表示行程最终正常收口，不表示 GPS 全程连续。
+- foreground service 存在不等于 Location callback 一定持续。
+- MapLibre 不是当前优先级；必须先让 GPS continuity 可观察、可诊断、可解释。
+
+PR #35 已将该方向写入正式设计；PR #36 第一阶段代码已实现并通过 Android Build Run #184。
+
+已实现第一阶段：
+
+- runtime `TripGpsHealth`
+- 15s / 30s / 120s health thresholds
+- ongoing notification 周期刷新 GPS health / last accepted age / provider / rejected count
+- 长 gap route geometry 拆段，禁止假实线
+- 全程均速 / 行驶均速 / 最高速度 / moving time 语义拆分
+
+仍需 P0：
+
+1. 长 gap 两端不参与可信距离累计
+2. GPS / Network point 去重与择优
+3. longest gap / provider counters / rejected reason 持久摘要
+4. service restart / re-delivery evidence
+5. 锁屏长行程真机复验
 
 MapLibre 继续作为可选展示层，不是业务阶段门槛。
 
 ---
 
-## 6. v0.3 状态: Feature Complete Candidate
+## 6. 速度与距离事实模型
 
-已实现：
+### 6.1 当前距离
 
-- 充电区间里程
-- 费用 / 100km 账本估算
-- 补入电量 / 100km 账本估算
-- Trip 覆盖辅助证据
-- SOC 可信度提示
-- 区间明细
-- 6 个月费用 / 电量趋势
-- 本月 vs 上月对比与 zero-baseline 降级
-- charger type 次数 / 电量 / 费用结构
-- ChargingPlace 文本派生聚合
-- Top 常用地点录入复用
-- 当前车辆 CSV 分析导出
-- 非阻塞异常输入提示
+当前 Trip distance 由连续 accepted location point 的地理距离累计得到。
 
-已确认基线：Android Build Run #169 Green，覆盖常用地点 + CSV。异常提示已经进入 main，等待后续累计 Android CI 一并验收。
+它不是道路里程，也不是车辆轮速里程，因此弯路、采样稀疏、provider switch、GPS gap 都可能影响结果。
 
-v0.3 不再扩重型 chart、独立 ChargingPlace 表或无真实需求的期间筛选。
+原则：长 gap 两端不能继续被视为可信连续距离。
+
+### 6.2 当前瞬时 / 最高速度
+
+当前 TripPoint `speedMps` 和最高已记录速度主要来自 Android `Location.speed`，不是简单的两点直线距离 / 时间。
+
+因此产品必须区分：
+
+- `Location.speed`：定位系统报告的时刻速度
+- derived segment speed：连续可信点的距离 / 时间及窗口统计
+- whole-trip / moving average：依赖累计 recorded distance 的派生统计
+
+短时峰值可能因为采样窗口没有命中而漏采。例如峰值只持续约 4 秒，而采样目标为 2-5 秒时，不能保证一定保存到该峰值。
+
+UI 应称“最高已记录速度”，不得宣称未采样到的真实车辆峰值。
+
+### 6.3 P1 速度可视化
+
+后续 `TripSpeedSegment`：
+
+- 基于连续可信 GPS segment
+- 结合 `Location.speed` / speed accuracy / point-to-point evidence
+- 不跨 LONG_GAP
+- 连续红 -> 黄 -> 绿 -> 蓝表示本车速度分布
+- 无道路类型 / 限速 / 交通数据前，不使用真实“拥堵/畅通”交通标签
 
 ---
 
-## 7. 当前阶段: v0.4 Local First Sync Foundation
+## 7. v0.3 状态: Feature Complete Candidate / Reliability Follow-up
 
-### 7.1 当前原则
+已实现充电区间、费用/100km、电量/100km、Trip 覆盖、SOC 可信度、月趋势、月环比、charger type、ChargingPlace、常用地点复用、CSV 与异常提示。
 
-先解决“同一条数据跨设备是谁”，再接 HTTP / Spring Boot。
+v0.3 当前不扩重型 chart、独立 ChargingPlace 表或无真实需求的期间筛选。Reliability follow-up 优先于继续堆统计 UI。
+
+---
+
+## 8. v0.4 Local First Sync Foundation
+
+Vehicle + ChargingRecord 已具备 stable `syncId`、`updatedAtEpochMillis`、ChargingRecord tombstone、Room v6 -> v7 migration、旧数据补 identity、Backup schema v6 与 sync identity tests。
+
+`SYNC_PROTOCOL.md` 已固定第一版 payload / idempotency / tombstone / conflict / cursor 边界。
+
+当前策略：不删除、不回退现有 sync foundation，但暂停继续扩 Spring Boot / PostgreSQL / Trip cloud sync，直到 Trip P0 reliability 具备可观察性并完成一次锁屏长行程复验。
+
+---
+
+## 9. P3 Optional Vehicle Data / OBD-II
+
+OBD-II 是未来可选数据源，不是当前产品依赖。
 
 ```text
-Room local id
-    = 当前设备内部关系键
-
-syncId
-    = 跨设备稳定业务身份
+VehicleSpeedSource
+├── GnssSpeedSource      当前默认
+├── DerivedSpeedSource   分段派生/校验
+└── ObdSpeedSource       P3 optional
 ```
 
-不重写现有 Room id / vehicleId / tripId 关系。
+第一个 PoC 只验证：
 
-### 7.2 Phase A 当前代码
+- 外接 Bluetooth/BLE/Wi-Fi OBD-II adapter
+- 查询标准 Vehicle Speed 支持
+- 读取 OBD Vehicle Speed
+- 与 GNSS speed 对照
 
-Vehicle + ChargingRecord 已进入同步身份实现：
+当前明确不做：厂商私有 CAN ID 逆向、私有 BMS PID 逆向、单车型复杂协议维护、让 OBD 成为 Trip 必需依赖。
 
-- stable `syncId`
-- `updatedAtEpochMillis`
-- ChargingRecord `isDeleted` tombstone
-- Room v6 -> v7 explicit migration
-- 旧数据自动补 sync identity
-- 正常充电查询 / analytics 排除 tombstone
-- 用户删除 ChargingRecord 改为 tombstone
-- Backup schema v6 保存 sync metadata / tombstone
-- 旧 Backup 缺 syncId 时生成新稳定 ID
-- sync identity JVM tests
-
-当前累计 Android code commit：`56830c03275a68a518f873cfcbfecb094a362758`。
-
-Android Build Run #177 已创建但仍在 GitHub runner 队列。Phase A 在 Build/Test + Debug APK Green 前不得标记 Accepted。
-
-### 7.3 同步协议
-
-`SYNC_PROTOCOL.md` 已固定第一版协议边界：
-
-- protocolVersion
-- Vehicle / ChargingRecord change payload
-- Vehicle 不同步 `isDefault` / selectedVehicleId
-- ChargingRecord 使用 `vehicleSyncId`，不发送本地 vehicleId
-- serverRevision/cursor 用于增量 pull
-- stable syncId + updatedAt 用于实体冲突
-- tombstone 防止旧设备复活已删除记录
-- batch apply 必须 Room transaction，成功后才能推进 cursor
-- 第一版无 CRDT / 微服务 / MQ / WebSocket
-
-### 7.4 下一步
-
-Phase A CI Green 后：
-
-1. 实现 Vehicle / ChargingRecord sync DTO / envelope
-2. 实现纯 Kotlin conflict/apply rules
-3. 固定 pull cursor / push acknowledgement
-4. 再实现最小 HTTPS sync client/server
-5. 第一批服务端只同步 Vehicle + ChargingRecord
-6. TripSession / TripPoint 后接
+如果 Vehicle Speed PoC 稳定且有产品价值，再评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
 
 ---
 
-## 8. 同步冲突原则
-
-第一版保持可解释：
-
-- stable syncId 确定同一实体
-- explicit edit 通过 updatedAt 决定新旧
-- 不做字段级自动拼接
-- 删除使用 tombstone，避免旧设备复活记录
-- odometer / SOC / GPS 等事实不做“智能纠错”
-- 重复 push / pull 必须幂等
-- selected/default vehicle 属于设备 UX 状态，不应因为切换当前车辆制造无意义云冲突
-
-如果实际测试证明设备时钟偏差成为问题，再引入 server revision/cursor 参与写冲突；当前不提前复杂化。
-
----
-
-## 9. 恢复与隐私
+## 10. 恢复与隐私
 
 - Local JSON Backup 长期保留
 - Cloud Sync 不是唯一恢复路径
 - restore 失败不得破坏当前数据
 - 持续定位必须可见
+- ongoing notification 不显示精确经纬度 / HOME / WORK 地址
 - 路线公开分享/导出之前实现 Privacy Zone
 - 云同步轨迹需要明确产品同意与隐私说明
 
 ---
 
-## 10. 发布 / CI 基线
+## 11. 发布 / CI 基线
 
 - JDK 17
 - Android SDK 36
@@ -214,13 +222,15 @@ Phase A CI Green 后：
 - Android CI 与 Production Release 分离
 - signed APK
 - Actions Artifact
-- server `.part` + SHA/apksigner + atomic activation
 
-最近已确认：Build Run #169 Green；同步 Phase A 等待累计 Run #177。
+近期关键验收：
+
+- Build Run #169：ChargingPlace + CSV 基线 Green
+- Build Run #184：PR #36 Trip GPS health / route gap / speed semantics，Build/Test + Debug APK Green
 
 ---
 
-## 11. 架构约束
+## 12. 架构约束
 
 Android 保持：
 
@@ -239,46 +249,64 @@ Spring Boot Monolith
 
 不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ 或其他当前没有收益的基础设施。
 
+OBD 未来也必须是 optional adapter，不允许反向污染核心 Trip 架构。
+
 ---
 
-## 12. 开发验收规则
+## 13. 当前执行顺序
+
+```text
+Trip P0 reliability
+  -> long-gap distance correction
+  -> GPS / Network dedupe + quality policy
+  -> Trip completeness / persistent diagnostics
+  -> lock-screen long-drive physical verification
+  -> Trip P1 segmented speed + continuous color route
+  -> v0.3 reliability closeout
+  -> resume v0.4 sync expansion
+  -> P3 OBD-II Vehicle Speed PoC only when justified
+```
+
+---
+
+## 14. 开发验收规则
 
 每轮业务代码必须：
 
 - Android Gradle test/build
 - GitHub CI Green
-- 更新 owning Issue
+- 更新 owning Issue / PR
 - 阶段变化同步 ROADMAP / PROJECT_MASTER
 - schema 改动必须显式 Migration
 - 不把“代码已写”标成“CI Accepted”
 - 不把 CI 通过标成“真机已验收”
+- GPS `COMPLETED` 不等同于 continuity accepted
 
 ---
 
-## 13. 当前 Issues
+## 15. 当前 Issues
 
-- #19 Data Reliability：只保留增量可靠性尾项，不阻塞 v0.4
+- #19 Data Reliability：只保留增量可靠性尾项
 - #22 UI polish：主要视觉工作已合并，真机视觉复核非阻塞
-- #27 v0.4 Sync 主线
+- #26 Background activity / lock-screen Trip status / notification center
+- #27 v0.4 Sync 主线：foundation 保留，扩展暂缓
 - #28 Sync Phase A 实现与验收
 - #20 Catalog Coverage：后续可持续车型目录管道
 
-#29/#30/#31/#32/#33 为工具误创建或 duplicate，已关闭，不作为任何业务入口。
-
 ---
 
-## 14. 决策记录
+## 16. 决策记录
+
+### v2.1.0
+
+- 基于真实 Trip #7 将 GPS continuity 提升为当前 P0
+- PR #36 第一阶段通过 Build Run #184
+- 明确 Location.speed / derived speed / average speed 的不同来源与可信度
+- 明确 long gap distance correction 与 GPS/Network dedupe 先于彩色轨迹
+- OBD-II 作为 P3 optional VehicleSpeedSource，仅从标准 Vehicle Speed PoC 开始
+- v0.4 sync foundation 保留，但 feature expansion 暂缓到 Trip reliability 真机复验之后
 
 ### v2.0.1
 
 - `SYNC_PROTOCOL.md` 纳入权威文档体系
 - 固定第一版 payload / idempotency / tombstone / conflict / cursor 边界
-
-### v2.0.0
-
-- Trip / Bluetooth 最新真机功能验证通过并关闭 owning Issues
-- v0.3 补齐常用地点复用、CSV 分析导出、异常提示
-- Build Run #169 Green
-- 正式切换主线到 v0.4 Local First Sync Foundation
-- Vehicle + ChargingRecord Phase A sync identity 已实现，等待累计 Run #177
-- 云同步必须先定 stable identity / tombstone / conflict protocol，再接服务端

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # EV Charge Book Roadmap
 
-版本: v2.5.0
+版本: v2.6.0
 更新时间: 2026-08-27
 
 ## 0. 路线原则
@@ -27,68 +27,9 @@
 
 ## v0.2 - Vehicle, Location & Trip Foundation
 
-状态: **Core Accepted**
+状态: **Core Accepted / Reliability Hardening**
 
-### Odometer & charging data loop (#18)
-
-- [x] nullable `odometerKm`
-- [x] Room migration
-- [x] Add/Edit/Records 支持里程
-- [x] 上一条可靠里程与下降提示
-- [x] ChargingIntervalAnalytics
-- [x] 区间距离 / cost per 100km / charged kWh per 100km
-- [x] Trip coverage evidence
-- [x] SOC confidence hints
-- [x] 区间明细 + JVM tests
-
-### Local Backup / Restore (#19)
-
-- [x] JSON + schemaVersion
-- [x] SAF export/import
-- [x] 覆盖确认 + Room transaction
-- [x] Vehicle / ChargingRecord / odometer / Location / Trip
-- [x] 引用关系与数量校验
-- [x] 真机恢复验收
-
-### Multi Vehicle / Vehicle Catalog (#17 / #16)
-
-- [x] selectedVehicleId persisted
-- [x] multi-vehicle switch
-- [x] Dashboard / Records / Stats isolation
-- [x] archive with history retention
-- [x] local versioned catalog
-- [x] search / override / custom fallback
-
-### Bluetooth connection prompt (#21)
-
-状态: Accepted / Issue Closed
-
-- [x] paired-device selection / persistence
-- [x] Android 12+ Nearby Devices permission
-- [x] Android 13+ notification permission
-- [x] selected-device ACL_CONNECTED notification
-- [x] A2DP / HEADSET already-connected state detection
-- [x] notification / app-resume opens Trip confirmation flow
-- [x] never silently auto-start location
-- [x] latest physical functional verification accepted
-
-### Location (#14)
-
-状态: Foundation Implemented
-
-- [x] LocationProvider + Android LocationManager
-- [x] current position
-- [x] ChargingRecord lat/lng/accuracy
-- [x] AddressResolver + Android Geocoder
-- [x] address failure preserves coordinates/manual text
-- [x] TripRouteGeometry / no-basemap route preview
-
-Optional, non-blocking:
-- [ ] external MapProvider / MapLibre real map rendering
-
-### Trip (#15)
-
-状态: Core Accepted; Reliability Follow-up Required
+### Trip / Location reliability
 
 - [x] TripSession / TripPoint + migration
 - [x] manual start/stop
@@ -96,24 +37,24 @@ Optional, non-blocking:
 - [x] WGS84 / accuracy / speed / bearing / altitude
 - [x] distance / elapsed / moving / stopped / average / max speed
 - [x] interrupted resume same TripSession
-- [x] Trip detail + raw point inspection
 - [x] GPS quality / jump filtering + stationary throttling
-- [x] main-Looper LocationListener + GPS/Network provider fallback
-- [x] provider failure -> INTERRUPTED instead of crash
-- [x] latest physical functional verification accepted
+- [x] GPS/Network provider fallback
+- [x] runtime GPS health / accepted-point heartbeat
+- [x] GPS LOST / LONG_GAP ongoing notification
+- [x] long GPS gap 在 route preview 中断开，不画假实线
+- [x] 全程均速 / 行驶均速 / 最高速度口径明确区分
+- [ ] 长 gap 两端不参与可信距离累计
+- [ ] GPS / Network 去重与择优
+- [ ] longest gap / provider counters / rejected reason 持久摘要
+- [ ] service lifecycle / restart / re-delivery evidence
+- [ ] 锁屏长行程真机复验
+- [ ] TripSpeedSegment 派生模型
+- [ ] 连续速度颜色映射
+- [ ] 短时峰值与 segment speed 分开展示
 
-真实长行程 follow-up：
+PR #36 第一阶段代码已通过 Android Build Run #184：Build/Test + Debug APK Green。
 
-- [ ] P0 GPS callback / accepted point heartbeat
-- [ ] P0 longest GPS gap / provider switch / rejected point diagnostics
-- [ ] P0 service lifecycle / restart / re-delivery evidence
-- [ ] P0 GPS LOST / LONG_GAP notification state
-- [ ] P1 全程平均 / 行驶平均速度明确区分
-- [ ] P1 TripSpeedSegment 派生模型
-- [ ] P1 连续速度颜色映射
-- [ ] P1 GPS gap 虚线/断开渲染
-
-详细设计：`docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
+详细设计：`docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` 与 `docs/LOCATION_TRIP.md`。
 
 ---
 
@@ -121,94 +62,77 @@ Optional, non-blocking:
 
 状态: **Feature Complete Candidate / Reliability Follow-up**
 
-### Analytics
+已实现：
 
-- [x] charging interval odometer distance
-- [x] cost/100km estimate
-- [x] charged kWh/100km estimate
-- [x] Trip + odometer coverage evidence
-- [x] SOC confidence hints
-- [x] interval detail samples
-- [x] six-month cost / energy trend
-- [x] month-over-month comparison + zero-baseline handling
-- [x] charger type classification / count / energy / cost mix
-- [x] supercharging classified as public fast
+- charging interval odometer distance
+- cost/100km estimate
+- charged kWh/100km estimate
+- Trip + odometer coverage evidence
+- SOC confidence hints
+- six-month cost / energy trend
+- month-over-month comparison
+- charger type mix
+- ChargingPlace aggregation + common-place reuse
+- selected-vehicle charging CSV analysis export
+- non-blocking anomaly hints
 
-### Charging places
+真实 Trip #7 观察到 12-15 分钟级 GPS gap，因此 reliability 优先级高于继续扩统计展示。
 
-- [x] ChargingPlaceAnalytics from existing location text
-- [x] location normalization + count / energy / cost / average price
-- [x] Stats Top common places
-- [x] Add Record Top 5 common-place quick reuse
-- [x] reuse copies text only; historical coordinates are never reused
-- [x] manual place edit clears unsaved GPS fix to prevent coordinate/text mismatch
+下一阶段：
 
-### Export
-
-- [x] full JSON backup remains recovery format
-- [x] selected-vehicle charging CSV analysis export
-- [x] UTF-8 BOM for Excel compatibility
-- [x] CSV escaping + derived price/kWh
-- [x] odometer / coordinate / accuracy fields included
-- [x] CSV JVM tests
-- [x] Android Build Run #169 Green + Debug APK
-
-### Data anomaly hints
-
-- [x] extreme unit price warning
-- [x] energy > 135% battery capacity warning
-- [x] nearly-flat SOC with meaningful energy warning
-- [x] Add/Edit live warnings
-- [x] warnings never block save or mutate raw facts
-- [x] JVM rules tests
-
-### Reliability priority change after real Trip data
-
-真实 Trip #7 观察到 12-15 分钟级 GPS gap。该问题优先级高于 MapLibre 和更丰富的统计展示。
-
-- [ ] P0 GPS health / continuity diagnostics
-- [ ] P0 lock-screen/background reliability evidence
-- [ ] P0 notification shows GPS health and last valid fix
-- [ ] P1 segmented speed analysis and colored route preview
-
-### Non-blocking follow-up
-
-- [ ] Privacy Zone before any route export/share
-- [ ] structured HOME / WORK / PUBLIC / HIGHWAY place type only if actual use proves value
-- [ ] DataSource metadata only where it changes interpretation
-- [ ] Room migration instrumentation QA
-
-No heavy charting framework and no new ChargingPlace Room table until real usage justifies them.
+1. long-gap distance aggregation correction
+2. GPS / Network provider fusion / dedupe
+3. Trip completeness summary / persistent diagnostics
+4. lock-screen physical verification
+5. segmented speed + continuous color route
 
 ---
 
 ## v0.4 - Cloud & Catalog Sync
 
-状态: Next Major Phase / Deferred until Trip P0 reliability is observable
+状态: Foundation started; feature expansion deferred until Trip P0 reliability is observable
 
-Candidate scope:
+已存在 Local First Sync Foundation 不回退：stable identity / tombstone / protocol 文档继续保留。
 
-- [ ] Spring Boot monolith
-- [ ] PostgreSQL
-- [ ] account / device identity
-- [ ] vehicle / charging / trip sync
-- [ ] catalog update pipeline (#20)
-- [ ] conflict / offline-first sync rules
+Cloud sync must not become the only recovery path. Existing local JSON backup remains supported。
 
-Cloud sync must not become the only recovery path. Existing local JSON backup remains supported.
+---
+
+## P3 - Optional Vehicle Data Source / OBD-II
+
+状态: Future Exploration / Not Product Blocker
+
+首个最小 PoC：
+
+- [ ] 定义轻量 `VehicleSpeedSource` 边界
+- [ ] 外接 OBD-II Bluetooth/BLE/Wi-Fi adapter
+- [ ] 查询标准 Vehicle Speed 支持能力
+- [ ] 读取 OBD Vehicle Speed
+- [ ] 与 GNSS `Location.speed` 对照
+
+明确不进入当前主线：
+
+- 厂商私有 CAN ID 逆向
+- 私有 BMS PID 逆向
+- 单车型复杂协议维护
+- OBD 成为 Trip 必需依赖
+
+只有 Vehicle Speed PoC 证明稳定价值后，才评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
 
 ---
 
 ## 当前执行顺序
 
 ```text
-Trip P0 GPS reliability diagnostics
-  -> notification GPS health / last valid fix
-  -> provider / service lifecycle evidence
-  -> Trip P1 segmented speed + colored route preview
-  -> v0.3 code/document closeout
-  -> Privacy Zone only when route export/share starts
-  -> v0.4 sync/catalog design
+Trip P0 reliability
+  -> long-gap distance correction
+  -> GPS / Network dedupe + quality policy
+  -> Trip completeness summary / diagnostics
+  -> physical lock-screen long-drive verification
+  -> Trip P1 segmented speed + colored route
+  -> v0.3 reliability closeout
+  -> resume v0.4 sync expansion
+  -> P3 OBD-II optional PoC when product value justifies it
 ```
 
 MapLibre 继续保持低优先级；没有必要为了彩色速度轨迹先引入地图 SDK。
@@ -217,27 +141,18 @@ MapLibre 继续保持低优先级；没有必要为了彩色速度轨迹先引�
 
 ## 变更记录
 
+### v2.6.0
+
+- PR #36 GPS health / notification / route-gap / speed semantics passed Android Build Run #184
+- clarified current peak speed comes primarily from `Location.speed`, not point-to-point straight-line division
+- recorded that average speed still inherits GPS distance-quality limitations
+- promoted long-gap distance correction and GPS/Network dedupe ahead of colored route work
+- added OBD-II as P3 optional VehicleSpeedSource PoC, explicitly excluding private CAN/BMS reverse engineering from current product scope
+
 ### v2.5.0
 
 - based on real Trip #7, promoted 12-15 minute GPS gaps to P0 reliability work
-- added GPS callback / provider / service lifecycle diagnostics before more feature expansion
 - added segmented speed / continuous color visualization as P1
 - clarified speed colors describe this vehicle's speed, not real traffic congestion
 - clarified long GPS gaps must not be rendered as trustworthy solid routes
 - deferred v0.4 execution until Trip P0 reliability becomes observable
-
-### v2.4.0
-
-- Trip #15 and Bluetooth #21 closed after latest physical functional verification
-- synced PR #24/#25 visual work as non-blocking business baseline
-- ChargingPlace derived aggregation and common-place entry reuse completed
-- CSV analysis export completed; Build Run #169 Green
-- added non-blocking charging anomaly warnings
-- v0.3 moved to Feature Complete Candidate pending final cumulative CI
-- next major phase identified as v0.4 Cloud & Catalog Sync
-
-### v2.3.0
-
-- cumulative Android Build Run #142 Green
-- month-over-month and charger-type analytics completed
-- next active work moved to ChargingPlace derived aggregation


### PR DESCRIPTION
## Summary

Final documentation closeout after merged PR #36.

Updates the SSOT docs to reflect the real Trip #7 GPS-gap findings, the implemented GPS-health hardening, and the clarified speed-data model.

### Updates

- `PROJECT_MASTER.md` -> v2.1.0
- `ROADMAP.md` -> v2.6.0
- `LOCATION_TRIP.md` -> v1.3.0

### Key decisions recorded

- current instantaneous / max recorded speed primarily comes from Android `Location.speed`
- point-to-point distance/time is a derived segment signal, not the primary instantaneous-speed source
- whole-trip / moving average still inherit GPS distance-quality limitations
- short ~4s speed peaks may be missed when no valid Location fix lands inside the peak window
- long GPS gaps must not be rendered or counted as trustworthy continuous route/distance
- GPS / Network dedupe and long-gap distance correction stay ahead of colored-speed visualization
- OBD-II is P3 optional only: first PoC is standard Vehicle Speed comparison against GNSS
- private CAN/BMS reverse engineering is explicitly outside the current product scope

### Current execution order

1. long-gap distance correction
2. GPS / Network dedupe + quality policy
3. Trip completeness / persistent diagnostics
4. lock-screen long-drive physical verification
5. segmented speed + continuous route coloring
6. resume v0.4 sync expansion
7. optional OBD-II Vehicle Speed PoC only when justified

Documentation only. Runtime implementation was already merged in PR #36 and validated by Android Build Run #184.