### PR TITLE
fix(android): finish responsive cockpit metrics

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
@@ -1,11 +1,15 @@
 package com.evchargebook.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material3.Button
@@ -16,7 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.evchargebook.ui.theme.spacing
 
 @Composable
@@ -48,5 +54,33 @@ fun EmptyState(title: String, message: String, actionLabel: String, onAction: ()
         )
         Spacer(Modifier.height(MaterialTheme.spacing.lg))
         Button(onClick = onAction) { Text(actionLabel) }
+    }
+}
+
+@Composable
+fun ResponsiveMetricGrid(
+    itemCount: Int,
+    itemContent: @Composable (index: Int, modifier: Modifier) -> Unit
+) {
+    BoxWithConstraints(Modifier.fillMaxWidth()) {
+        val compact = maxWidth < 360.dp || LocalDensity.current.fontScale >= 1.3f
+        val columns = if (compact) 2 else 3
+
+        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            var start = 0
+            while (start < itemCount) {
+                val end = minOf(start + columns, itemCount)
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                ) {
+                    for (index in start until end) {
+                        itemContent(index, Modifier.weight(1f))
+                    }
+                    repeat(columns - (end - start)) { Spacer(Modifier.weight(1f)) }
+                }
+                start = end
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/components/AppComponents.kt
@@ -1,15 +1,6 @@
 package com.evchargebook.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material3.Button

--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -36,6 +36,7 @@ import com.evchargebook.domain.ChargingRecordRules
 import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.location.AndroidLocationProvider
 import com.evchargebook.location.LocationFix
+import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
 import kotlinx.coroutines.launch
@@ -255,6 +256,11 @@ private fun ChargeInputCockpit(startSoc: String, endSoc: String, energy: String,
     val costValue = cost.toDoubleOrNull()
     val delta = if (start != null && end != null && end >= start) end - start else null
     val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
+    val metrics = listOf(
+        "SOC" to (delta?.let { "+$it%" } ?: "--"),
+        "补能" to (energyValue?.let { "${formatOne(it)} kWh" } ?: "--"),
+        "均价" to (unitPrice?.let { "¥ ${formatTwo(it)}" } ?: "--")
+    )
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -268,10 +274,9 @@ private fun ChargeInputCockpit(startSoc: String, endSoc: String, energy: String,
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
                 Text("CHARGE / NEW", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-                InputMetric("SOC", delta?.let { "+$it%" } ?: "--", Modifier.weight(1f))
-                InputMetric("补能", energyValue?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
-                InputMetric("均价", unitPrice?.let { "¥ ${formatTwo(it)}" } ?: "--", Modifier.weight(1f))
+            ResponsiveMetricGrid(metrics.size) { index, modifier ->
+                val (label, value) = metrics[index]
+                InputMetric(label, value, modifier)
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
+import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
 import java.text.SimpleDateFormat
@@ -176,6 +177,11 @@ private fun EditChargeSummary(startSoc: String, endSoc: String, energy: String, 
     val costValue = cost.toDoubleOrNull()
     val delta = if (start != null && end != null && end >= start) end - start else null
     val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
+    val metrics = listOf(
+        "SOC" to (delta?.let { "+$it%" } ?: "--"),
+        "补能" to (energyValue?.let { String.format(Locale.US, "%.1f kWh", it) } ?: "--"),
+        "均价" to (unitPrice?.let { String.format(Locale.US, "¥ %.2f", it) } ?: "--")
+    )
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -189,10 +195,9 @@ private fun EditChargeSummary(startSoc: String, endSoc: String, energy: String, 
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
                 Text("CHARGE / EDIT", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .58f))
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-                EditMetric("SOC", delta?.let { "+$it%" } ?: "--", Modifier.weight(1f))
-                EditMetric("补能", energyValue?.let { String.format(Locale.US, "%.1f kWh", it) } ?: "--", Modifier.weight(1f))
-                EditMetric("均价", unitPrice?.let { String.format(Locale.US, "¥ %.2f", it) } ?: "--", Modifier.weight(1f))
+            ResponsiveMetricGrid(metrics.size) { index, modifier ->
+                val (label, value) = metrics[index]
+                EditMetric(label, value, modifier)
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.ui.components.EmptyState
+import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import java.time.Instant
 import java.time.ZoneId
@@ -94,6 +95,11 @@ private fun LedgerCockpit(records: List<ChargingRecordEntity>) {
     val totalCost = records.sumOf { it.cost }
     val totalEnergy = records.sumOf { it.energyKwh }
     val averagePrice = if (totalEnergy > 0.0) totalCost / totalEnergy else 0.0
+    val metrics = listOf(
+        "补能" to "${one(totalEnergy)} kWh",
+        "记录" to "${records.size} 笔",
+        "均价" to "¥ ${two(averagePrice)}"
+    )
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -135,10 +141,9 @@ private fun LedgerCockpit(records: List<ChargingRecordEntity>) {
 
             HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-                CockpitValue("补能", "${one(totalEnergy)} kWh", Modifier.weight(1f))
-                CockpitValue("记录", "${records.size} 笔", Modifier.weight(1f))
-                CockpitValue("均价", "¥ ${two(averagePrice)}", Modifier.weight(1f))
+            ResponsiveMetricGrid(metrics.size) { index, modifier ->
+                val (label, value) = metrics[index]
+                CockpitValue(label, value, modifier)
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/stats/StatsScreen.kt
@@ -18,6 +18,7 @@ import com.evchargebook.domain.ChargingEstimateConfidence
 import com.evchargebook.domain.ChargingIntervalSample
 import com.evchargebook.domain.ChargingTripCoverageInterval
 import com.evchargebook.domain.MonthlyChargingComparison
+import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
 import com.evchargebook.viewmodel.MainUiState
@@ -64,6 +65,12 @@ fun StatsScreen(state: MainUiState) {
 
 @Composable
 private fun MonthSummary(state: MainUiState) {
+    val metrics = listOf(
+        "补能" to "${one(state.monthEnergy)} kWh",
+        "次数" to "${state.chargingCount} 次",
+        "均价" to "¥ ${two(state.averagePrice)}"
+    )
+
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
@@ -81,10 +88,9 @@ private fun MonthSummary(state: MainUiState) {
                 Text("¥ ${two(state.monthCost)}", style = MaterialTheme.typography.displaySmall, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.inverseOnSurface)
             }
             HorizontalDivider(color = MaterialTheme.colorScheme.inverseOnSurface.copy(alpha = .12f))
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
-                StatValue("补能", "${one(state.monthEnergy)} kWh", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
-                StatValue("次数", "${state.chargingCount} 次", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
-                StatValue("均价", "¥ ${two(state.averagePrice)}", Modifier.weight(1f), MaterialTheme.colorScheme.inverseOnSurface)
+            ResponsiveMetricGrid(metrics.size) { index, modifier ->
+                val (label, value) = metrics[index]
+                StatValue(label, value, modifier, MaterialTheme.colorScheme.inverseOnSurface)
             }
         }
     }


### PR DESCRIPTION
## Summary

Finish #42 small-screen / large-font hardening for the remaining 3-column cockpit metric groups.

## Shared behavior
- normal width + font scale keeps the existing 3-column cockpit layout
- width below 360dp or fontScale >= 1.3 switches to 2 columns
- no text shrinking is used to force values into narrow cells
- a small shared `ResponsiveMetricGrid` keeps the threshold and layout behavior in one place

## Covered
- Records ledger cockpit
- Stats monthly cockpit
- Add charging record live cockpit
- Edit charging record live cockpit

Trip already has equivalent adaptive behavior; Vehicle preview is already 2-column and is intentionally unchanged.

## Scope
Layout-only hardening. No analytics formulas, charging validation, repositories, Room schema, Trip logic, or data model changes.

Refs #42