### PR TITLE
feat(android): derive trip completeness summary

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripCompletenessSummary.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripCompletenessSummary.kt
@@ -1,0 +1,48 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripPointEntity
+
+data class TripCompletenessSummary(
+    val acceptedPointCount: Int,
+    val gpsPointCount: Int,
+    val networkPointCount: Int,
+    val otherProviderPointCount: Int,
+    val longGapCount: Int,
+    val longestGapSeconds: Long,
+    val cumulativeLongGapSeconds: Long
+) {
+    val hasLongGap: Boolean get() = longGapCount > 0
+}
+
+object TripCompletenessAnalytics {
+    fun summarize(points: List<TripPointEntity>): TripCompletenessSummary {
+        val ordered = points.sortedBy { it.capturedAtEpochMillis }
+        var longGapCount = 0
+        var longestGapSeconds = 0L
+        var cumulativeLongGapSeconds = 0L
+
+        ordered.zipWithNext().forEach { (previous, current) ->
+            val deltaSeconds = ((current.capturedAtEpochMillis - previous.capturedAtEpochMillis) / 1000)
+                .coerceAtLeast(0L)
+            if (deltaSeconds >= TripContinuityRules.LONG_GAP_SECONDS) {
+                longGapCount += 1
+                longestGapSeconds = maxOf(longestGapSeconds, deltaSeconds)
+                cumulativeLongGapSeconds += deltaSeconds
+            }
+        }
+
+        val gpsPointCount = ordered.count { it.provider.equals("gps", ignoreCase = true) }
+        val networkPointCount = ordered.count { it.provider.equals("network", ignoreCase = true) }
+        val otherProviderPointCount = ordered.size - gpsPointCount - networkPointCount
+
+        return TripCompletenessSummary(
+            acceptedPointCount = ordered.size,
+            gpsPointCount = gpsPointCount,
+            networkPointCount = networkPointCount,
+            otherProviderPointCount = otherProviderPointCount,
+            longGapCount = longGapCount,
+            longestGapSeconds = longestGapSeconds,
+            cumulativeLongGapSeconds = cumulativeLongGapSeconds
+        )
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripCompletenessSummaryTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripCompletenessSummaryTest.kt
@@ -1,0 +1,84 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripPointEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripCompletenessSummaryTest {
+    @Test
+    fun summarizesProvidersWithoutLongGaps() {
+        val summary = TripCompletenessAnalytics.summarize(
+            listOf(
+                point(1_000L, "gps"),
+                point(5_000L, "gps"),
+                point(9_000L, "network")
+            )
+        )
+
+        assertEquals(3, summary.acceptedPointCount)
+        assertEquals(2, summary.gpsPointCount)
+        assertEquals(1, summary.networkPointCount)
+        assertEquals(0, summary.otherProviderPointCount)
+        assertEquals(0, summary.longGapCount)
+        assertEquals(0L, summary.longestGapSeconds)
+        assertEquals(0L, summary.cumulativeLongGapSeconds)
+        assertFalse(summary.hasLongGap)
+    }
+
+    @Test
+    fun countsMultipleLongGapsAndKeepsLongest() {
+        val summary = TripCompletenessAnalytics.summarize(
+            listOf(
+                point(1_000L, "gps"),
+                point(121_000L, "gps"),
+                point(125_000L, "gps"),
+                point(305_000L, "network")
+            )
+        )
+
+        assertEquals(2, summary.longGapCount)
+        assertEquals(180L, summary.longestGapSeconds)
+        assertEquals(300L, summary.cumulativeLongGapSeconds)
+        assertTrue(summary.hasLongGap)
+    }
+
+    @Test
+    fun treatsOneHundredNineteenSecondsAsContinuousAndOneTwentyAsGap() {
+        val below = TripCompletenessAnalytics.summarize(
+            listOf(point(0L, "gps"), point(119_999L, "gps"))
+        )
+        val boundary = TripCompletenessAnalytics.summarize(
+            listOf(point(0L, "gps"), point(120_000L, "gps"))
+        )
+
+        assertEquals(0, below.longGapCount)
+        assertEquals(1, boundary.longGapCount)
+    }
+
+    @Test
+    fun sortsPointsBeforeCalculatingGaps() {
+        val summary = TripCompletenessAnalytics.summarize(
+            listOf(
+                point(305_000L, "network"),
+                point(1_000L, null),
+                point(5_000L, "gps")
+            )
+        )
+
+        assertEquals(1, summary.gpsPointCount)
+        assertEquals(1, summary.networkPointCount)
+        assertEquals(1, summary.otherProviderPointCount)
+        assertEquals(1, summary.longGapCount)
+        assertEquals(300L, summary.longestGapSeconds)
+    }
+
+    private fun point(time: Long, provider: String?) = TripPointEntity(
+        tripId = 1L,
+        capturedAtEpochMillis = time,
+        latitude = 31.0,
+        longitude = 121.0,
+        provider = provider
+    )
+}


### PR DESCRIPTION
## Summary

Adds a pure derived Trip completeness model as the next #41 reliability slice after PR #44.

### What this adds

- `TripCompletenessSummary`
- `TripCompletenessAnalytics.summarize(points)`
- accepted point count
- GPS / Network / other provider counts
- long-gap count using the same `>=120s` continuity boundary
- longest long gap
- cumulative long-gap duration
- explicit `hasLongGap`

### Why derived first

These values can be reconstructed exactly from existing `TripPoint` rows, so this PR deliberately avoids a Room migration and avoids duplicating facts in the database.

The following evidence cannot be reconstructed from accepted points and remains the next persistence slice:

- rejected point count/history
- service create/start/destroy/re-delivery evidence
- provider disabled / permission loss events

### Tests

Pure JVM coverage includes:

- provider counts
- multiple long gaps
- longest/cumulative gap duration
- exact 119.999s vs 120s boundary
- unordered input points

No UI redesign, no MapLibre, no OBD, no database migration.

Refs #41.