### PR TITLE
fix(android): reject coarse provider spikes from Trip max speed

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -3,6 +3,8 @@ package com.evchargebook.domain
 object TripSpeedTrustRules {
     const val MIN_CORROBORATING_DISTANCE_METERS = 5.0
     private const val MIN_EXPECTED_DISTANCE_RATIO = 0.25
+    private const val MAX_PEAK_HORIZONTAL_ACCURACY_METERS = 25.0
+    private const val MAX_PEAK_SPEED_ACCURACY_MPS = 3.0
 
     fun eligibleForAggregate(
         reportedSpeedMps: Double?,
@@ -20,5 +22,32 @@ object TripSpeedTrustRules {
             expectedDistance * MIN_EXPECTED_DISTANCE_RATIO
         )
         return trustedDistanceMeters >= requiredDistance
+    }
+
+    fun eligibleForMaxSpeed(
+        reportedSpeedMps: Double?,
+        deltaSeconds: Long,
+        trustedDistanceMeters: Double,
+        continuityAllowsSpeed: Boolean,
+        provider: String?,
+        horizontalAccuracyMeters: Double?,
+        speedAccuracyMps: Double?
+    ): Boolean {
+        if (!eligibleForAggregate(reportedSpeedMps, deltaSeconds, trustedDistanceMeters, continuityAllowsSpeed)) {
+            return false
+        }
+        if (!provider.equals("gps", ignoreCase = true)) return false
+
+        val horizontalAccuracy = horizontalAccuracyMeters ?: return false
+        if (!horizontalAccuracy.isFinite() || horizontalAccuracy < 0.0 || horizontalAccuracy > MAX_PEAK_HORIZONTAL_ACCURACY_METERS) {
+            return false
+        }
+
+        if (speedAccuracyMps != null &&
+            (!speedAccuracyMps.isFinite() || speedAccuracyMps < 0.0 || speedAccuracyMps > MAX_PEAK_SPEED_ACCURACY_MPS)
+        ) {
+            return false
+        }
+        return true
     }
 }

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -251,6 +251,12 @@ class TripTrackingService : Service() {
         val trustedSegmentDistance = if (continuity.countDistance) rawSegmentDistance else 0.0
         val statsDeltaSeconds = if (continuity.countDuration) rawDeltaSeconds ?: 0 else 0
         val rawSpeed = location.speed.takeIf { location.hasSpeed() }?.toDouble()
+        val accuracy = location.accuracy.takeIf { location.hasAccuracy() }?.toDouble()
+        val speedAccuracy = if (Build.VERSION.SDK_INT >= 26 && location.hasSpeedAccuracy()) {
+            location.speedAccuracyMetersPerSecond.toDouble()
+        } else {
+            null
+        }
         val aggregateSpeed = if (
             TripSpeedTrustRules.eligibleForAggregate(
                 reportedSpeedMps = rawSpeed,
@@ -259,7 +265,17 @@ class TripTrackingService : Service() {
                 continuityAllowsSpeed = continuity.speedEligibleForAggregate
             )
         ) rawSpeed else null
-        val accuracy = location.accuracy.takeIf { location.hasAccuracy() }?.toDouble()
+        val maxSpeedCandidate = if (
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = rawSpeed,
+                deltaSeconds = statsDeltaSeconds,
+                trustedDistanceMeters = trustedSegmentDistance,
+                continuityAllowsSpeed = continuity.speedEligibleForAggregate,
+                provider = location.provider,
+                horizontalAccuracyMeters = accuracy,
+                speedAccuracyMps = speedAccuracy
+            )
+        ) rawSpeed else null
         val decision = TripSamplingRules.decide(statsDeltaSeconds, trustedSegmentDistance, aggregateSpeed, accuracy)
         if (!decision.accept) {
             rejectLocation(tripId, location.provider, "sampling_rejected")
@@ -281,7 +297,7 @@ class TripTrackingService : Service() {
             bearingDegrees = location.bearing.takeIf { location.hasBearing() }?.toDouble(),
             horizontalAccuracyMeters = accuracy,
             verticalAccuracyMeters = if (Build.VERSION.SDK_INT >= 26 && location.hasVerticalAccuracy()) location.verticalAccuracyMeters.toDouble() else null,
-            speedAccuracyMps = if (Build.VERSION.SDK_INT >= 26 && location.hasSpeedAccuracy()) location.speedAccuracyMetersPerSecond.toDouble() else null,
+            speedAccuracyMps = speedAccuracy,
             provider = location.provider
         )
         val pointId = tripDao.insertPoint(point)
@@ -297,7 +313,7 @@ class TripTrackingService : Service() {
                 movingSeconds = newMovingSeconds,
                 stoppedSeconds = newStoppedSeconds,
                 averageSpeedMps = if (newMovingSeconds > 0) newDistance / newMovingSeconds else null,
-                maxSpeedMps = listOfNotNull(session.maxSpeedMps, aggregateSpeed).maxOrNull(),
+                maxSpeedMps = listOfNotNull(session.maxSpeedMps, maxSpeedCandidate).maxOrNull(),
                 startLatitude = session.startLatitude ?: location.latitude,
                 startLongitude = session.startLongitude ?: location.longitude,
                 endLatitude = location.latitude,

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -463,7 +463,8 @@ class TripTrackingService : Service() {
         private const val CHANNEL_ID = "trip_tracking"
         private const val NOTIFICATION_ID = 2201
         private const val SAMPLE_INTERVAL_MS = 4_000L
-        private const val SAMPLE_DISTANCE_METERS = 8f
+        // Keep callback liveness time-based; TripSamplingRules owns stationary write throttling.
+        private const val SAMPLE_DISTANCE_METERS = 0f
         private const val HEALTH_REFRESH_INTERVAL_MS = 10_000L
         private const val MAX_DETAIL_LENGTH = 160
 

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -52,4 +52,49 @@ class TripSpeedTrustRulesTest {
             )
         )
     }
+
+    @Test
+    fun `network speed spike cannot update max speed even when distance corroborates it`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 34.005,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 140.0,
+                continuityAllowsSpeed = true,
+                provider = "network",
+                horizontalAccuracyMeters = 100.0,
+                speedAccuracyMps = null
+            )
+        )
+    }
+
+    @Test
+    fun `accurate gps highway peak can update max speed`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 30.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 110.0,
+                continuityAllowsSpeed = true,
+                provider = "gps",
+                horizontalAccuracyMeters = 8.0,
+                speedAccuracyMps = 1.2
+            )
+        )
+    }
+
+    @Test
+    fun `coarse gps point cannot update max speed`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 30.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 110.0,
+                continuityAllowsSpeed = true,
+                provider = "gps",
+                horizontalAccuracyMeters = 60.0,
+                speedAccuracyMps = 1.2
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Implements the P0 max-speed trust fix from #78 without deleting or rewriting raw TripPoint data.

