### PR TITLE
refactor(android): expose cockpit theme tokens for compose screens

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/theme/CockpitColorsExtension.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/CockpitColorsExtension.kt
@@ -1,0 +1,24 @@
+package com.evchargebook.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Stable product colors for cockpit surfaces.
+ *
+ * Screens should consume these tokens instead of Material inverse colors
+ * so cockpit UI remains consistent across theme changes.
+ */
+val MaterialTheme.cockpitColors: CockpitColors
+    @Composable
+    get() = LocalCockpitColors.current
+
+val CockpitColors.backgroundColor: Color
+    get() = background
+
+val CockpitColors.primaryTextColor: Color
+    get() = primaryText
+
+val CockpitColors.accentColor: Color
+    get() = accent


### PR DESCRIPTION
Closed after RC1 review. The cockpit token foundation work is no longer an open PR candidate; follow-up UI migration will be tracked in the v0.5 roadmap.