### PR TITLE
feat(android): add vehicle state foundation

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/dao/VehicleStateDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/VehicleStateDao.kt
@@ -1,0 +1,26 @@
+package com.evchargebook.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.evchargebook.data.entity.VehicleStateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface VehicleStateDao {
+    @Query("SELECT * FROM vehicle_state WHERE vehicleId = :vehicleId")
+    fun observe(vehicleId: Long): Flow<VehicleStateEntity?>
+
+    @Query("SELECT * FROM vehicle_state WHERE vehicleId = :vehicleId")
+    suspend fun get(vehicleId: Long): VehicleStateEntity?
+
+    @Query("SELECT * FROM vehicle_state ORDER BY vehicleId")
+    suspend fun getAll(): List<VehicleStateEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(state: VehicleStateEntity)
+
+    @Query("DELETE FROM vehicle_state")
+    suspend fun deleteAll()
+}

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -10,12 +10,14 @@ import com.evchargebook.data.dao.ChargingRecordDao
 import com.evchargebook.data.dao.TripDao
 import com.evchargebook.data.dao.VehicleDao
 import com.evchargebook.data.dao.VehicleCatalogDao
+import com.evchargebook.data.dao.VehicleStateDao
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.TripDiagnosticEventEntity
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.data.entity.VehicleStateEntity
 
 @Database(
     entities = [
@@ -24,9 +26,10 @@ import com.evchargebook.data.entity.VehicleEntity
         VehicleCatalogEntity::class,
         TripSessionEntity::class,
         TripPointEntity::class,
-        TripDiagnosticEventEntity::class
+        TripDiagnosticEventEntity::class,
+        VehicleStateEntity::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,6 +37,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun vehicleCatalogDao(): VehicleCatalogDao
     abstract fun chargingRecordDao(): ChargingRecordDao
     abstract fun tripDao(): TripDao
+    abstract fun vehicleStateDao(): VehicleStateDao
 
     companion object {
         private val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -104,6 +108,38 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE TABLE IF NOT EXISTS vehicle_state (vehicleId INTEGER NOT NULL, currentSoc INTEGER, currentMileage REAL, updatedAtEpochMillis INTEGER NOT NULL, updateSource TEXT NOT NULL, PRIMARY KEY(vehicleId))")
+                db.execSQL(
+                    """
+                    INSERT OR REPLACE INTO vehicle_state (vehicleId, currentSoc, currentMileage, updatedAtEpochMillis, updateSource)
+                    SELECT
+                        vehicles.id,
+                        (
+                            SELECT charging_records.endSoc
+                            FROM charging_records
+                            WHERE charging_records.vehicleId = vehicles.id AND charging_records.isDeleted = 0
+                            ORDER BY charging_records.chargeTimeEpochMillis DESC, charging_records.id DESC
+                            LIMIT 1
+                        ),
+                        (
+                            SELECT charging_records.odometerKm
+                            FROM charging_records
+                            WHERE charging_records.vehicleId = vehicles.id
+                              AND charging_records.isDeleted = 0
+                              AND charging_records.odometerKm IS NOT NULL
+                            ORDER BY charging_records.chargeTimeEpochMillis DESC, charging_records.id DESC
+                            LIMIT 1
+                        ),
+                        CAST(strftime('%s','now') AS INTEGER) * 1000,
+                        'MIGRATION'
+                    FROM vehicles
+                    """.trimIndent()
+                )
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -121,7 +157,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_4_5,
                         MIGRATION_5_6,
                         MIGRATION_6_7,
-                        MIGRATION_7_8
+                        MIGRATION_7_8,
+                        MIGRATION_8_9
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
@@ -1,0 +1,23 @@
+package com.evchargebook.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "vehicle_state")
+data class VehicleStateEntity(
+    @PrimaryKey
+    val vehicleId: Long,
+    val currentSoc: Int? = null,
+    val currentMileage: Double? = null,
+    val updatedAtEpochMillis: Long = System.currentTimeMillis(),
+    val updateSource: String = VehicleStateUpdateSource.UNKNOWN.name
+)
+
+enum class VehicleStateUpdateSource {
+    UNKNOWN,
+    MIGRATION,
+    CHARGE_RECORD,
+    TRIP_END,
+    MANUAL_UPDATE,
+    IMPORT
+}

--- a/android/app/src/main/java/com/evchargebook/data/repository/VehicleStateRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/VehicleStateRepository.kt
@@ -1,0 +1,19 @@
+package com.evchargebook.data.repository
+
+import com.evchargebook.data.dao.VehicleStateDao
+import com.evchargebook.data.entity.VehicleStateEntity
+import kotlinx.coroutines.flow.Flow
+
+class VehicleStateRepository(
+    private val dao: VehicleStateDao
+) {
+    fun observe(vehicleId: Long): Flow<VehicleStateEntity?> = dao.observe(vehicleId)
+
+    suspend fun get(vehicleId: Long): VehicleStateEntity? = dao.get(vehicleId)
+
+    suspend fun getAll(): List<VehicleStateEntity> = dao.getAll()
+
+    suspend fun save(state: VehicleStateEntity) = dao.upsert(state)
+
+    suspend fun deleteAll() = dao.deleteAll()
+}

--- a/android/app/src/main/java/com/evchargebook/domain/state/VehicleStateManager.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/state/VehicleStateManager.kt
@@ -1,0 +1,57 @@
+package com.evchargebook.domain.state
+
+import com.evchargebook.data.entity.VehicleStateEntity
+import com.evchargebook.data.entity.VehicleStateUpdateSource
+import com.evchargebook.data.repository.VehicleStateRepository
+
+class VehicleStateManager(
+    private val repository: VehicleStateRepository
+) {
+    suspend fun updateAfterCharge(vehicleId: Long, endSoc: Int, odometerKm: Double? = null) {
+        require(endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = endSoc,
+            currentMileage = odometerKm,
+            source = VehicleStateUpdateSource.CHARGE_RECORD
+        )
+    }
+
+    suspend fun updateAfterTrip(vehicleId: Long, endSoc: Int?, endMileageKm: Double? = null) {
+        require(endSoc == null || endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = endSoc,
+            currentMileage = endMileageKm,
+            source = VehicleStateUpdateSource.TRIP_END
+        )
+    }
+
+    suspend fun manualUpdate(vehicleId: Long, currentSoc: Int?, currentMileageKm: Double? = null) {
+        require(currentSoc == null || currentSoc in 0..100) { "SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = currentSoc,
+            currentMileage = currentMileageKm,
+            source = VehicleStateUpdateSource.MANUAL_UPDATE
+        )
+    }
+
+    private suspend fun update(
+        vehicleId: Long,
+        currentSoc: Int?,
+        currentMileage: Double?,
+        source: VehicleStateUpdateSource
+    ) {
+        val existing = repository.get(vehicleId)
+        repository.save(
+            VehicleStateEntity(
+                vehicleId = vehicleId,
+                currentSoc = currentSoc ?: existing?.currentSoc,
+                currentMileage = currentMileage ?: existing?.currentMileage,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                updateSource = source.name
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the v0.5 vehicle-state foundation so SOC and mileage can become shared app state instead of being re-entered independently in charging and trip flows.

## Changes

- add `VehicleStateEntity` and update-source enum
- add `VehicleStateDao` and repository
- add `VehicleStateManager` for charge/trip/manual updates
- upgrade Room schema from 8 to 9
- preserve all existing migrations and indexes
- backfill state on 8 -> 9 from the latest non-deleted charging record per vehicle
- keep unknown SOC/mileage as null instead of inventing values

## Scope

Foundation only. This PR does not yet change charging or trip UI behavior.

## Next

Follow with smart charge defaults and charge-completion state updates, then trip start/end SOC integration.