### PR TITLE
fix(android): harden warning semantics and active-trip data guards

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -32,6 +32,7 @@ import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.location.AndroidLocationProvider
 import com.evchargebook.location.LocationFix
 import com.evchargebook.ui.theme.spacing
+import com.evchargebook.ui.theme.warningColor
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -158,13 +159,13 @@ fun AddRecordScreen(
                     AddNumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
                     AddNumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
                 }
-                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }
             }
 
             FormSection("车辆与备注", "里程有助于后续估算每百公里补能成本。") {
                 AddNumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
                 previousOdometer?.let { Text("上一条有效里程 ${formatKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+                odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }
                 OutlinedTextField(remark, { remark = it }, label = { Text("备注") }, placeholder = { Text("可选") }, modifier = Modifier.fillMaxWidth(), minLines = 2)
             }
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -22,6 +22,7 @@ import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
 import com.evchargebook.ui.theme.spacing
+import com.evchargebook.ui.theme.warningColor
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -83,12 +84,12 @@ fun RecordEditScreen(
                     NumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
                     NumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
                 }
-                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+                anomalyWarnings.forEach { warning -> Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }
             }
             EditSection("车辆与备注") {
                 NumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
                 previousOdometer?.let { Text("上一条有效里程 ${formatEditKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
-                odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.tertiary) }
+                odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }
                 OutlinedTextField(remark, { remark = it }, label = { Text("备注") }, placeholder = { Text("可选") }, modifier = Modifier.fillMaxWidth(), minLines = 2)
             }
             error?.let { Text(it, color = MaterialTheme.colorScheme.error) }

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
@@ -30,6 +30,12 @@ val LocalAppSpacing = staticCompositionLocalOf { AppSpacing() }
 val MaterialTheme.spacing: AppSpacing
     @Composable get() = LocalAppSpacing.current
 
+private val WarningLight = Color(0xFF8A4B08)
+private val WarningDark = Color(0xFFFFC56B)
+private val LocalWarningColor = staticCompositionLocalOf { WarningLight }
+val MaterialTheme.warningColor: Color
+    @Composable get() = LocalWarningColor.current
+
 private val Ink = Color(0xFF171A1F)
 private val MutedInk = Color(0xFF686E78)
 private val Canvas = Color(0xFFF7F8FA)
@@ -111,8 +117,13 @@ private val AppShapes = Shapes(
 
 @Composable
 fun EvChargeTheme(content: @Composable () -> Unit) {
-    val colors = if (isSystemInDarkTheme()) BrandDark else BrandLight
-    CompositionLocalProvider(LocalAppSpacing provides AppSpacing()) {
+    val dark = isSystemInDarkTheme()
+    val colors = if (dark) BrandDark else BrandLight
+    val warning = if (dark) WarningDark else WarningLight
+    CompositionLocalProvider(
+        LocalAppSpacing provides AppSpacing(),
+        LocalWarningColor provides warning
+    ) {
         MaterialTheme(
             colorScheme = colors,
             typography = AppTypography,

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -122,8 +122,31 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
         }
     }
 
-    fun exportBackup(appVersion: String, onReady: (String) -> Unit) { viewModelScope.launch { runCatching { repository.exportBackup(appVersion) }.onSuccess(onReady).onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "备份导出失败") } } }
-    fun restoreBackup(content: String) { viewModelScope.launch { runCatching { repository.restoreBackup(content) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "本地备份已恢复") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "备份恢复失败") } } }
+    fun exportBackup(appVersion: String, onReady: (String) -> Unit) {
+        viewModelScope.launch {
+            runCatching { repository.exportBackup(appVersion) }
+                .onSuccess { content ->
+                    if (_uiState.value.activeTrip != null) {
+                        _uiState.value = _uiState.value.copy(successMessage = "已生成备份；当前行程仍在进行，这是进行中快照")
+                    }
+                    onReady(content)
+                }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "备份导出失败") }
+        }
+    }
+
+    fun restoreBackup(content: String) {
+        if (_uiState.value.activeTrip != null) {
+            _uiState.value = _uiState.value.copy(errorMessage = "行程进行中，结束行程后才能恢复备份")
+            return
+        }
+        viewModelScope.launch {
+            runCatching { repository.restoreBackup(content) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "本地备份已恢复") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "备份恢复失败") }
+        }
+    }
+
     fun startTrip() { val vehicleId = _uiState.value.vehicle?.id ?: return; viewModelScope.launch { runCatching { repository.startTrip(vehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已开始") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法开始行程") } } }
     fun resumeTrip(tripId: Long) { viewModelScope.launch { runCatching { repository.resumeTrip(tripId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程记录已恢复") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法恢复行程") } } }
     fun stopTrip() { viewModelScope.launch { runCatching { repository.stopActiveTrip() }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已结束") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法结束行程") } } }
