### PR TITLE
style(android): integrate Trip cockpit with GPS reliability UX

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -95,38 +95,109 @@ private fun ActiveTripPanel(
     onOpenDetail: (Long) -> Unit
 ) {
     val interrupted = activeTrip?.status == TripStatus.INTERRUPTED
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = if (activeTrip == null) MaterialTheme.colorScheme.surfaceContainerLow else MaterialTheme.colorScheme.primaryContainer
-    ) {
-        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-            if (activeTrip == null) {
+    if (activeTrip == null) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerLow
+        ) {
+            Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                Text("TRIP / READY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
                 Text("准备出发", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
                 Text(selectedVehicle?.let { "${it.brand} ${it.model}" } ?: "请先选择车辆", style = MaterialTheme.typography.bodyLarge)
                 Text("开始后会持续记录真实 GPS 轨迹；没有有效定位点时不会虚构距离。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Button(onClick = onStart, enabled = selectedVehicle != null, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.PlayArrow, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("开始行程")
+                    Icon(Icons.Default.PlayArrow, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("开始行程")
                 }
-            } else {
-                Text(if (interrupted) "行程已中断" else "行程进行中", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                Text(activeVehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${activeTrip.vehicleId}", style = MaterialTheme.typography.bodyLarge)
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
-                    TripMetric("距离", if (activeTrip.distanceMeters > 0) formatDistance(activeTrip.distanceMeters) else "--", Modifier.weight(1f))
-                    TripMetric("耗时", formatDuration(activeTrip.elapsedSeconds), Modifier.weight(1f))
-                    TripMetric("状态", statusText(activeTrip.status), Modifier.weight(1f))
+            }
+        }
+        return
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface
+    ) {
+        Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    if (interrupted) "TRIP / INTERRUPTED" else "TRIP / LIVE",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = if (interrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.inversePrimary,
+                    modifier = Modifier.weight(1f)
+                )
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = if (interrupted) MaterialTheme.colorScheme.error.copy(alpha = .16f) else MaterialTheme.colorScheme.inversePrimary.copy(alpha = .14f)
+                ) {
+                    Text(
+                        if (interrupted) "需恢复" else "记录中",
+                        modifier = Modifier.padding(horizontal = MaterialTheme.spacing.xs, vertical = MaterialTheme.spacing.xxs),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (interrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.inversePrimary
+                    )
                 }
-                if (interrupted) {
-                    Text("定位服务曾被中断，恢复会继续同一条行程。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
-                    Button(onClick = { onResume(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
-                        Icon(Icons.Default.Refresh, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("恢复记录")
-                    }
+            }
+
+            Text(
+                activeVehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${activeTrip.vehicleId}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .7f)
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                Text("当前距离", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+                Text(
+                    if (activeTrip.distanceMeters > 0) formatDistance(activeTrip.distanceMeters) else "--",
+                    style = MaterialTheme.typography.displayMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.inverseOnSurface
+                )
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                CockpitMetric("耗时", formatDuration(activeTrip.elapsedSeconds), Modifier.weight(1f))
+                CockpitMetric("行驶均速", activeTrip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                CockpitMetric("最高速度", activeTrip.maxSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+            }
+
+            if (interrupted) {
+                Text(
+                    "定位服务曾被中断。恢复后会继续同一条行程；GPS 健康状态也会继续通过前台通知更新。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .7f)
+                )
+                Button(onClick = { onResume(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
+                    Icon(Icons.Default.Refresh, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("恢复记录")
                 }
-                OutlinedButton(onClick = { onOpenDetail(activeTrip.id) }, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.Route, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text("查看实时轨迹")
+            }
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                OutlinedButton(
+                    onClick = { onOpenDetail(activeTrip.id) },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.inverseOnSurface),
+                    border = ButtonDefaults.outlinedButtonBorder.copy(brush = androidx.compose.ui.graphics.SolidColor(MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .3f)))
+                ) {
+                    Icon(Icons.Default.Route, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("实时轨迹")
                 }
-                TextButton(onClick = onStop, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.Stop, null); Spacer(Modifier.width(MaterialTheme.spacing.xs)); Text(if (interrupted) "结束这条行程" else "结束行程")
+                TextButton(
+                    onClick = onStop,
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.inverseOnSurface)
+                ) {
+                    Icon(Icons.Default.Stop, null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text(if (interrupted) "结束行程" else "结束")
                 }
             }
         }
@@ -139,10 +210,16 @@ private fun TripHistoryRow(trip: TripSessionEntity, onClick: () -> Unit, onDelet
         Row(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md), verticalAlignment = Alignment.CenterVertically) {
             Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
                 Text(formatTime(trip.startedAtEpochMillis), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                Text(statusText(trip.status), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text("${formatDistance(trip.distanceMeters)} · ${formatDuration(trip.elapsedSeconds)}", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    listOfNotNull(
+                        trip.averageSpeedMps?.let { "行驶均速 ${formatSpeed(it)}" },
+                        statusText(trip.status)
+                    ).joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
-            trip.averageSpeedMps?.let { Text(formatSpeed(it), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
             if (trip.status == TripStatus.COMPLETED) IconButton(onClick = onDelete) { Icon(Icons.Default.Delete, "删除行程") }
         }
     }
@@ -155,6 +232,10 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
     val firstPoint = points.firstOrNull()
     val lastPoint = points.lastOrNull()
     val wholeTripAverageMps = if (trip.elapsedSeconds > 0) trip.distanceMeters / trip.elapsedSeconds else null
+    val geometry = remember(points) {
+        if (points.size >= 2) TripRouteGeometryBuilder.build(points.map { TripGeoPoint(it.latitude, it.longitude, it.capturedAtEpochMillis) }) else null
+    }
+
     Scaffold(topBar = { TopAppBar(title = { Text("行程详情") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
@@ -162,38 +243,72 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
-                    Text(vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                    Text("${formatTime(trip.startedAtEpochMillis)} · ${statusText(trip.status)}", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.inverseSurface,
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface
+                ) {
+                    Column(Modifier.padding(MaterialTheme.spacing.lg), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Column(Modifier.weight(1f)) {
+                                Text("TRIP / SUMMARY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.inversePrimary)
+                                Text(vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}", style = MaterialTheme.typography.titleLarge)
+                                Text("${formatTime(trip.startedAtEpochMillis)} · ${statusText(trip.status)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .65f))
+                            }
+                            geometry?.let {
+                                Surface(
+                                    shape = MaterialTheme.shapes.small,
+                                    color = if (it.gapCount > 0) MaterialTheme.colorScheme.error.copy(alpha = .16f) else MaterialTheme.colorScheme.inversePrimary.copy(alpha = .14f)
+                                ) {
+                                    Text(
+                                        if (it.gapCount > 0) "GPS ${it.gapCount} 缺口" else "GPS 连续",
+                                        modifier = Modifier.padding(horizontal = MaterialTheme.spacing.xs, vertical = MaterialTheme.spacing.xxs),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = if (it.gapCount > 0) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.inversePrimary
+                                    )
+                                }
+                            }
+                        }
+
+                        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                            Text("行程距离", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
+                            Text(formatDistance(trip.distanceMeters), style = MaterialTheme.typography.displaySmall, fontWeight = FontWeight.SemiBold)
+                        }
+
+                        HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                            CockpitMetric("总耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
+                            CockpitMetric("全程均速", wholeTripAverageMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                            CockpitMetric("行驶均速", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                        }
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+                            CockpitMetric("最高速度", trip.maxSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
+                            CockpitMetric("移动时间", trip.movingSeconds?.let(::formatDuration) ?: "--", Modifier.weight(1f))
+                            CockpitMetric("GPS 点", points.size.toString(), Modifier.weight(1f))
+                        }
+                    }
                 }
             }
+
+            geometry?.let { if (it.isDrawable) item { TripRoutePreview(points) } }
+
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                        TripMetric("距离", formatDistance(trip.distanceMeters), Modifier.weight(1f))
-                        TripMetric("总耗时", formatDuration(trip.elapsedSeconds), Modifier.weight(1f))
-                        TripMetric("全程均速", wholeTripAverageMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
-                    }
-                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                        TripMetric("行驶均速", trip.averageSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
-                        TripMetric("最高速度", trip.maxSpeedMps?.let(::formatSpeed) ?: "--", Modifier.weight(1f))
-                        TripMetric("移动时间", trip.movingSeconds?.let(::formatDuration) ?: "--", Modifier.weight(1f))
-                    }
-                }
-            }
-            if (points.size >= 2) item { TripRoutePreview(points) }
-            item {
-                SectionHeading("轨迹数据", "${points.size} 个有效 GPS 点")
+                SectionHeading("轨迹可信度", if ((geometry?.gapCount ?: 0) > 0) "存在长时间 GPS 缺口，缺失区间不会被伪造连接" else "当前已保存轨迹中未检测到超过 2 分钟的长缺口")
                 Spacer(Modifier.height(MaterialTheme.spacing.sm))
                 firstPoint?.let { Text("起点  ${formatCoordinate(it.latitude)}, ${formatCoordinate(it.longitude)}") }
                 lastPoint?.let { Text("终点  ${formatCoordinate(it.latitude)}, ${formatCoordinate(it.longitude)}") }
                 if (points.isEmpty()) Text("本次没有保存有效 GPS 轨迹点。", color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
+
             if (points.isNotEmpty()) {
                 item { SectionHeading("最近轨迹点", "用于排查 GPS 质量，不作为主视觉") }
                 items(points.takeLast(6).reversed(), key = { it.id }) { point ->
                     Row(Modifier.fillMaxWidth().padding(vertical = MaterialTheme.spacing.xs), horizontalArrangement = Arrangement.SpaceBetween) {
-                        Column { Text(SimpleDateFormat("HH:mm:ss", Locale.SIMPLIFIED_CHINESE).format(Date(point.capturedAtEpochMillis)), fontWeight = FontWeight.SemiBold); Text("${formatCoordinate(point.latitude)}, ${formatCoordinate(point.longitude)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                        Column {
+                            Text(SimpleDateFormat("HH:mm:ss", Locale.SIMPLIFIED_CHINESE).format(Date(point.capturedAtEpochMillis)), fontWeight = FontWeight.SemiBold)
+                            Text("${formatCoordinate(point.latitude)}, ${formatCoordinate(point.longitude)}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
                         point.horizontalAccuracyMeters?.let { Text("±${it.toInt()} m", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
                     }
                 }
@@ -203,16 +318,19 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
 }
 
 @Composable
-private fun TripMetric(label: String, value: String, modifier: Modifier) {
+private fun CockpitMetric(label: String, value: String, modifier: Modifier) {
     Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .52f))
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
     }
 }
 
 @Composable
 private fun SectionHeading(title: String, subtitle: String) {
-    Column { Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold); Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+    Column {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
 }
 
 @Composable
@@ -227,12 +345,28 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
 
     Surface(Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainerLow) {
         Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text("轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                Text("${geometry.points.size} 点 · ${geometry.segments.size} 段", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Column {
+                    Text("真实轨迹", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text("${geometry.points.size} 点 · ${geometry.segments.size} 段", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = if (geometry.gapCount > 0) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Text(
+                        if (geometry.gapCount > 0) "${geometry.gapCount} 个长缺口" else "轨迹连续",
+                        modifier = Modifier.padding(horizontal = MaterialTheme.spacing.xs, vertical = MaterialTheme.spacing.xxs),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (geometry.gapCount > 0) MaterialTheme.colorScheme.onErrorContainer else MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
             }
+
             Canvas(Modifier.fillMaxWidth().height(240.dp)) {
-                val p = 16.dp.toPx(); val w = (size.width - p * 2).coerceAtLeast(1f); val h = (size.height - p * 2).coerceAtLeast(1f)
+                val p = 16.dp.toPx()
+                val w = (size.width - p * 2).coerceAtLeast(1f)
+                val h = (size.height - p * 2).coerceAtLeast(1f)
                 fun offset(point: com.evchargebook.domain.trip.TripRoutePoint) = Offset(p + point.x * w, p + point.y * h)
                 geometry.segments.forEach { segment ->
                     segment.map(::offset).zipWithNext().forEach { (from, to) ->
@@ -242,9 +376,13 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
                 drawCircle(startColor, 6.dp.toPx(), offset(geometry.points.first()))
                 drawCircle(endColor, 6.dp.toPx(), offset(geometry.points.last()))
             }
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text("起点", style = MaterialTheme.typography.labelMedium, color = startColor); Text("终点", style = MaterialTheme.typography.labelMedium, color = endColor) }
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("起点", style = MaterialTheme.typography.labelMedium, color = startColor)
+                Text("终点", style = MaterialTheme.typography.labelMedium, color = endColor)
+            }
             if (geometry.gapCount > 0) {
-                Text("检测到 ${geometry.gapCount} 处超过 2 分钟的 GPS 缺口，缺失区间不会用实线伪造连接。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary)
+                Text("检测到 ${geometry.gapCount} 处超过 2 分钟的 GPS 缺口。断点保持断开，不用实线假装连续。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
             }
             Text("基于真实 WGS84 轨迹点绘制，不做道路吸附或虚构路线。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }


### PR DESCRIPTION
## Summary

Rebuild the Trip cockpit visual layer on top of the merged GPS reliability baseline from PR #36.

## What changed

- Active Trip
  - dark `TRIP / LIVE` cockpit surface
  - distance becomes the primary driving metric
  - elapsed time, moving average and max recorded speed become secondary instruments
  - interrupted state becomes `TRIP / INTERRUPTED` with a clear resume action
  - live-route and stop actions remain immediately reachable

- Trip detail
  - new `TRIP / SUMMARY` cockpit summary
  - clearly separates:
    - total distance
    - total elapsed time
    - whole-trip average
    - moving average
    - max recorded speed
    - moving time
    - saved GPS point count
  - route continuity badge reports GPS continuity vs long gaps

- Route reliability UX
  - preserves PR #36 segmented geometry
  - long GPS gaps stay visually disconnected
  - explicitly says missing sections are not fabricated with a solid line
  - promotes track trustworthiness above raw coordinate diagnostics

- History
  - remains neutral and dense
  - surfaces moving average without turning every row into a cockpit card

## Design rule

Cockpit treatment is reserved for active state and primary trip summary. Route diagnostics and history remain restrained.

## Safety

UI-only change in `TripScreen.kt`. No changes to location sampling, foreground service, GPS-health thresholds, route segmentation rules, repositories, Room, Bluetooth, or persistence.

## Relationship to previous PRs

- replaces the closed stale visual PR #34
- builds directly on merged GPS reliability PR #36
- matches the cockpit system merged via PR #37