### What changed
- add a dedicated `TripSpeedTrustRules.eligibleForMaxSpeed(...)` gate
- keep existing `eligibleForAggregate(...)` behavior for movement/sampling decisions
- only allow max-speed candidates from `gps`
- require horizontal accuracy <= 25m for a max-speed candidate
- when Android reports `speedAccuracy`, reject values worse than 3 m/s
- preserve raw `speedMps`, provider and accuracy fields in TripPoint for diagnostics/audit
- add regression coverage for the 2026-08-27 `network / 100m / 34.005m/s (~122.4km/h)` spike

## Why separate max-speed trust

Network fallback can still be useful for position continuity and movement inference. Rejecting all network locations from Trip sampling would reduce resilience. The stricter gate therefore applies only to the derived `maxSpeedMps` statistic.

## Regression cases

- [x] network 122.4 km/h point cannot update max speed even if distance appears to corroborate it
- [x] accurate GPS highway peak remains eligible
- [x] coarse GPS peak is rejected
- [x] existing aggregate/movement trust tests remain intact

## Physical acceptance

After CI is green, verify one real Trip where vehicle dashboard speed is known:
- max speed should be plausible and close to actual peak
- coarse network fallback points must not create a new max
- normal distance/moving-time behavior must remain unchanged

Closes the implementation scope of #78; keep #78 open until CI and physical-device verification are recorded.