### PR TITLE
style(android): polish global navigation and empty-state UX

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -226,18 +226,40 @@ fun MainApp(
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) { data ->
+                Snackbar(
+                    snackbarData = data,
+                    containerColor = MaterialTheme.colorScheme.inverseSurface,
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    actionColor = MaterialTheme.colorScheme.inversePrimary
+                )
+            }
+        },
         bottomBar = {
             if (!hasOverlayPage) {
-                NavigationBar {
+                NavigationBar(containerColor = MaterialTheme.colorScheme.surface) {
                     titles.forEachIndexed { index, title ->
-                        NavigationBarItem(selected = tab == index, onClick = { tab = index }, icon = { Icon(icons[index], title) }, label = { Text(title) })
+                        NavigationBarItem(
+                            selected = tab == index,
+                            onClick = { tab = index },
+                            icon = { Icon(icons[index], title) },
+                            label = { Text(title) },
+                            colors = NavigationBarItemDefaults.colors(
+                                selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                selectedTextColor = MaterialTheme.colorScheme.onSurface,
+                                indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+                                unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        )
                     }
                 }
             }
         }
     ) { padding ->
-        Surface(Modifier.padding(padding)) {
+        Surface(Modifier.padding(padding), color = MaterialTheme.colorScheme.background) {
             when {
                 addRecord -> AddRecordScreen(
                     vehicleId = state.vehicle?.id ?: 0L,

--- a/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
@@ -11,24 +11,41 @@ import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import com.evchargebook.ui.theme.spacing
 
 @Composable
 fun EmptyState(title: String, message: String, actionLabel: String, onAction: () -> Unit) {
     Column(
-        modifier = Modifier.fillMaxSize().padding(MaterialTheme.spacing.lg),
+        modifier = Modifier.fillMaxSize().padding(horizontal = MaterialTheme.spacing.xl, vertical = MaterialTheme.spacing.lg),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Icon(Icons.Default.ElectricBolt, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.primary
+        ) {
+            Icon(
+                Icons.Default.ElectricBolt,
+                contentDescription = null,
+                modifier = Modifier.padding(MaterialTheme.spacing.md)
+            )
+        }
         Spacer(Modifier.height(MaterialTheme.spacing.md))
-        Text(title, style = MaterialTheme.typography.headlineSmall)
+        Text(title, style = MaterialTheme.typography.headlineSmall, textAlign = TextAlign.Center)
         Spacer(Modifier.height(MaterialTheme.spacing.xs))
-        Text(message, style = MaterialTheme.typography.bodyMedium)
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
         Spacer(Modifier.height(MaterialTheme.spacing.lg))
         Button(onClick = onAction) { Text(actionLabel) }
     }


### PR DESCRIPTION
## Summary

Polish the shared app chrome after the cockpit system landed across core screens.

## What changed

- Bottom navigation
  - explicit surface container instead of default-looking navigation chrome
  - restrained primary-container selection indicator
  - clearer selected vs unselected icon/text hierarchy
  - overlay/detail pages still hide the bottom bar exactly as before

- Snackbar feedback
  - use the app's inverse/cockpit surface for transient feedback
  - align content/action colors with the EV visual system
  - no change to success/error message flow or business behavior

- Shared empty state
  - electric-bolt icon now sits in a soft energy container
  - centered title/message hierarchy
  - supporting copy uses on-surface-variant instead of competing with the title
  - primary action remains obvious

## Design rule

Global chrome should feel branded but quiet. Cockpit treatment remains reserved for primary state/metrics; navigation and empty states use the same tokens without becoming decorative.

## Scope

UI-only changes in `MainActivity.kt` and `ui/components/AppComponents.kt`. No navigation routes, state transitions, permissions, repositories, persistence, Bluetooth or Trip behavior changed.
