### PR TITLE
feat(android): add persistent trip diagnostic events

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/dao/TripDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/TripDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import com.evchargebook.data.entity.TripDiagnosticEventEntity
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +36,15 @@ interface TripDao {
     @Query("SELECT * FROM trip_points WHERE tripId = :tripId ORDER BY capturedAtEpochMillis")
     suspend fun getPoints(tripId: Long): List<TripPointEntity>
 
+    @Query("SELECT * FROM trip_diagnostic_events WHERE tripId = :tripId ORDER BY occurredAtEpochMillis, id")
+    fun observeDiagnosticEvents(tripId: Long): Flow<List<TripDiagnosticEventEntity>>
+
+    @Query("SELECT * FROM trip_diagnostic_events WHERE tripId = :tripId ORDER BY occurredAtEpochMillis, id")
+    suspend fun getDiagnosticEvents(tripId: Long): List<TripDiagnosticEventEntity>
+
+    @Query("SELECT * FROM trip_diagnostic_events ORDER BY tripId, occurredAtEpochMillis, id")
+    suspend fun getAllDiagnosticEvents(): List<TripDiagnosticEventEntity>
+
     @Insert
     suspend fun insertSession(session: TripSessionEntity): Long
 
@@ -49,6 +59,12 @@ interface TripDao {
 
     @Insert
     suspend fun insertPoints(points: List<TripPointEntity>)
+
+    @Insert
+    suspend fun insertDiagnosticEvent(event: TripDiagnosticEventEntity): Long
+
+    @Insert
+    suspend fun insertDiagnosticEvents(events: List<TripDiagnosticEventEntity>)
 
     @Delete
     suspend fun deleteSession(session: TripSessionEntity)

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -11,14 +11,22 @@ import com.evchargebook.data.dao.TripDao
 import com.evchargebook.data.dao.VehicleDao
 import com.evchargebook.data.dao.VehicleCatalogDao
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.TripDiagnosticEventEntity
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
 
 @Database(
-    entities = [VehicleEntity::class, ChargingRecordEntity::class, VehicleCatalogEntity::class, TripSessionEntity::class, TripPointEntity::class],
-    version = 7,
+    entities = [
+        VehicleEntity::class,
+        ChargingRecordEntity::class,
+        VehicleCatalogEntity::class,
+        TripSessionEntity::class,
+        TripPointEntity::class,
+        TripDiagnosticEventEntity::class
+    ],
+    version = 8,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -87,6 +95,15 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE TABLE IF NOT EXISTS trip_diagnostic_events (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, tripId INTEGER NOT NULL, occurredAtEpochMillis INTEGER NOT NULL, type TEXT NOT NULL, provider TEXT, detail TEXT, FOREIGN KEY(tripId) REFERENCES trip_sessions(id) ON UPDATE NO ACTION ON DELETE CASCADE)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_trip_diagnostic_events_tripId ON trip_diagnostic_events(tripId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_trip_diagnostic_events_occurredAtEpochMillis ON trip_diagnostic_events(occurredAtEpochMillis)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_trip_diagnostic_events_type ON trip_diagnostic_events(type)")
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -97,7 +114,15 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "ev-charge-book.db"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+                    .addMigrations(
+                        MIGRATION_1_2,
+                        MIGRATION_2_3,
+                        MIGRATION_3_4,
+                        MIGRATION_4_5,
+                        MIGRATION_5_6,
+                        MIGRATION_6_7,
+                        MIGRATION_7_8
+                    )
                     .build()
                     .also { instance = it }
             }

--- a/android/app/src/main/java/com/evchargebook/data/entity/TripDiagnosticEventEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/TripDiagnosticEventEntity.kt
@@ -1,0 +1,42 @@
+package com.evchargebook.data.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+object TripDiagnosticEventType {
+    const val SERVICE_START = "SERVICE_START"
+    const val SERVICE_REDELIVERED = "SERVICE_REDELIVERED"
+    const val SERVICE_DESTROY = "SERVICE_DESTROY"
+    const val LOCATION_REGISTRATION_FAILED = "LOCATION_REGISTRATION_FAILED"
+    const val PROVIDER_DISABLED = "PROVIDER_DISABLED"
+    const val PERMISSION_MISSING = "PERMISSION_MISSING"
+    const val LOCATION_REJECTED = "LOCATION_REJECTED"
+}
+
+@Entity(
+    tableName = "trip_diagnostic_events",
+    foreignKeys = [
+        ForeignKey(
+            entity = TripSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["tripId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["tripId"]),
+        Index(value = ["occurredAtEpochMillis"]),
+        Index(value = ["type"])
+    ]
+)
+data class TripDiagnosticEventEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val tripId: Long,
+    val occurredAtEpochMillis: Long,
+    val type: String,
+    val provider: String? = null,
+    val detail: String? = null
+)


### PR DESCRIPTION
## Summary

Adds the persistence foundation for the next #41 Trip reliability slice.

### Current stage

This PR is **not the next release checkpoint yet**. The current release checkpoint is:

1. Merge this diagnostic persistence layer
2. Add runtime event writes from TripTrackingService
3. Include diagnostic evidence in Backup/Restore if needed
4. Expose a compact Trip diagnostic summary
5. Complete lock-screen long-drive verification
6. Only then evaluate Trip reliability closeout and resume v0.4 sync expansion

### What this adds

- `TripDiagnosticEventEntity`
- Room database v8
- migration `7 -> 8`
- diagnostic event indices by trip / time / type
- DAO insert/query APIs for per-trip and all diagnostic events

### Event model

Initial event types:

- `SERVICE_START`
- `SERVICE_REDELIVERED`
- `SERVICE_DESTROY`
- `LOCATION_REGISTRATION_FAILED`
- `PROVIDER_DISABLED`
- `PERMISSION_MISSING`
- `LOCATION_REJECTED`

Each event stores:

- trip id
- event time
- type
- optional provider
- optional short detail

No coordinates are duplicated into the diagnostic table.

### Why an event table

These facts cannot be reconstructed from accepted `TripPoint` rows. A timeline is more useful than adding many counters into `TripSession`, because it can explain whether GPS gaps were related to service lifecycle, provider state, permission changes, or rejected points.

### Validation

- Latest main baseline is Build/Test Green.
- This PR must be revalidated against current `main` before merge.
- Do not treat stale historical Action runs as blockers.

### Scope

This PR intentionally contains persistence infrastructure only. Runtime writes, backup/export inclusion, and UI diagnostic summaries are follow-up slices so migration risk and behavior changes stay independently testable.

Refs #41.