### PR TITLE
fix(android): protect unsaved form edits

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.pm.PackageManager
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.horizontalScroll
@@ -57,7 +58,8 @@ fun AddRecordScreen(
     val locationProvider = remember(context) { AndroidLocationProvider(context.applicationContext) }
     val addressResolver = remember(context) { AndroidGeocoderAddressResolver(context.applicationContext) }
     val calendar = remember { Calendar.getInstance() }
-    var chargeTime by remember { mutableLongStateOf(calendar.timeInMillis) }
+    val initialChargeTime = remember { calendar.timeInMillis }
+    var chargeTime by remember { mutableLongStateOf(initialChargeTime) }
     var location by remember { mutableStateOf("") }
     var locationFix by remember { mutableStateOf<LocationFix?>(null) }
     var locating by remember { mutableStateOf(false) }
@@ -70,6 +72,18 @@ fun AddRecordScreen(
     var chargerType by remember { mutableStateOf("公共慢充") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var addressMessage by remember { mutableStateOf<String?>(null) }
+    var showDiscardConfirm by remember { mutableStateOf(false) }
+
+    val isDirty = chargeTime != initialChargeTime ||
+        location.isNotBlank() || locationFix != null || remark.isNotBlank() ||
+        startSoc.isNotBlank() || endSoc.isNotBlank() || energy.isNotBlank() ||
+        cost.isNotBlank() || odometer.isNotBlank() || chargerType != "公共慢充"
+
+    fun requestBack() {
+        if (isDirty) showDiscardConfirm = true else onBack()
+    }
+
+    BackHandler(enabled = isDirty) { showDiscardConfirm = true }
 
     fun requestCurrentLocation() {
         locating = true
@@ -107,7 +121,7 @@ fun AddRecordScreen(
         batteryCapacityKwh = batteryCapacityKwh
     )
 
-    Scaffold(topBar = { TopAppBar(title = { Text("记录充电") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+    Scaffold(topBar = { TopAppBar(title = { Text("记录充电") }, navigationIcon = { IconButton(onClick = ::requestBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             ChargeInputCockpit(startSoc, endSoc, energy, cost)
@@ -188,6 +202,16 @@ fun AddRecordScreen(
             }, modifier = Modifier.fillMaxWidth()) { Text("保存充电记录") }
             Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
+    }
+
+    if (showDiscardConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDiscardConfirm = false },
+            title = { Text("放弃未保存修改？") },
+            text = { Text("当前填写的充电记录还没有保存，返回后这些内容会丢失。") },
+            confirmButton = { TextButton(onClick = { showDiscardConfirm = false; onBack() }) { Text("放弃", color = MaterialTheme.colorScheme.error) } },
+            dismissButton = { TextButton(onClick = { showDiscardConfirm = false }) { Text("继续填写") } }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -2,6 +2,7 @@ package com.evchargebook.ui.records
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -48,6 +49,21 @@ fun RecordEditScreen(
     var odometer by remember { mutableStateOf(record.odometerKm?.toString().orEmpty()) }
     var chargerType by remember { mutableStateOf(record.chargerType ?: "公共慢充") }
     var error by remember { mutableStateOf<String?>(null) }
+    var showDiscardConfirm by remember { mutableStateOf(false) }
+
+    val isDirty = chargeTime != record.chargeTimeEpochMillis ||
+        location != record.location.orEmpty() || remark != record.remark.orEmpty() ||
+        energy != record.energyKwh.toString() || cost != record.cost.toString() ||
+        startSoc != record.startSoc.toString() || endSoc != record.endSoc.toString() ||
+        odometer != record.odometerKm?.toString().orEmpty() ||
+        chargerType != (record.chargerType ?: "公共慢充")
+
+    fun requestBack() {
+        if (isDirty) showDiscardConfirm = true else onBack()
+    }
+
+    BackHandler(enabled = isDirty) { showDiscardConfirm = true }
+
     val dateText = remember(chargeTime) { SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
     val timeText = remember(chargeTime) { SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
     val previousOdometer = remember(records, record.id, record.vehicleId, chargeTime) { ChargingRecordRules.previousOdometerKm(records, record.vehicleId, chargeTime, record.id) }
@@ -60,7 +76,7 @@ fun RecordEditScreen(
         batteryCapacityKwh = batteryCapacityKwh
     )
 
-    Scaffold(topBar = { TopAppBar(title = { Text("编辑充电记录") }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+    Scaffold(topBar = { TopAppBar(title = { Text("编辑充电记录") }, navigationIcon = { IconButton(onClick = ::requestBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             EditChargeSummary(startSoc, endSoc, energy, cost)
@@ -108,6 +124,16 @@ fun RecordEditScreen(
             }, modifier = Modifier.fillMaxWidth()) { Text("保存修改") }
             Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
+    }
+
+    if (showDiscardConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDiscardConfirm = false },
+            title = { Text("放弃未保存修改？") },
+            text = { Text("这条充电记录已经被修改，返回后未保存的修改会丢失。") },
+            confirmButton = { TextButton(onClick = { showDiscardConfirm = false; onBack() }) { Text("放弃", color = MaterialTheme.colorScheme.error) } },
+            dismissButton = { TextButton(onClick = { showDiscardConfirm = false }) { Text("继续编辑") } }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
@@ -1,5 +1,6 @@
 package com.evchargebook.ui.vehicle
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
@@ -31,8 +32,17 @@ fun VehicleEditScreen(
     var battery by remember { mutableStateOf(initialBatteryCapacity) }
     var range by remember { mutableStateOf(initialRange) }
     var error by remember { mutableStateOf<String?>(null) }
+    var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    Scaffold(topBar = { TopAppBar(title = { Text(title) }, navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
+    val isDirty = brand != initialBrand || model != initialModel || battery != initialBatteryCapacity || range != initialRange
+
+    fun requestBack() {
+        if (isDirty) showDiscardConfirm = true else onBack()
+    }
+
+    BackHandler(enabled = isDirty) { showDiscardConfirm = true }
+
+    Scaffold(topBar = { TopAppBar(title = { Text(title) }, navigationIcon = { IconButton(onClick = ::requestBack) { Icon(Icons.Default.ArrowBack, "返回") } }) }) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             VehiclePreviewCockpit(brand, model, battery, range, title == "添加车辆")
@@ -64,6 +74,16 @@ fun VehicleEditScreen(
             }, modifier = Modifier.fillMaxWidth()) { Text(if (title == "添加车辆") "添加车辆" else "保存车辆") }
             Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
+    }
+
+    if (showDiscardConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDiscardConfirm = false },
+            title = { Text("放弃未保存修改？") },
+            text = { Text(if (title == "添加车辆") "当前车辆信息还没有保存，返回后这些内容会丢失。" else "车辆信息已经被修改，返回后未保存的修改会丢失。") },
+            confirmButton = { TextButton(onClick = { showDiscardConfirm = false; onBack() }) { Text("放弃", color = MaterialTheme.colorScheme.error) } },
+            dismissButton = { TextButton(onClick = { showDiscardConfirm = false }) { Text("继续编辑") } }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

P1 usability hardening from #42: prevent accidental loss of partially entered or edited form data.

## Covered forms
- Add charging record
- Edit charging record
- Add vehicle
- Edit vehicle

## Behavior
- clean form: top app bar back and system/back gesture return immediately
- dirty form: back first shows `放弃未保存修改？`
- user can continue editing or explicitly discard
- saving still follows the existing business flow and closes the overlay normally

## Dirty-state rules
Charging form tracks meaningful changes to time, location/GPS fix, SOC, energy, cost, odometer, charger type and remark.
Editing compares against the original persisted record. Vehicle form compares against initial brand/model/battery/range values.

## Scope
UI state-safety only. No database schema, validation rules, repository logic, navigation routes or Trip behavior changed.

Refs #42