### PR TITLE
fix(android): keep Trip callbacks alive while stationary

### DIFF
--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -447,7 +447,8 @@ class TripTrackingService : Service() {
         private const val CHANNEL_ID = "trip_tracking"
         private const val NOTIFICATION_ID = 2201
         private const val SAMPLE_INTERVAL_MS = 4_000L
-        private const val SAMPLE_DISTANCE_METERS = 8f
+        // Keep callback liveness time-based; TripSamplingRules owns stationary write throttling.
+        private const val SAMPLE_DISTANCE_METERS = 0f
         private const val HEALTH_REFRESH_INTERVAL_MS = 10_000L
         private const val MAX_DETAIL_LENGTH = 160
 

--- a/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
@@ -1,5 +1,6 @@
 package com.evchargebook.domain
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,6 +26,15 @@ class TripSamplingRulesTest {
         val decision = TripSamplingRules.decide(15, 1.0, 0.0, 10.0)
         assertTrue(decision.accept)
         assertFalse(decision.moving)
+    }
+
+    @Test
+    fun stationaryHeartbeatAccumulatesStoppedTime() {
+        val decision = TripSamplingRules.decide(16, 1.0, 0.0, 10.0)
+        assertTrue(decision.accept)
+        assertFalse(decision.moving)
+        assertEquals(46L, TripSamplingRules.stoppedSeconds(30L, 16L, decision.moving))
+        assertEquals(30L, TripSamplingRules.movingSeconds(30L, 16L, decision.moving))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the first minimal P0 fix from #77 using the existing foreground location service and existing Trip sampling rules.

### What changed
- remove the `8m` LocationManager displacement gate (`SAMPLE_DISTANCE_METERS = 0f`)
- keep the existing 4s request interval so stationary callbacks can still arrive
- leave database write throttling to `TripSamplingRules`, which already stores stationary heartbeats at 15s intervals
- add regression coverage proving a stationary heartbeat contributes to `stoppedSeconds` without changing `movingSeconds`

## Why

The previous two-layer configuration conflicted:

- Android service: callback required >=8m movement
- domain sampling: stationary state should be persisted every 15s

At a 2–3 minute red light, the service-level movement gate could prevent callbacks entirely, so the domain layer could not emit its stationary heartbeat. The next accepted point could then cross the existing 120s continuity threshold and look like a GPS long gap.

This PR intentionally does **not** change the 120s true-gap rule yet. With time-based callbacks restored, healthy stationary periods should remain below it through 15s persisted heartbeats. A real callback/provider starvation still remains diagnosable as a gap.

## Physical acceptance required

CI cannot prove Android background delivery. After CI is green, retest on device:

1. start Trip in foreground
2. lock screen briefly
3. unlock and switch to another app for 5–10 minutes while moving
4. stop at a traffic light for 2–3 minutes
5. resume driving and end Trip

Pass criteria:
- trusted distance continues increasing while another app is foreground
- stationary period adds meaningful `stoppedSeconds`
- stationary period is not rendered as a false LONG_GAP
- genuine provider/callback loss still becomes LOST/LONG_GAP
- stationary TripPoint writes remain throttled rather than every 4s

Closes only the implementation slice of #77; keep #77 open until physical-device acceptance passes.