### PR TITLE
fix(android): type trip diagnostic SQL arguments

### DIFF
--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -92,7 +92,7 @@ class TripTrackingService : Service() {
             runCatching {
                 AppDatabase.getInstance(applicationContext).openHelper.writableDatabase.execSQL(
                     "INSERT INTO trip_diagnostic_events (tripId, occurredAtEpochMillis, type, provider, detail) VALUES (?, ?, ?, NULL, ?)",
-                    arrayOf(tripId, System.currentTimeMillis(), TripDiagnosticEventType.SERVICE_DESTROY, "service destroyed while trip active")
+                    arrayOf<Any?>(tripId, System.currentTimeMillis(), TripDiagnosticEventType.SERVICE_DESTROY, "service destroyed while trip active")
                 )
             }
         }


### PR DESCRIPTION
## Summary
- make the mixed execSQL bind-argument array explicitly nullable Any values
- resolve the Kotlin compiler inference failure in Android CI

## Validation
- .\\gradlew.bat --no-daemon :app:compileDebugKotlin --console=plain