### PR TITLE
fix(android): isolate debug package from release

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,6 +42,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+
         release {
             isMinifyEnabled = false
             signingConfig = if (hasReleaseSigning) {


### PR DESCRIPTION
## Summary

Fix the Android debug/release installation conflict by giving debug builds a distinct application ID and version suffix.

## Changes

- add `applicationIdSuffix = ".debug"` to the `debug` build type
- add `versionNameSuffix = "-debug"` so debug builds are easier to identify
- keep the release package ID unchanged as `com.evchargebook`
- leave the existing release signing and publication workflow unchanged

## Result

After this change:

- release installs as `com.evchargebook`
- debug installs as `com.evchargebook.debug`
- both variants can coexist on the same device
- a debug-signed APK no longer conflicts with an installed production-signed release APK

## Scope

Minimal Gradle-only change; no business logic or release pipeline behavior is modified.