### PR TITLE
fix(android): harden trip startup speed and trusted distance

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripContinuityRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripContinuityRules.kt
@@ -1,0 +1,47 @@
+package com.evchargebook.domain
+
+data class TripContinuityDecision(
+    val acceptPoint: Boolean,
+    val countDistance: Boolean,
+    val countDuration: Boolean,
+    val speedEligibleForAggregate: Boolean,
+    val reason: String? = null
+)
+
+object TripContinuityRules {
+    const val LONG_GAP_SECONDS = 120L
+    const val PROVIDER_DEDUP_SECONDS = 8L
+    const val MAX_LOCATION_AGE_MILLIS = 15_000L
+
+    fun isFreshLocation(ageMillis: Long): Boolean = ageMillis in 0..MAX_LOCATION_AGE_MILLIS
+
+    fun decide(
+        deltaSeconds: Long?,
+        previousProvider: String?,
+        currentProvider: String?
+    ): TripContinuityDecision {
+        if (deltaSeconds == null) {
+            return TripContinuityDecision(true, false, false, false, "首个定位点仅建立基线")
+        }
+        if (deltaSeconds < 0) {
+            return TripContinuityDecision(false, false, false, false, "时间倒序")
+        }
+        if (deltaSeconds >= LONG_GAP_SECONDS) {
+            return TripContinuityDecision(true, false, false, false, "GPS 长时间中断后重新建立基线")
+        }
+
+        val previousIsGps = previousProvider.equals("gps", ignoreCase = true)
+        val currentIsNetwork = currentProvider.equals("network", ignoreCase = true)
+        if (deltaSeconds <= PROVIDER_DEDUP_SECONDS && previousIsGps && currentIsNetwork) {
+            return TripContinuityDecision(false, false, false, false, "近期已有 GPS 点，忽略重复网络定位")
+        }
+
+        val previousIsNetwork = previousProvider.equals("network", ignoreCase = true)
+        val currentIsGps = currentProvider.equals("gps", ignoreCase = true)
+        if (deltaSeconds <= PROVIDER_DEDUP_SECONDS && previousIsNetwork && currentIsGps) {
+            return TripContinuityDecision(true, false, false, true, "GPS 恢复，替代近期网络定位作为新基线")
+        }
+
+        return TripContinuityDecision(true, true, true, true)
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -1,0 +1,24 @@
+package com.evchargebook.domain
+
+object TripSpeedTrustRules {
+    const val MIN_CORROBORATING_DISTANCE_METERS = 5.0
+    private const val MIN_EXPECTED_DISTANCE_RATIO = 0.25
+
+    fun eligibleForAggregate(
+        reportedSpeedMps: Double?,
+        deltaSeconds: Long,
+        trustedDistanceMeters: Double,
+        continuityAllowsSpeed: Boolean
+    ): Boolean {
+        if (!continuityAllowsSpeed || reportedSpeedMps == null || reportedSpeedMps < 0.0) return false
+        if (reportedSpeedMps < TripSamplingRules.MOVING_SPEED_MPS) return true
+        if (deltaSeconds <= 0) return false
+
+        val expectedDistance = reportedSpeedMps * deltaSeconds
+        val requiredDistance = maxOf(
+            MIN_CORROBORATING_DISTANCE_METERS,
+            expectedDistance * MIN_EXPECTED_DISTANCE_RATIO
+        )
+        return trustedDistanceMeters >= requiredDistance
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -15,6 +15,7 @@ import android.location.LocationManager
 import android.os.Build
 import android.os.IBinder
 import android.os.Looper
+import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
@@ -22,11 +23,13 @@ import com.evchargebook.MainActivity
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.TripContinuityRules
 import com.evchargebook.domain.TripGpsHealth
 import com.evchargebook.domain.TripGpsHealthSnapshot
 import com.evchargebook.domain.TripGpsHealthStatus
 import com.evchargebook.domain.TripRules
 import com.evchargebook.domain.TripSamplingRules
+import com.evchargebook.domain.TripSpeedTrustRules
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -178,7 +181,7 @@ class TripTrackingService : Service() {
     }
 
     private suspend fun handleLocation(tripId: Long, location: Location) {
-        if (!isBasicLocationValid(location)) {
+        if (!isBasicLocationValid(location) || !isFreshLocation(location)) {
             rejectedPointCount += 1
             updateNotification()
             return
@@ -193,24 +196,45 @@ class TripTrackingService : Service() {
             return
         }
 
-        val segmentDistance = previous?.let { previousPoint ->
+        val rawDeltaSeconds = previous?.let { ((capturedAt - it.capturedAtEpochMillis) / 1000).coerceAtLeast(0) }
+        val continuity = TripContinuityRules.decide(
+            deltaSeconds = rawDeltaSeconds,
+            previousProvider = previous?.provider,
+            currentProvider = location.provider
+        )
+        if (!continuity.acceptPoint) {
+            rejectedPointCount += 1
+            updateNotification()
+            return
+        }
+
+        val rawSegmentDistance = previous?.let { previousPoint ->
             val result = FloatArray(1)
             Location.distanceBetween(previousPoint.latitude, previousPoint.longitude, location.latitude, location.longitude, result)
             result[0].toDouble().coerceAtLeast(0.0)
         } ?: 0.0
-        val deltaSeconds = previous?.let { ((capturedAt - it.capturedAtEpochMillis) / 1000).coerceAtLeast(0) } ?: 0
-        val speed = location.speed.takeIf { location.hasSpeed() }?.toDouble()
+        val trustedSegmentDistance = if (continuity.countDistance) rawSegmentDistance else 0.0
+        val statsDeltaSeconds = if (continuity.countDuration) rawDeltaSeconds ?: 0 else 0
+        val rawSpeed = location.speed.takeIf { location.hasSpeed() }?.toDouble()
+        val aggregateSpeed = if (
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = rawSpeed,
+                deltaSeconds = statsDeltaSeconds,
+                trustedDistanceMeters = trustedSegmentDistance,
+                continuityAllowsSpeed = continuity.speedEligibleForAggregate
+            )
+        ) rawSpeed else null
         val accuracy = location.accuracy.takeIf { location.hasAccuracy() }?.toDouble()
-        val decision = TripSamplingRules.decide(deltaSeconds, segmentDistance, speed, accuracy)
+        val decision = TripSamplingRules.decide(statsDeltaSeconds, trustedSegmentDistance, aggregateSpeed, accuracy)
         if (!decision.accept) {
             rejectedPointCount += 1
             updateNotification()
             return
         }
 
-        val newMovingSeconds = TripSamplingRules.movingSeconds(session.movingSeconds ?: 0, deltaSeconds, decision.moving)
-        val newStoppedSeconds = TripSamplingRules.stoppedSeconds(session.stoppedSeconds ?: 0, deltaSeconds, decision.moving)
-        val newDistance = session.distanceMeters + segmentDistance
+        val newMovingSeconds = TripSamplingRules.movingSeconds(session.movingSeconds ?: 0, statsDeltaSeconds, decision.moving)
+        val newStoppedSeconds = TripSamplingRules.stoppedSeconds(session.stoppedSeconds ?: 0, statsDeltaSeconds, decision.moving)
+        val newDistance = session.distanceMeters + trustedSegmentDistance
         val altitude = location.altitude.takeIf { location.hasAltitude() }
 
         val point = TripPointEntity(
@@ -219,7 +243,7 @@ class TripTrackingService : Service() {
             latitude = location.latitude,
             longitude = location.longitude,
             altitudeMeters = altitude,
-            speedMps = speed,
+            speedMps = rawSpeed,
             bearingDegrees = location.bearing.takeIf { location.hasBearing() }?.toDouble(),
             horizontalAccuracyMeters = accuracy,
             verticalAccuracyMeters = if (Build.VERSION.SDK_INT >= 26 && location.hasVerticalAccuracy()) location.verticalAccuracyMeters.toDouble() else null,
@@ -239,7 +263,7 @@ class TripTrackingService : Service() {
                 movingSeconds = newMovingSeconds,
                 stoppedSeconds = newStoppedSeconds,
                 averageSpeedMps = if (newMovingSeconds > 0) newDistance / newMovingSeconds else null,
-                maxSpeedMps = listOfNotNull(session.maxSpeedMps, speed).maxOrNull(),
+                maxSpeedMps = listOfNotNull(session.maxSpeedMps, aggregateSpeed).maxOrNull(),
                 startLatitude = session.startLatitude ?: location.latitude,
                 startLongitude = session.startLongitude ?: location.longitude,
                 endLatitude = location.latitude,
@@ -291,6 +315,12 @@ class TripTrackingService : Service() {
         if (!location.latitude.isFinite() || !location.longitude.isFinite()) return false
         if (location.latitude !in -90.0..90.0 || location.longitude !in -180.0..180.0) return false
         return true
+    }
+
+    private fun isFreshLocation(location: Location): Boolean {
+        val locationElapsedNanos = location.elapsedRealtimeNanos.takeIf { it > 0L } ?: return true
+        val ageNanos = (SystemClock.elapsedRealtimeNanos() - locationElapsedNanos).coerceAtLeast(0L)
+        return TripContinuityRules.isFreshLocation(ageNanos / 1_000_000L)
     }
 
     private fun currentHealthSnapshot(): TripGpsHealthSnapshot = TripGpsHealth.evaluate(

--- a/android/app/src/test/java/com/evchargebook/domain/TripContinuityRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripContinuityRulesTest.kt
@@ -1,0 +1,55 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripContinuityRulesTest {
+    @Test
+    fun `first point establishes baseline only`() {
+        val decision = TripContinuityRules.decide(null, null, "gps")
+        assertTrue(decision.acceptPoint)
+        assertFalse(decision.countDistance)
+        assertFalse(decision.countDuration)
+        assertFalse(decision.speedEligibleForAggregate)
+    }
+
+    @Test
+    fun `long gap restarts trusted baseline`() {
+        val decision = TripContinuityRules.decide(120, "gps", "gps")
+        assertTrue(decision.acceptPoint)
+        assertFalse(decision.countDistance)
+        assertFalse(decision.countDuration)
+        assertFalse(decision.speedEligibleForAggregate)
+    }
+
+    @Test
+    fun `continuous gps segment is fully trusted`() {
+        val decision = TripContinuityRules.decide(4, "gps", "gps")
+        assertTrue(decision.acceptPoint)
+        assertTrue(decision.countDistance)
+        assertTrue(decision.countDuration)
+        assertTrue(decision.speedEligibleForAggregate)
+    }
+
+    @Test
+    fun `recent network point is ignored after gps`() {
+        val decision = TripContinuityRules.decide(4, "gps", "network")
+        assertFalse(decision.acceptPoint)
+    }
+
+    @Test
+    fun `gps recovery after network resets distance baseline`() {
+        val decision = TripContinuityRules.decide(4, "network", "gps")
+        assertTrue(decision.acceptPoint)
+        assertFalse(decision.countDistance)
+        assertFalse(decision.countDuration)
+        assertTrue(decision.speedEligibleForAggregate)
+    }
+
+    @Test
+    fun `stale location age is rejected`() {
+        assertFalse(TripContinuityRules.isFreshLocation(15_001))
+        assertTrue(TripContinuityRules.isFreshLocation(15_000))
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -1,0 +1,55 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripSpeedTrustRulesTest {
+    @Test
+    fun `rejects stationary high-speed spike`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 33.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 3.0,
+                continuityAllowsSpeed = true
+            )
+        )
+    }
+
+    @Test
+    fun `keeps short real highway peak when distance corroborates it`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 30.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 110.0,
+                continuityAllowsSpeed = true
+            )
+        )
+    }
+
+    @Test
+    fun `first baseline point cannot update aggregate speed`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 30.0,
+                deltaSeconds = 0,
+                trustedDistanceMeters = 0.0,
+                continuityAllowsSpeed = false
+            )
+        )
+    }
+
+    @Test
+    fun `trusted stationary speed remains eligible`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 0.2,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 0.5,
+                continuityAllowsSpeed = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Implements the first trusted-data slice of #41 after two real-device findings:

1. a completed long trip contained 12-15 minute GPS gaps;
2. starting a Trip while the car was still stationary could briefly show about 120 km/h.

### Startup / false-speed guard

- the first accepted point establishes a baseline only and cannot immediately update moving/max-speed aggregates
- a point after a >=120s gap also re-establishes the baseline before aggregates resume
- stale Location callbacks older than 15s are rejected using elapsed realtime
- raw `Location.speed` is still stored on TripPoint for diagnosis
- a reported moving/high speed is allowed into moving/max aggregates only when trusted geographic displacement corroborates it

This deliberately does **not** use a simplistic high-speed cutoff, so a real short highway peak (for example ~109 km/h for ~4s) remains eligible when the corresponding displacement supports it.

### Trusted distance / provider continuity

- >=120s gaps no longer add straight-line distance between the two ends
- gap duration is not silently added to moving/stopped time
- a Network point arriving within 8s after GPS is treated as duplicate fallback and ignored
- GPS recovery within 8s after Network establishes a new high-quality baseline without adding provider-switch distance/time

### Tests

Adds pure JVM coverage for:

- first-point baseline behavior
- long-gap baseline reset
- normal continuous GPS
- GPS -> Network dedupe
- Network -> GPS recovery
- stale callback threshold
- stationary 120 km/h-like spike rejection
- real ~109 km/h short peak acceptance when displacement corroborates it

### Scope

Android code/tests only. No Room migration, no MapLibre, no colored-speed visualization, no OBD work in this PR.

Refs #41.