@@ -132,8 +155,32 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
     fun deleteTrip(trip: TripSessionEntity) { viewModelScope.launch { runCatching { repository.deleteTrip(trip) }.onSuccess { if (selectedTripId.value == trip.id) closeTripDetail() }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法删除行程") } } }
     fun saveVehicle(brand: String, model: String, battery: Double, range: Int) { val current = _uiState.value.vehicle ?: return; viewModelScope.launch { runCatching { repository.saveVehicle(current.copy(brand = brand.trim(), model = model.trim(), batteryCapacityKwh = battery, rangeKm = range)) }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
     fun addVehicle(brand: String, model: String, battery: Double, range: Int, catalogVehicleId: String? = null) { viewModelScope.launch { runCatching { repository.addVehicle(brand, model, battery, range, catalogVehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆已添加并切换") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
-    fun selectVehicle(vehicleId: Long) { viewModelScope.launch { runCatching { repository.selectVehicle(vehicleId) }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
-    fun archiveVehicle(vehicleId: Long) { viewModelScope.launch { runCatching { repository.archiveVehicle(vehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆已归档，历史记录仍保留") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
+
+    fun selectVehicle(vehicleId: Long) {
+        val activeTrip = _uiState.value.activeTrip
+        viewModelScope.launch {
+            runCatching { repository.selectVehicle(vehicleId) }
+                .onSuccess {
+                    if (activeTrip != null && activeTrip.vehicleId != vehicleId) {
+                        _uiState.value = _uiState.value.copy(successMessage = "已切换当前车辆；正在进行的行程仍归属原车辆")
+                    }
+                }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) }
+        }
+    }
+
+    fun archiveVehicle(vehicleId: Long) {
+        if (_uiState.value.activeTrip?.vehicleId == vehicleId) {
+            _uiState.value = _uiState.value.copy(errorMessage = "该车辆正在记录行程，请结束行程后再归档")
+            return
+        }
+        viewModelScope.launch {
+            runCatching { repository.archiveVehicle(vehicleId) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆已归档，历史记录仍保留") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) }
+        }
+    }
+
     fun refreshPairedBluetoothDevices() { _uiState.value = _uiState.value.copy(pairedBluetoothDevices = repository.pairedBluetoothDevices()) }
     fun saveBluetoothPrompt(enabled: Boolean, address: String?, name: String?) { viewModelScope.launch { repository.saveBluetoothPrompt(enabled, address, name) } }
     fun addChargingRecord(startSoc: Int, endSoc: Int, energyKwh: Double, cost: Double, location: String?, chargerType: String?, remark: String?, chargeTime: Long, odometerKm: Double?, latitude: Double?, longitude: Double?, locationAccuracyMeters: Double?) {


### PR DESCRIPTION
## Summary

First P0 hardening slice from #42. This moves the app from visual polish into state-safety and readability hardening.

## Warning semantics

- adds a dedicated semantic warning color separate from the electric-mint brand accent
- light warning: high-contrast amber/brown
- dark warning: readable warm amber
- Add Record and Edit Record anomaly / odometer warnings now use the semantic warning token
- electric mint remains reserved for EV/cockpit emphasis rather than caution text

## Active Trip data guards

Guards are implemented at the ViewModel boundary so future UI entry points cannot bypass them:

- restoring a backup while a Trip is active is blocked
- archiving the vehicle that owns the active Trip is blocked
- switching the selected/default vehicle remains allowed, but explicitly tells the user that the active Trip stays attached to its original vehicleId
- backup export remains allowed and tells the user when the export is an in-progress Trip snapshot

## Safety

No schema changes, no Trip sampling changes, no repository protocol changes, no GPS thresholds changed.

## Follow-up in #42

- migrate remaining warning-like tertiary usages in analytics / Trip diagnostics
- unsaved-form dirty protection
- large font / small-screen metric adaptation
- IME and accessibility pass

Refs #42