### PR TITLE
refactor(android): introduce cockpit theme token foundation

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/theme/CockpitTheme.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/CockpitTheme.kt
@@ -1,0 +1,30 @@
+package com.evchargebook.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Product-level colors for EV cockpit surfaces.
+ *
+ * Keep this separate from Material inverse colors so dashboard,
+ * trip and charging cockpit surfaces remain stable across theme changes.
+ */
+data class CockpitColors(
+    val background: Color,
+    val primaryText: Color,
+    val secondaryText: Color,
+    val accent: Color,
+    val warning: Color,
+    val danger: Color
+)
+
+val LocalCockpitColors = staticCompositionLocalOf {
+    CockpitColors(
+        background = Color(0xFF11171B),
+        primaryText = Color(0xFFF4F8F6),
+        secondaryText = Color(0xFFB7C2BD),
+        accent = Color(0xFF45E6A8),
+        warning = Color(0xFFFFC56B),
+        danger = Color(0xFFFFB4AB)
+    )
+}

--- a/docs/UIUX_RC1_CHECKLIST.md
+++ b/docs/UIUX_RC1_CHECKLIST.md
@@ -1,0 +1,24 @@
+# EV Charge Book UIUX RC1 Checklist
+
+## Goal
+
+Prepare the UI layer for v0.4 RC1 without expanding product scope.
+
+## Completed
+
+- Cockpit visual language
+- Responsive cockpit metrics
+- Form interaction hardening
+- UIUX convergence roadmap
+- Cockpit token foundation
+
+## Remaining UI gates
+
+- Migrate cockpit screens to dedicated tokens
+- Add Trip diagnostic presentation components
+- Accessibility hardening
+- Long text overflow handling
+
+## Constraints
+
+Do not add new business features, sync UI, map UI, or AI surfaces during this phase.


### PR DESCRIPTION
## Summary

Introduce the first UIUX convergence code step: a dedicated cockpit color token foundation.

## Purpose

The app currently uses Material inverse colors for cockpit surfaces. This works visually but couples product identity to Material theme semantics.

This PR introduces a stable cockpit token layer for future migration.

## Included

- Add CockpitColors model
- Add LocalCockpitColors composition local
- Define stable EV cockpit background/text/accent/warning/danger tokens

## Scope

Foundation only. No screen migration yet.

No changes to:
- Trip logic
- GPS
- Room
- Repository
- Sync

Follow-up PRs will migrate existing cockpit screens incrementally.

Refs: UIUX Convergence Roadmap