### PR TITLE
feat(android): derive trip energy from SOC and update vehicle state

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -269,6 +269,8 @@ fun MainApp(
                     vehicleId = state.vehicle?.id ?: 0L,
                     records = state.chargingRecords,
                     batteryCapacityKwh = state.vehicle?.batteryCapacityKwh,
+                    currentSoc = state.currentSoc,
+                    currentMileageKm = state.currentMileageKm,
                     commonPlaces = state.chargingPlaceSummary.map { it.displayName },
                     onBack = { addRecord = false },
                     onSave = { location, start, end, energy, cost, type, remark, time, odometer, latitude, longitude, accuracy ->

--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -12,13 +12,15 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -29,6 +31,7 @@ import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.export.ChargingCsvExporter
 import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.ui.dashboard.DashboardScreen
 import com.evchargebook.ui.records.AddRecordScreen
 import com.evchargebook.ui.records.RecordEditScreen
@@ -104,6 +107,10 @@ fun MainApp(
     var pendingRestoreContent by remember { mutableStateOf<String?>(null) }
     var pendingResumeTripId by remember { mutableStateOf<Long?>(null) }
     var promptedConnectedAddress by remember { mutableStateOf<String?>(null) }
+    var showTripCompletion by remember { mutableStateOf(false) }
+    var tripEndSocText by remember { mutableStateOf("") }
+    var tripEndMileageText by remember { mutableStateOf("") }
+    var tripCompletionError by remember { mutableStateOf<String?>(null) }
 
     fun showBluetoothTripPrompt(message: String) {
         viewModel.closeTripDetail()
@@ -211,6 +218,17 @@ fun MainApp(
             pendingResumeTripId = tripId
             tripLocationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
         }
+    }
+
+    fun requestTripCompletion() {
+        val active = state.activeTrip ?: return
+        tripEndSocText = ""
+        tripEndMileageText = active.startMileageKm
+            ?.plus(active.distanceMeters / 1000.0)
+            ?.let { String.format(Locale.US, "%.1f", it) }
+            .orEmpty()
+        tripCompletionError = null
+        showTripCompletion = true
     }
 
     val hasOverlayPage = editVehicle || addVehicle || selectCatalogVehicle || bluetoothPrompt || addRecord || editingRecord != null || state.selectedTripId != null
@@ -324,7 +342,7 @@ fun MainApp(
                         selectedTripPoints = state.selectedTripPoints,
                         onStart = ::startTripWithPermission,
                         onResume = ::resumeTripWithPermission,
-                        onStop = viewModel::stopTrip,
+                        onStop = ::requestTripCompletion,
                         onOpenDetail = viewModel::openTripDetail,
                         onCloseDetail = viewModel::closeTripDetail,
                         onDelete = viewModel::deleteTrip
@@ -374,5 +392,85 @@ fun MainApp(
             confirmButton = { TextButton(onClick = { pendingRestoreContent = null; viewModel.restoreBackup(content) }) { Text("确认恢复", color = MaterialTheme.colorScheme.error) } },
             dismissButton = { TextButton(onClick = { pendingRestoreContent = null }) { Text("取消") } }
         )
+    }
+
+    if (showTripCompletion) {
+        val active = state.activeTrip
+        if (active == null) {
+            showTripCompletion = false
+        } else {
+            val tripVehicle = state.vehicles.firstOrNull { it.id == active.vehicleId } ?: state.vehicle
+            val endSoc = tripEndSocText.toIntOrNull()
+            val estimate = TripEnergyCalculator.estimate(
+                batteryCapacityKwh = tripVehicle?.batteryCapacityKwh,
+                startSoc = active.startSoc,
+                endSoc = endSoc,
+                distanceMeters = active.distanceMeters
+            )
+            AlertDialog(
+                onDismissRequest = { showTripCompletion = false },
+                title = { Text("完成本次行程") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text(
+                            "开始 SOC ${active.startSoc?.let { "$it%" } ?: "未知"} · GPS 距离 ${String.format(Locale.US, "%.1f", active.distanceMeters / 1000.0)} km",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        OutlinedTextField(
+                            value = tripEndSocText,
+                            onValueChange = { tripEndSocText = it.filter(Char::isDigit).take(3); tripCompletionError = null },
+                            label = { Text("结束 SOC") },
+                            suffix = { Text("%") },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        OutlinedTextField(
+                            value = tripEndMileageText,
+                            onValueChange = { tripEndMileageText = it; tripCompletionError = null },
+                            label = { Text("结束总里程") },
+                            suffix = { Text("km") },
+                            supportingText = { Text("已按开始里程 + GPS 距离预填，可修改；留空则保存时自动估算") },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        if (estimate.consumedEnergyKwh != null) {
+                            HorizontalDivider()
+                            Text(
+                                "SOC ${active.startSoc}% → ${endSoc}% · 消耗约 ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                estimate.averageConsumptionKwhPer100Km?.let { "平均能耗 ${String.format(Locale.US, "%.1f", it)} kWh/100km" }
+                                    ?: "距离不足，暂不能计算平均能耗",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                        tripCompletionError?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        val parsedSoc = tripEndSocText.toIntOrNull()
+                        val parsedMileage = tripEndMileageText.toDoubleOrNull()
+                        tripCompletionError = when {
+                            parsedSoc == null || parsedSoc !in 0..100 -> "请输入 0~100 的结束 SOC"
+                            active.startSoc != null && parsedSoc > active.startSoc -> "结束 SOC 不能高于开始 SOC"
+                            tripEndMileageText.isNotBlank() && (parsedMileage == null || parsedMileage < 0.0) -> "请输入有效的结束总里程"
+                            active.startMileageKm != null && parsedMileage != null && parsedMileage < active.startMileageKm -> "结束里程不能低于开始里程"
+                            else -> null
+                        }
+                        if (tripCompletionError == null) {
+                            showTripCompletion = false
+                            viewModel.stopTrip(parsedSoc!!, parsedMileage)
+                        }
+                    }) { Text("保存并结束") }
+                },
+                dismissButton = { TextButton(onClick = { showTripCompletion = false }) { Text("继续行驶") } }
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.core.content.ContextCompat
 import com.evchargebook.bluetooth.BluetoothConnectionStateChecker
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.export.ChargingCsvExporter
 import com.evchargebook.data.repository.ChargingRepository
 import com.evchargebook.domain.trip.TripEnergyCalculator
@@ -38,6 +39,7 @@ import com.evchargebook.ui.records.RecordEditScreen
 import com.evchargebook.ui.records.RecordsScreen
 import com.evchargebook.ui.stats.StatsScreen
 import com.evchargebook.ui.theme.EvChargeTheme
+import com.evchargebook.ui.trip.TripReadyScreen
 import com.evchargebook.ui.trip.TripScreen
 import com.evchargebook.ui.vehicle.BluetoothPromptScreen
 import com.evchargebook.ui.vehicle.VehicleCatalogScreen
@@ -333,20 +335,33 @@ fun MainApp(
                     0 -> DashboardScreen(state, { addRecord = true }, viewModel::selectVehicle)
                     1 -> RecordsScreen(state.chargingRecords, viewModel::deleteChargingRecord, { addRecord = true }, { editingRecord = it })
                     2 -> StatsScreen(state)
-                    3 -> TripScreen(
-                        vehicle = state.vehicle,
-                        vehicles = state.vehicles,
-                        trips = state.trips,
-                        activeTrip = state.activeTrip,
-                        selectedTripId = state.selectedTripId,
-                        selectedTripPoints = state.selectedTripPoints,
-                        onStart = ::startTripWithPermission,
-                        onResume = ::resumeTripWithPermission,
-                        onStop = ::requestTripCompletion,
-                        onOpenDetail = viewModel::openTripDetail,
-                        onCloseDetail = viewModel::closeTripDetail,
-                        onDelete = viewModel::deleteTrip
-                    )
+                    3 -> {
+                        if (state.activeTrip == null && state.selectedTripId == null) {
+                            TripReadyScreen(
+                                vehicle = state.vehicle,
+                                currentSoc = state.currentSoc,
+                                currentMileageKm = state.currentMileageKm,
+                                recentTrips = state.trips.filter { it.status == TripStatus.COMPLETED },
+                                onStart = ::startTripWithPermission,
+                                onOpenDetail = viewModel::openTripDetail
+                            )
+                        } else {
+                            TripScreen(
+                                vehicle = state.vehicle,
+                                vehicles = state.vehicles,
+                                trips = state.trips,
+                                activeTrip = state.activeTrip,
+                                selectedTripId = state.selectedTripId,
+                                selectedTripPoints = state.selectedTripPoints,
+                                onStart = ::startTripWithPermission,
+                                onResume = ::resumeTripWithPermission,
+                                onStop = ::requestTripCompletion,
+                                onOpenDetail = viewModel::openTripDetail,
+                                onCloseDetail = viewModel::closeTripDetail,
+                                onDelete = viewModel::deleteTrip
+                            )
+                        }
+                    }
                     4 -> VehicleScreen(
                         vehicle = state.vehicle,
                         vehicles = state.vehicles,

--- a/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
+++ b/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
@@ -20,7 +20,7 @@ data class BackupPayload(
 )
 
 object BackupCodec {
-    const val CURRENT_SCHEMA_VERSION = 6
+    const val CURRENT_SCHEMA_VERSION = 7
 
     fun encode(payload: BackupPayload): String = JSONObject().apply {
         put("schemaVersion", payload.schemaVersion)
@@ -87,6 +87,12 @@ object BackupCodec {
                     putNullable("endAltitudeMeters", trip.endAltitudeMeters)
                     putNullable("minAltitudeMeters", trip.minAltitudeMeters)
                     putNullable("maxAltitudeMeters", trip.maxAltitudeMeters)
+                    putNullable("startSoc", trip.startSoc)
+                    putNullable("endSoc", trip.endSoc)
+                    putNullable("startMileageKm", trip.startMileageKm)
+                    putNullable("endMileageKm", trip.endMileageKm)
+                    putNullable("consumedEnergyKwh", trip.consumedEnergyKwh)
+                    putNullable("averageConsumptionKwhPer100Km", trip.averageConsumptionKwhPer100Km)
                     put("status", trip.status)
                 })
             }
@@ -195,6 +201,12 @@ object BackupCodec {
                         endAltitudeMeters = item.optNullableDouble("endAltitudeMeters"),
                         minAltitudeMeters = item.optNullableDouble("minAltitudeMeters"),
                         maxAltitudeMeters = item.optNullableDouble("maxAltitudeMeters"),
+                        startSoc = item.optNullableInt("startSoc"),
+                        endSoc = item.optNullableInt("endSoc"),
+                        startMileageKm = item.optNullableDouble("startMileageKm"),
+                        endMileageKm = item.optNullableDouble("endMileageKm"),
+                        consumedEnergyKwh = item.optNullableDouble("consumedEnergyKwh"),
+                        averageConsumptionKwhPer100Km = item.optNullableDouble("averageConsumptionKwhPer100Km"),
                         status = item.optString("status", TripStatus.COMPLETED)
                     )
                 )
@@ -236,6 +248,8 @@ object BackupCodec {
         require(sessions.all { it.vehicleId in vehicleIds }) { "备份中存在无法关联车辆的行程" }
         require(sessions.all { it.status in setOf(TripStatus.RECORDING, TripStatus.INTERRUPTED, TripStatus.COMPLETED) }) { "备份中存在未知行程状态" }
         require(sessions.all { (it.startLatitude == null) == (it.startLongitude == null) && (it.endLatitude == null) == (it.endLongitude == null) }) { "备份中存在不完整的行程坐标" }
+        require(sessions.all { it.startSoc == null || it.startSoc in 0..100 }) { "备份中存在无效行程开始 SOC" }
+        require(sessions.all { it.endSoc == null || it.endSoc in 0..100 }) { "备份中存在无效行程结束 SOC" }
         require(points.all { it.tripId in tripIds }) { "备份中存在无法关联行程的轨迹点" }
 
         return BackupPayload(
@@ -261,4 +275,7 @@ object BackupCodec {
 
     private fun JSONObject.optNullableLong(name: String): Long? =
         if (!has(name) || isNull(name)) null else getLong(name)
+
+    private fun JSONObject.optNullableInt(name: String): Int? =
+        if (!has(name) || isNull(name)) null else getInt(name)
 }

--- a/android/app/src/main/java/com/evchargebook/data/dao/ChargingRecordDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/ChargingRecordDao.kt
@@ -16,6 +16,12 @@ interface ChargingRecordDao {
     @Query("SELECT * FROM charging_records WHERE vehicleId = :vehicleId AND isDeleted = 0 ORDER BY chargeTimeEpochMillis DESC")
     fun observeForVehicle(vehicleId: Long): Flow<List<ChargingRecordEntity>>
 
+    @Query("SELECT * FROM charging_records WHERE vehicleId = :vehicleId AND isDeleted = 0 ORDER BY chargeTimeEpochMillis DESC, id DESC LIMIT 1")
+    suspend fun getLatestForVehicle(vehicleId: Long): ChargingRecordEntity?
+
+    @Query("SELECT * FROM charging_records WHERE vehicleId = :vehicleId AND isDeleted = 0 AND odometerKm IS NOT NULL ORDER BY chargeTimeEpochMillis DESC, id DESC LIMIT 1")
+    suspend fun getLatestWithOdometerForVehicle(vehicleId: Long): ChargingRecordEntity?
+
     @Query("SELECT * FROM charging_records ORDER BY id")
     suspend fun getAll(): List<ChargingRecordEntity>
 

--- a/android/app/src/main/java/com/evchargebook/data/dao/VehicleStateDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/VehicleStateDao.kt
@@ -1,0 +1,26 @@
+package com.evchargebook.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.evchargebook.data.entity.VehicleStateEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface VehicleStateDao {
+    @Query("SELECT * FROM vehicle_state WHERE vehicleId = :vehicleId")
+    fun observe(vehicleId: Long): Flow<VehicleStateEntity?>
+
+    @Query("SELECT * FROM vehicle_state WHERE vehicleId = :vehicleId")
+    suspend fun get(vehicleId: Long): VehicleStateEntity?
+
+    @Query("SELECT * FROM vehicle_state ORDER BY vehicleId")
+    suspend fun getAll(): List<VehicleStateEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(state: VehicleStateEntity)
+
+    @Query("DELETE FROM vehicle_state")
+    suspend fun deleteAll()
+}

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -10,12 +10,14 @@ import com.evchargebook.data.dao.ChargingRecordDao
 import com.evchargebook.data.dao.TripDao
 import com.evchargebook.data.dao.VehicleDao
 import com.evchargebook.data.dao.VehicleCatalogDao
+import com.evchargebook.data.dao.VehicleStateDao
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.TripDiagnosticEventEntity
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.data.entity.VehicleStateEntity
 
 @Database(
     entities = [
@@ -24,9 +26,10 @@ import com.evchargebook.data.entity.VehicleEntity
         VehicleCatalogEntity::class,
         TripSessionEntity::class,
         TripPointEntity::class,
-        TripDiagnosticEventEntity::class
+        TripDiagnosticEventEntity::class,
+        VehicleStateEntity::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,6 +37,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun vehicleCatalogDao(): VehicleCatalogDao
     abstract fun chargingRecordDao(): ChargingRecordDao
     abstract fun tripDao(): TripDao
+    abstract fun vehicleStateDao(): VehicleStateDao
 
     companion object {
         private val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -104,6 +108,38 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE TABLE IF NOT EXISTS vehicle_state (vehicleId INTEGER NOT NULL, currentSoc INTEGER, currentMileage REAL, updatedAtEpochMillis INTEGER NOT NULL, updateSource TEXT NOT NULL, PRIMARY KEY(vehicleId))")
+                db.execSQL(
+                    """
+                    INSERT OR REPLACE INTO vehicle_state (vehicleId, currentSoc, currentMileage, updatedAtEpochMillis, updateSource)
+                    SELECT
+                        vehicles.id,
+                        (
+                            SELECT charging_records.endSoc
+                            FROM charging_records
+                            WHERE charging_records.vehicleId = vehicles.id AND charging_records.isDeleted = 0
+                            ORDER BY charging_records.chargeTimeEpochMillis DESC, charging_records.id DESC
+                            LIMIT 1
+                        ),
+                        (
+                            SELECT charging_records.odometerKm
+                            FROM charging_records
+                            WHERE charging_records.vehicleId = vehicles.id
+                              AND charging_records.isDeleted = 0
+                              AND charging_records.odometerKm IS NOT NULL
+                            ORDER BY charging_records.chargeTimeEpochMillis DESC, charging_records.id DESC
+                            LIMIT 1
+                        ),
+                        CAST(strftime('%s','now') AS INTEGER) * 1000,
+                        'MIGRATION'
+                    FROM vehicles
+                    """.trimIndent()
+                )
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -121,7 +157,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_4_5,
                         MIGRATION_5_6,
                         MIGRATION_6_7,
-                        MIGRATION_7_8
+                        MIGRATION_7_8,
+                        MIGRATION_8_9
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -29,7 +29,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
         TripDiagnosticEventEntity::class,
         VehicleStateEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -140,6 +140,17 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN startSoc INTEGER")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN endSoc INTEGER")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN startMileageKm REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN endMileageKm REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN consumedEnergyKwh REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN averageConsumptionKwhPer100Km REAL")
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -158,7 +169,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_5_6,
                         MIGRATION_6_7,
                         MIGRATION_7_8,
-                        MIGRATION_8_9
+                        MIGRATION_8_9,
+                        MIGRATION_9_10
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/entity/TripSessionEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/TripSessionEntity.kt
@@ -34,5 +34,11 @@ data class TripSessionEntity(
     val endAltitudeMeters: Double? = null,
     val minAltitudeMeters: Double? = null,
     val maxAltitudeMeters: Double? = null,
+    val startSoc: Int? = null,
+    val endSoc: Int? = null,
+    val startMileageKm: Double? = null,
+    val endMileageKm: Double? = null,
+    val consumedEnergyKwh: Double? = null,
+    val averageConsumptionKwhPer100Km: Double? = null,
     val status: String = TripStatus.RECORDING
 )

--- a/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
@@ -1,0 +1,23 @@
+package com.evchargebook.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "vehicle_state")
+data class VehicleStateEntity(
+    @PrimaryKey
+    val vehicleId: Long,
+    val currentSoc: Int? = null,
+    val currentMileage: Double? = null,
+    val updatedAtEpochMillis: Long = System.currentTimeMillis(),
+    val updateSource: String = VehicleStateUpdateSource.UNKNOWN.name
+)
+
+enum class VehicleStateUpdateSource {
+    UNKNOWN,
+    MIGRATION,
+    CHARGE_RECORD,
+    TRIP_END,
+    MANUAL_UPDATE,
+    IMPORT
+}

--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
@@ -18,6 +18,8 @@ import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.data.entity.VehicleStateEntity
+import com.evchargebook.data.entity.VehicleStateUpdateSource
 import com.evchargebook.domain.ChargingRecordRules
 import com.evchargebook.domain.TripRules
 import com.evchargebook.trip.TripTrackingService
@@ -39,6 +41,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
     private val vehicleCatalogDao = database.vehicleCatalogDao()
     private val chargingRecordDao = database.chargingRecordDao()
     private val tripDao = database.tripDao()
+    private val vehicleStateDao = database.vehicleStateDao()
     private val bluetoothPreferences = BluetoothPromptPreferences(context)
 
     val vehicles: Flow<List<VehicleEntity>> = vehicleDao.observeActive()
@@ -47,6 +50,9 @@ class ChargingRepository(private val database: AppDatabase, private val context:
     private val selectedVehicleId: Flow<Long?> = context.vehicleSelectionDataStore.data.map { it[selectedVehicleIdKey] }
     val vehicle: Flow<VehicleEntity?> = combine(vehicles, selectedVehicleId) { vehicles, selectedId ->
         vehicles.firstOrNull { it.id == selectedId } ?: vehicles.firstOrNull { it.isDefault } ?: vehicles.firstOrNull()
+    }
+    val vehicleState: Flow<VehicleStateEntity?> = vehicle.flatMapLatest { selected ->
+        selected?.let { vehicleStateDao.observe(it.id) } ?: flowOf(null)
     }
     val chargingRecords: Flow<List<ChargingRecordEntity>> = vehicle.flatMapLatest { selected ->
         selected?.let { chargingRecordDao.observeForVehicle(it.id) } ?: flowOf(emptyList())
@@ -63,11 +69,13 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         val activeVehicles = vehicles.first()
         if (activeVehicles.isEmpty()) {
             val id = vehicleDao.insert(VehicleEntity(brand = "零跑", model = "C16 2026款", batteryCapacityKwh = 67.7, rangeKm = 520, isDefault = true))
+            ensureVehicleState(id)
             selectVehicle(id)
         } else {
             val defaultVehicle = activeVehicles.firstOrNull { it.isDefault } ?: activeVehicles.first()
             if (!defaultVehicle.isDefault) vehicleDao.setDefault(defaultVehicle.id)
             if (selectedVehicleId.first() !in activeVehicles.map { it.id }) selectVehicle(defaultVehicle.id)
+            activeVehicles.forEach { ensureVehicleState(it.id) }
         }
     }
 
@@ -96,11 +104,13 @@ class ChargingRepository(private val database: AppDatabase, private val context:
             require(tripDao.getActive() == null) { "请先结束当前行程，再恢复备份" }
             tripDao.deleteAllSessions()
             chargingRecordDao.deleteAll()
+            vehicleStateDao.deleteAll()
             vehicleDao.deleteAll()
             vehicleDao.insertAll(payload.vehicles)
             chargingRecordDao.insertAll(payload.chargingRecords)
             tripDao.insertSessions(payload.tripSessions)
             tripDao.insertPoints(payload.tripPoints)
+            payload.vehicles.forEach { rebuildVehicleStateFromChargingRecords(it.id, VehicleStateUpdateSource.IMPORT) }
             require(vehicleDao.getAll().size == payload.vehicles.size) { "车辆恢复数量校验失败" }
             require(chargingRecordDao.getAll().size == payload.chargingRecords.size) { "充电记录恢复数量校验失败" }
             require(tripDao.getAllSessions().size == payload.tripSessions.size) { "行程恢复数量校验失败" }
@@ -172,39 +182,54 @@ class ChargingRepository(private val database: AppDatabase, private val context:
     ) {
         ChargingRecordRules.validate(startSoc, endSoc, energyKwh, cost, odometerKm)
         require((latitude == null) == (longitude == null)) { "定位坐标不完整" }
-        chargingRecordDao.insert(
-            ChargingRecordEntity(
-                vehicleId = vehicleId,
-                chargeTimeEpochMillis = chargeTimeEpochMillis,
-                startSoc = startSoc,
-                endSoc = endSoc,
-                energyKwh = energyKwh,
-                cost = cost,
-                location = location?.trim()?.takeIf { it.isNotEmpty() },
-                chargerType = chargerType,
-                remark = remark?.trim()?.takeIf { it.isNotEmpty() },
-                odometerKm = odometerKm,
-                latitude = latitude,
-                longitude = longitude,
-                locationAccuracyMeters = locationAccuracyMeters
+        database.withTransaction {
+            chargingRecordDao.insert(
+                ChargingRecordEntity(
+                    vehicleId = vehicleId,
+                    chargeTimeEpochMillis = chargeTimeEpochMillis,
+                    startSoc = startSoc,
+                    endSoc = endSoc,
+                    energyKwh = energyKwh,
+                    cost = cost,
+                    location = location?.trim()?.takeIf { it.isNotEmpty() },
+                    chargerType = chargerType,
+                    remark = remark?.trim()?.takeIf { it.isNotEmpty() },
+                    odometerKm = odometerKm,
+                    latitude = latitude,
+                    longitude = longitude,
+                    locationAccuracyMeters = locationAccuracyMeters
+                )
             )
-        )
+            writeChargeState(vehicleId, endSoc, odometerKm)
+        }
     }
 
     suspend fun deleteChargingRecord(record: ChargingRecordEntity) {
-        chargingRecordDao.markDeleted(record.id, System.currentTimeMillis())
+        database.withTransaction {
+            chargingRecordDao.markDeleted(record.id, System.currentTimeMillis())
+            val state = vehicleStateDao.get(record.vehicleId)
+            if (state?.updateSource == VehicleStateUpdateSource.CHARGE_RECORD.name) {
+                rebuildVehicleStateFromChargingRecords(record.vehicleId, VehicleStateUpdateSource.CHARGE_RECORD)
+            }
+        }
     }
 
     suspend fun updateChargingRecord(record: ChargingRecordEntity) {
         ChargingRecordRules.validate(record.startSoc, record.endSoc, record.energyKwh, record.cost, record.odometerKm)
         require((record.latitude == null) == (record.longitude == null)) { "定位坐标不完整" }
-        chargingRecordDao.update(
-            record.copy(
-                location = record.location?.trim()?.takeIf { it.isNotEmpty() },
-                remark = record.remark?.trim()?.takeIf { it.isNotEmpty() },
-                updatedAtEpochMillis = System.currentTimeMillis()
+        database.withTransaction {
+            chargingRecordDao.update(
+                record.copy(
+                    location = record.location?.trim()?.takeIf { it.isNotEmpty() },
+                    remark = record.remark?.trim()?.takeIf { it.isNotEmpty() },
+                    updatedAtEpochMillis = System.currentTimeMillis()
+                )
             )
-        )
+            val state = vehicleStateDao.get(record.vehicleId)
+            if (state?.updateSource == VehicleStateUpdateSource.CHARGE_RECORD.name) {
+                rebuildVehicleStateFromChargingRecords(record.vehicleId, VehicleStateUpdateSource.CHARGE_RECORD)
+            }
+        }
     }
 
     suspend fun saveVehicle(vehicle: VehicleEntity) {
@@ -217,6 +242,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         val vehicle = VehicleEntity(catalogVehicleId = catalogVehicleId, brand = brand.trim(), model = model.trim(), batteryCapacityKwh = battery, rangeKm = range)
         validateVehicle(vehicle)
         val id = vehicleDao.insert(vehicle)
+        ensureVehicleState(id)
         selectVehicle(id)
     }
 
@@ -245,6 +271,39 @@ class ChargingRepository(private val database: AppDatabase, private val context:
     }.getOrDefault(emptyList())
 
     suspend fun saveBluetoothPrompt(enabled: Boolean, deviceAddress: String?, deviceName: String?) = bluetoothPreferences.save(enabled, deviceAddress, deviceName)
+
+    private suspend fun ensureVehicleState(vehicleId: Long) {
+        if (vehicleStateDao.get(vehicleId) == null) {
+            vehicleStateDao.upsert(VehicleStateEntity(vehicleId = vehicleId))
+        }
+    }
+
+    private suspend fun writeChargeState(vehicleId: Long, endSoc: Int, odometerKm: Double?) {
+        val existing = vehicleStateDao.get(vehicleId)
+        vehicleStateDao.upsert(
+            VehicleStateEntity(
+                vehicleId = vehicleId,
+                currentSoc = endSoc,
+                currentMileage = odometerKm ?: existing?.currentMileage,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                updateSource = VehicleStateUpdateSource.CHARGE_RECORD.name
+            )
+        )
+    }
+
+    private suspend fun rebuildVehicleStateFromChargingRecords(vehicleId: Long, source: VehicleStateUpdateSource) {
+        val latest = chargingRecordDao.getLatestForVehicle(vehicleId)
+        val latestWithOdometer = chargingRecordDao.getLatestWithOdometerForVehicle(vehicleId)
+        vehicleStateDao.upsert(
+            VehicleStateEntity(
+                vehicleId = vehicleId,
+                currentSoc = latest?.endSoc,
+                currentMileage = latestWithOdometer?.odometerKm,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                updateSource = if (latest == null && latestWithOdometer == null) VehicleStateUpdateSource.UNKNOWN.name else source.name
+            )
+        )
+    }
 
     private fun validateVehicle(vehicle: VehicleEntity) {
         require(vehicle.brand.isNotBlank()) { "品牌不能为空" }

--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
@@ -22,6 +22,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
 import com.evchargebook.data.entity.VehicleStateUpdateSource
 import com.evchargebook.domain.ChargingRecordRules
 import com.evchargebook.domain.TripRules
+import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.trip.TripTrackingService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -120,9 +121,19 @@ class ChargingRepository(private val database: AppDatabase, private val context:
 
     suspend fun startTrip(vehicleId: Long, startedAtEpochMillis: Long = System.currentTimeMillis()): Long {
         val tripId = database.withTransaction {
-            require(vehicleDao.observeActive().first().any { it.id == vehicleId }) { "当前车辆不可用" }
+            val selectedVehicle = vehicleDao.observeActive().first().firstOrNull { it.id == vehicleId }
+                ?: error("当前车辆不可用")
             TripRules.requireCanStart(tripDao.getActive() != null)
-            tripDao.insertSession(TripSessionEntity(vehicleId = vehicleId, startedAtEpochMillis = startedAtEpochMillis, status = TripStatus.RECORDING))
+            val state = vehicleStateDao.get(vehicleId)
+            tripDao.insertSession(
+                TripSessionEntity(
+                    vehicleId = selectedVehicle.id,
+                    startedAtEpochMillis = startedAtEpochMillis,
+                    startSoc = state?.currentSoc,
+                    startMileageKm = state?.currentMileage,
+                    status = TripStatus.RECORDING
+                )
+            )
         }
         startTrackingOrInterrupt(tripId)
         return tripId
@@ -152,10 +163,49 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         }
     }
 
-    suspend fun stopActiveTrip(endedAtEpochMillis: Long = System.currentTimeMillis()) {
+    suspend fun stopActiveTrip(
+        endSoc: Int,
+        endMileageKm: Double? = null,
+        endedAtEpochMillis: Long = System.currentTimeMillis()
+    ) {
+        require(endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
         database.withTransaction {
             val active = tripDao.getActive() ?: error("当前没有进行中的行程")
-            tripDao.updateSession(active.copy(endedAtEpochMillis = endedAtEpochMillis, elapsedSeconds = TripRules.elapsedSeconds(active.startedAtEpochMillis, endedAtEpochMillis), status = TripStatus.COMPLETED))
+            if (active.startSoc != null) require(endSoc <= active.startSoc) { "结束 SOC 不能高于开始 SOC" }
+            require(endMileageKm == null || endMileageKm >= 0.0) { "结束里程不能小于 0" }
+            if (active.startMileageKm != null && endMileageKm != null) {
+                require(endMileageKm >= active.startMileageKm) { "结束里程不能低于开始里程" }
+            }
+
+            val selectedVehicle = vehicleDao.observeActive().first().firstOrNull { it.id == active.vehicleId }
+                ?: error("行程车辆不可用")
+            val derivedEndMileage = endMileageKm ?: active.startMileageKm?.plus(active.distanceMeters / 1000.0)
+            val estimate = TripEnergyCalculator.estimate(
+                batteryCapacityKwh = selectedVehicle.batteryCapacityKwh,
+                startSoc = active.startSoc,
+                endSoc = endSoc,
+                distanceMeters = active.distanceMeters
+            )
+            tripDao.updateSession(
+                active.copy(
+                    endedAtEpochMillis = endedAtEpochMillis,
+                    elapsedSeconds = TripRules.elapsedSeconds(active.startedAtEpochMillis, endedAtEpochMillis),
+                    endSoc = endSoc,
+                    endMileageKm = derivedEndMileage,
+                    consumedEnergyKwh = estimate.consumedEnergyKwh,
+                    averageConsumptionKwhPer100Km = estimate.averageConsumptionKwhPer100Km,
+                    status = TripStatus.COMPLETED
+                )
+            )
+            vehicleStateDao.upsert(
+                VehicleStateEntity(
+                    vehicleId = active.vehicleId,
+                    currentSoc = endSoc,
+                    currentMileage = derivedEndMileage,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                    updateSource = VehicleStateUpdateSource.TRIP_END.name
+                )
+            )
         }
         TripTrackingService.stop(context)
     }

--- a/android/app/src/main/java/com/evchargebook/data/repository/VehicleStateRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/VehicleStateRepository.kt
@@ -1,0 +1,19 @@
+package com.evchargebook.data.repository
+
+import com.evchargebook.data.dao.VehicleStateDao
+import com.evchargebook.data.entity.VehicleStateEntity
+import kotlinx.coroutines.flow.Flow
+
+class VehicleStateRepository(
+    private val dao: VehicleStateDao
+) {
+    fun observe(vehicleId: Long): Flow<VehicleStateEntity?> = dao.observe(vehicleId)
+
+    suspend fun get(vehicleId: Long): VehicleStateEntity? = dao.get(vehicleId)
+
+    suspend fun getAll(): List<VehicleStateEntity> = dao.getAll()
+
+    suspend fun save(state: VehicleStateEntity) = dao.upsert(state)
+
+    suspend fun deleteAll() = dao.deleteAll()
+}

--- a/android/app/src/main/java/com/evchargebook/domain/charge/ChargeDefaults.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/charge/ChargeDefaults.kt
@@ -1,0 +1,41 @@
+package com.evchargebook.domain.charge
+
+import com.evchargebook.data.entity.ChargingRecordEntity
+
+data class ChargeDefaults(
+    val startSoc: Int?,
+    val endSoc: Int,
+    val chargerType: String,
+    val pricePerKwh: Double?,
+    val location: String?
+)
+
+object ChargeDefaultResolver {
+    private const val FALLBACK_END_SOC = 100
+    const val FALLBACK_CHARGER_TYPE = "公共慢充"
+
+    fun resolve(
+        currentSoc: Int?,
+        records: List<ChargingRecordEntity>,
+        chargerType: String? = null
+    ): ChargeDefaults {
+        val latest = records.firstOrNull { !it.isDeleted }
+        val resolvedType = chargerType ?: latest?.chargerType ?: FALLBACK_CHARGER_TYPE
+        val sameType = records.firstOrNull { !it.isDeleted && it.chargerType == resolvedType }
+        val priceSource = sameType ?: latest
+
+        return ChargeDefaults(
+            startSoc = currentSoc ?: latest?.endSoc,
+            endSoc = latest?.endSoc ?: FALLBACK_END_SOC,
+            chargerType = resolvedType,
+            pricePerKwh = priceSource?.takeIf { it.energyKwh > 0.0 }?.pricePerKwh,
+            location = sameType?.location ?: latest?.location
+        )
+    }
+
+    fun priceForType(records: List<ChargingRecordEntity>, chargerType: String): Double? {
+        return records
+            .firstOrNull { !it.isDeleted && it.chargerType == chargerType && it.energyKwh > 0.0 }
+            ?.pricePerKwh
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/domain/charge/ChargeEnergyCalculator.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/charge/ChargeEnergyCalculator.kt
@@ -1,0 +1,46 @@
+package com.evchargebook.domain.charge
+
+data class ChargeEnergyEstimate(
+    val receivedEnergyKwh: Double?,
+    val chargedEnergyKwh: Double?,
+    val lossEnergyKwh: Double?,
+    val lossRate: Double?
+)
+
+object ChargeEnergyCalculator {
+    fun estimate(
+        batteryCapacityKwh: Double?,
+        startSoc: Int?,
+        endSoc: Int?,
+        chargedEnergyKwh: Double?
+    ): ChargeEnergyEstimate {
+        val received = if (
+            batteryCapacityKwh != null && batteryCapacityKwh > 0.0 &&
+            startSoc != null && endSoc != null &&
+            startSoc in 0..100 && endSoc in 0..100 && endSoc >= startSoc
+        ) {
+            batteryCapacityKwh * (endSoc - startSoc) / 100.0
+        } else {
+            null
+        }
+
+        val loss = if (chargedEnergyKwh != null && chargedEnergyKwh >= 0.0 && received != null) {
+            (chargedEnergyKwh - received).coerceAtLeast(0.0)
+        } else {
+            null
+        }
+
+        val lossRate = if (loss != null && chargedEnergyKwh != null && chargedEnergyKwh > 0.0) {
+            loss / chargedEnergyKwh
+        } else {
+            null
+        }
+
+        return ChargeEnergyEstimate(
+            receivedEnergyKwh = received,
+            chargedEnergyKwh = chargedEnergyKwh,
+            lossEnergyKwh = loss,
+            lossRate = lossRate
+        )
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/domain/state/VehicleStateManager.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/state/VehicleStateManager.kt
@@ -1,0 +1,57 @@
+package com.evchargebook.domain.state
+
+import com.evchargebook.data.entity.VehicleStateEntity
+import com.evchargebook.data.entity.VehicleStateUpdateSource
+import com.evchargebook.data.repository.VehicleStateRepository
+
+class VehicleStateManager(
+    private val repository: VehicleStateRepository
+) {
+    suspend fun updateAfterCharge(vehicleId: Long, endSoc: Int, odometerKm: Double? = null) {
+        require(endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = endSoc,
+            currentMileage = odometerKm,
+            source = VehicleStateUpdateSource.CHARGE_RECORD
+        )
+    }
+
+    suspend fun updateAfterTrip(vehicleId: Long, endSoc: Int?, endMileageKm: Double? = null) {
+        require(endSoc == null || endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = endSoc,
+            currentMileage = endMileageKm,
+            source = VehicleStateUpdateSource.TRIP_END
+        )
+    }
+
+    suspend fun manualUpdate(vehicleId: Long, currentSoc: Int?, currentMileageKm: Double? = null) {
+        require(currentSoc == null || currentSoc in 0..100) { "SOC 必须在 0 到 100 之间" }
+        update(
+            vehicleId = vehicleId,
+            currentSoc = currentSoc,
+            currentMileage = currentMileageKm,
+            source = VehicleStateUpdateSource.MANUAL_UPDATE
+        )
+    }
+
+    private suspend fun update(
+        vehicleId: Long,
+        currentSoc: Int?,
+        currentMileage: Double?,
+        source: VehicleStateUpdateSource
+    ) {
+        val existing = repository.get(vehicleId)
+        repository.save(
+            VehicleStateEntity(
+                vehicleId = vehicleId,
+                currentSoc = currentSoc ?: existing?.currentSoc,
+                currentMileage = currentMileage ?: existing?.currentMileage,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                updateSource = source.name
+            )
+        )
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
@@ -1,0 +1,37 @@
+package com.evchargebook.domain.trip
+
+data class TripEnergyEstimate(
+    val consumedEnergyKwh: Double?,
+    val averageConsumptionKwhPer100Km: Double?
+)
+
+object TripEnergyCalculator {
+    fun estimate(
+        batteryCapacityKwh: Double?,
+        startSoc: Int?,
+        endSoc: Int?,
+        distanceMeters: Double
+    ): TripEnergyEstimate {
+        val consumed = if (
+            batteryCapacityKwh != null && batteryCapacityKwh > 0.0 &&
+            startSoc != null && endSoc != null &&
+            startSoc in 0..100 && endSoc in 0..100 &&
+            endSoc <= startSoc
+        ) {
+            batteryCapacityKwh * (startSoc - endSoc) / 100.0
+        } else {
+            null
+        }
+
+        val average = if (consumed != null && distanceMeters > 0.0) {
+            consumed / (distanceMeters / 1000.0) * 100.0
+        } else {
+            null
+        }
+
+        return TripEnergyEstimate(
+            consumedEnergyKwh = consumed,
+            averageConsumptionKwhPer100Km = average
+        )
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -67,6 +67,8 @@ fun AddRecordScreen(
     vehicleId: Long,
     records: List<ChargingRecordEntity>,
     batteryCapacityKwh: Double? = null,
+    currentSoc: Int? = null,
+    currentMileageKm: Double? = null,
     commonPlaces: List<String> = emptyList(),
     onBack: () -> Unit,
     onSave: (
@@ -81,9 +83,12 @@ fun AddRecordScreen(
     val locationProvider = remember(context) { AndroidLocationProvider(context.applicationContext) }
     val addressResolver = remember(context) { AndroidGeocoderAddressResolver(context.applicationContext) }
     val vehicleRecords = remember(records, vehicleId) { records.filter { it.vehicleId == vehicleId && !it.isDeleted } }
-    val defaults = remember(vehicleRecords) { ChargeDefaultResolver.resolve(currentSoc = null, records = vehicleRecords) }
+    val defaults = remember(vehicleRecords, currentSoc) {
+        ChargeDefaultResolver.resolve(currentSoc = currentSoc, records = vehicleRecords)
+    }
     val calendar = remember { Calendar.getInstance() }
     val initialChargeTime = remember { calendar.timeInMillis }
+    val initialOdometer = remember(currentMileageKm) { currentMileageKm?.toEditableNumber().orEmpty() }
 
     var chargeTime by remember { mutableLongStateOf(initialChargeTime) }
     var location by remember(defaults) { mutableStateOf(defaults.location.orEmpty()) }
@@ -99,7 +104,7 @@ fun AddRecordScreen(
     }
     var cost by remember { mutableStateOf("") }
     var costEditedManually by remember { mutableStateOf(false) }
-    var odometer by remember { mutableStateOf("") }
+    var odometer by remember(initialOdometer) { mutableStateOf(initialOdometer) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var addressMessage by remember { mutableStateOf<String?>(null) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
@@ -117,7 +122,7 @@ fun AddRecordScreen(
     }
 
     val isDirty = chargeTime != initialChargeTime || remark.isNotBlank() || energy.isNotBlank() ||
-        odometer.isNotBlank() || startSoc != defaults.startSoc?.toString().orEmpty() ||
+        odometer != initialOdometer || startSoc != defaults.startSoc?.toString().orEmpty() ||
         endSoc != defaults.endSoc.toString() || chargerType != defaults.chargerType ||
         location != defaults.location.orEmpty() || locationFix != null || costEditedManually
 
@@ -232,7 +237,7 @@ fun AddRecordScreen(
                 }
             }
 
-            FormSection("SOC 与电量", "ENERGY", "车辆接收电量按电池容量和 SOC 变化自动估算；桩端电量用于计费。") {
+            FormSection("SOC 与电量", "ENERGY", "起始 SOC 和里程优先继承车辆当前状态；车辆接收电量按电池容量和 SOC 变化自动估算。") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     AddNumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
                     AddNumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
@@ -337,7 +342,7 @@ fun AddRecordScreen(
                 addressMessage?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
             }
 
-            FormSection("车辆与备注", "VEHICLE CONTEXT", "里程与备注都是可选项。") {
+            FormSection("车辆与备注", "VEHICLE CONTEXT", "当前里程优先继承车辆状态；里程与备注都可以修改。") {
                 AddNumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
                 previousOdometer?.let { Text("上一条有效里程 ${formatKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
                 odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }

--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -7,26 +7,28 @@ import android.content.pm.PackageManager
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material.icons.filled.EvStation
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -37,10 +39,11 @@ import androidx.core.content.ContextCompat
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
+import com.evchargebook.domain.charge.ChargeDefaultResolver
+import com.evchargebook.domain.charge.ChargeEnergyCalculator
 import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.location.AndroidLocationProvider
 import com.evchargebook.location.LocationFix
-import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
 import kotlinx.coroutines.launch
@@ -48,8 +51,14 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-private val ChargeEntryHeroBrush = Brush.linearGradient(
-    listOf(Color(0xFF06100B), Color(0xFF0B2117), Color(0xFF07120D))
+private data class ChargerTypeOption(val label: String, val icon: ImageVector)
+
+private val ChargerTypeOptions = listOf(
+    ChargerTypeOption("家充", Icons.Default.Home),
+    ChargerTypeOption("公共慢充", Icons.Default.EvStation),
+    ChargerTypeOption("公共快充", Icons.Default.Bolt),
+    ChargerTypeOption("超充", Icons.Default.Speed),
+    ChargerTypeOption("闪充", Icons.Default.ElectricBolt)
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -71,27 +80,46 @@ fun AddRecordScreen(
     val scope = rememberCoroutineScope()
     val locationProvider = remember(context) { AndroidLocationProvider(context.applicationContext) }
     val addressResolver = remember(context) { AndroidGeocoderAddressResolver(context.applicationContext) }
+    val vehicleRecords = remember(records, vehicleId) { records.filter { it.vehicleId == vehicleId && !it.isDeleted } }
+    val defaults = remember(vehicleRecords) { ChargeDefaultResolver.resolve(currentSoc = null, records = vehicleRecords) }
     val calendar = remember { Calendar.getInstance() }
     val initialChargeTime = remember { calendar.timeInMillis }
+
     var chargeTime by remember { mutableLongStateOf(initialChargeTime) }
-    var location by remember { mutableStateOf("") }
+    var location by remember(defaults) { mutableStateOf(defaults.location.orEmpty()) }
     var locationFix by remember { mutableStateOf<LocationFix?>(null) }
     var locating by remember { mutableStateOf(false) }
     var remark by remember { mutableStateOf("") }
-    var startSoc by remember { mutableStateOf("") }
-    var endSoc by remember { mutableStateOf("") }
+    var startSoc by remember(defaults) { mutableStateOf(defaults.startSoc?.toString().orEmpty()) }
+    var endSoc by remember(defaults) { mutableStateOf(defaults.endSoc.toString()) }
     var energy by remember { mutableStateOf("") }
+    var chargerType by remember(defaults) { mutableStateOf(defaults.chargerType) }
+    var pricePerKwh by remember(defaults) {
+        mutableStateOf((defaults.pricePerKwh ?: defaultPriceForType(defaults.chargerType)).toEditableNumber())
+    }
     var cost by remember { mutableStateOf("") }
+    var costEditedManually by remember { mutableStateOf(false) }
     var odometer by remember { mutableStateOf("") }
-    var chargerType by remember { mutableStateOf("公共慢充") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var addressMessage by remember { mutableStateOf<String?>(null) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    val isDirty = chargeTime != initialChargeTime ||
-        location.isNotBlank() || locationFix != null || remark.isNotBlank() ||
-        startSoc.isNotBlank() || endSoc.isNotBlank() || energy.isNotBlank() ||
-        cost.isNotBlank() || odometer.isNotBlank() || chargerType != "公共慢充"
+    fun updateCalculatedCost(newEnergy: String = energy, newPrice: String = pricePerKwh) {
+        if (!costEditedManually) {
+            val amount = newEnergy.toDoubleOrNull()
+            val price = newPrice.toDoubleOrNull()
+            cost = if (amount != null && amount > 0.0 && price != null && price >= 0.0) {
+                (amount * price).toEditableNumber()
+            } else {
+                ""
+            }
+        }
+    }
+
+    val isDirty = chargeTime != initialChargeTime || remark.isNotBlank() || energy.isNotBlank() ||
+        odometer.isNotBlank() || startSoc != defaults.startSoc?.toString().orEmpty() ||
+        endSoc != defaults.endSoc.toString() || chargerType != defaults.chargerType ||
+        location != defaults.location.orEmpty() || locationFix != null || costEditedManually
 
     fun requestBack() {
         if (isDirty) showDiscardConfirm = true else onBack()
@@ -109,10 +137,10 @@ fun AddRecordScreen(
                     errorMessage = null
                     val resolved = addressResolver.reverse(fix.latitude, fix.longitude)
                     if (!resolved.isNullOrBlank()) {
-                        if (location.isBlank()) location = resolved
-                        addressMessage = "已解析地址：$resolved"
+                        location = resolved
+                        addressMessage = "已自动使用当前位置"
                     } else {
-                        addressMessage = "已保存经纬度；系统地址服务暂时不可用，可手动填写地点"
+                        addressMessage = "已保存当前位置坐标；地址解析暂不可用"
                     }
                 }
                 .onFailure { errorMessage = it.message ?: "获取当前位置失败" }
@@ -121,7 +149,15 @@ fun AddRecordScreen(
     }
 
     val locationPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-        if (granted) requestCurrentLocation() else errorMessage = "未授予精确定位权限，可继续手动记录充电地点"
+        if (granted) requestCurrentLocation() else addressMessage = "未授予精确定位权限，可继续手动填写地点"
+    }
+
+    LaunchedEffect(Unit) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            requestCurrentLocation()
+        } else {
+            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
     }
 
     val dateText = remember(chargeTime) { SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(chargeTime) }
@@ -129,13 +165,20 @@ fun AddRecordScreen(
     val previousOdometer = remember(records, vehicleId, chargeTime) { ChargingRecordRules.previousOdometerKm(records, vehicleId, chargeTime) }
     val odometerValue = odometer.toDoubleOrNull()
     val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometerValue)
+    val energyValue = energy.toDoubleOrNull()
+    val startSocValue = startSoc.toIntOrNull()
+    val endSocValue = endSoc.toIntOrNull()
+    val estimate = ChargeEnergyCalculator.estimate(batteryCapacityKwh, startSocValue, endSocValue, energyValue)
     val anomalyWarnings = ChargingAnomalyRules.evaluate(
-        startSoc = startSoc.toIntOrNull(),
-        endSoc = endSoc.toIntOrNull(),
-        energyKwh = energy.toDoubleOrNull(),
+        startSoc = startSocValue,
+        endSoc = endSocValue,
+        energyKwh = energyValue,
         cost = cost.toDoubleOrNull(),
         batteryCapacityKwh = batteryCapacityKwh
     )
+    val recentPresets = remember(vehicleRecords) {
+        vehicleRecords.distinctBy { "${it.chargerType}|${it.location}|${it.pricePerKwh.toEditableNumber()}" }.take(4)
+    }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -153,13 +196,104 @@ fun AddRecordScreen(
         }
     ) { padding ->
         Column(
-            Modifier.fillMaxSize().padding(padding).imePadding().verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md),
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
-            ChargeInputCockpit(startSoc, endSoc, energy, cost)
 
-            FormSection("时间与地点", "WHEN & WHERE", "先记录事实，详细备注可以之后再补。") {
+            FormSection("充电方式", "CHARGE TYPE", "按最近使用习惯自动带入，随时可以切换。") {
+                ChargerTypeSelector(chargerType) { selected ->
+                    chargerType = selected
+                    val remembered = ChargeDefaultResolver.priceForType(vehicleRecords, selected) ?: defaultPriceForType(selected)
+                    pricePerKwh = remembered.toEditableNumber()
+                    updateCalculatedCost(newPrice = pricePerKwh)
+                }
+                if (recentPresets.isNotEmpty()) {
+                    Text("最近使用", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                        recentPresets.forEach { record ->
+                            AssistChip(
+                                onClick = {
+                                    chargerType = record.chargerType ?: ChargeDefaultResolver.FALLBACK_CHARGER_TYPE
+                                    endSoc = record.endSoc.toString()
+                                    pricePerKwh = record.pricePerKwh.toEditableNumber()
+                                    record.location?.let { location = it }
+                                    updateCalculatedCost(newPrice = pricePerKwh)
+                                },
+                                label = { Text("${record.chargerType ?: "充电"} · ¥${formatTwo(record.pricePerKwh)}") }
+                            )
+                        }
+                    }
+                }
+            }
+
+            FormSection("SOC 与电量", "ENERGY", "车辆接收电量按电池容量和 SOC 变化自动估算；桩端电量用于计费。") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    AddNumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                    AddNumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                }
+                AddNumberField(
+                    energy,
+                    {
+                        energy = it
+                        updateCalculatedCost(newEnergy = it)
+                    },
+                    "桩端 / 电表电量",
+                    "kWh",
+                    Modifier.fillMaxWidth(),
+                    KeyboardType.Decimal
+                )
+                EnergyEstimateRow(
+                    receivedEnergyKwh = estimate.receivedEnergyKwh,
+                    chargedEnergyKwh = estimate.chargedEnergyKwh,
+                    lossEnergyKwh = estimate.lossEnergyKwh
+                )
+                if (energyValue != null && estimate.receivedEnergyKwh != null && energyValue + 0.05 < estimate.receivedEnergyKwh) {
+                    Text("桩端电量低于按 SOC 估算的车辆接收电量，请检查 SOC 或充电量。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
+                }
+                anomalyWarnings.forEach { warning ->
+                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
+                }
+            }
+
+            FormSection("电价与费用", "COST", "电价优先复用同类型最近记录；总费用默认自动计算，也允许修改。") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    AddNumberField(
+                        pricePerKwh,
+                        {
+                            pricePerKwh = it
+                            updateCalculatedCost(newPrice = it)
+                        },
+                        "电价",
+                        "元/kWh",
+                        Modifier.weight(1f),
+                        KeyboardType.Decimal
+                    )
+                    AddNumberField(
+                        cost,
+                        {
+                            cost = it
+                            costEditedManually = true
+                        },
+                        "总费用",
+                        "元",
+                        Modifier.weight(1f),
+                        KeyboardType.Decimal
+                    )
+                }
+                if (costEditedManually) {
+                    TextButton(onClick = { costEditedManually = false; updateCalculatedCost() }, contentPadding = PaddingValues(0.dp)) {
+                        Text("恢复按电价自动计算")
+                    }
+                }
+            }
+
+            FormSection("时间与地点", "WHEN & WHERE", "默认获取当前位置，也可以选择常用地点或手动修改。") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     OutlinedButton(
                         onClick = { DatePickerDialog(context, { _, y, m, d -> calendar.set(y, m, d); chargeTime = calendar.timeInMillis }, calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)).show() },
@@ -173,31 +307,18 @@ fun AddRecordScreen(
                 OutlinedTextField(
                     value = location,
                     onValueChange = { newValue ->
-                        if (newValue != location) {
-                            locationFix = null
-                            addressMessage = null
-                        }
+                        if (newValue != location) locationFix = null
                         location = newValue
                     },
                     label = { Text("充电地点") },
-                    placeholder = { Text("例如：公司地库 3 号桩") },
+                    placeholder = { Text("例如：家 / 公司地库 / 充电站") },
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) })
+                    singleLine = true
                 )
                 if (commonPlaces.isNotEmpty()) {
-                    Text("常用地点", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
                         commonPlaces.take(5).forEach { place ->
-                            AssistChip(
-                                onClick = {
-                                    location = place
-                                    locationFix = null
-                                    addressMessage = "已复用地点名称；未复用历史坐标"
-                                },
-                                label = { Text(place) }
-                            )
+                            AssistChip(onClick = { location = place; locationFix = null }, label = { Text(place) })
                         }
                     }
                 }
@@ -211,30 +332,12 @@ fun AddRecordScreen(
                 ) {
                     Icon(Icons.Default.LocationOn, null)
                     Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                    Text(if (locating) "正在获取位置…" else "使用当前位置")
-                }
-                locationFix?.let { fix ->
-                    Text("${formatCoordinate(fix.latitude)}, ${formatCoordinate(fix.longitude)} · 精度约 ${fix.accuracyMeters.toInt()} m", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(if (locating) "正在获取位置…" else "重新获取当前位置")
                 }
                 addressMessage?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
             }
 
-            FormSection("充电数据", "ENERGY INPUT", "SOC、电量与费用是统计的核心字段。") {
-                SingleChoiceSegment(listOf("家充", "公共慢充", "公共快充"), chargerType) { chargerType = it }
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    AddNumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
-                    AddNumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    AddNumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
-                    AddNumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
-                }
-                anomalyWarnings.forEach { warning ->
-                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
-                }
-            }
-
-            FormSection("车辆与备注", "VEHICLE CONTEXT", "里程有助于后续估算每百公里补能成本。") {
+            FormSection("车辆与备注", "VEHICLE CONTEXT", "里程与备注都是可选项。") {
                 AddNumberField(odometer, { odometer = it }, "当前总里程", "km", Modifier.fillMaxWidth(), KeyboardType.Decimal)
                 previousOdometer?.let { Text("上一条有效里程 ${formatKm(it)} km", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
                 odometerWarning?.let { Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor) }
@@ -256,14 +359,15 @@ fun AddRecordScreen(
                     focusManager.clearFocus()
                     val start = startSoc.toIntOrNull()
                     val end = endSoc.toIntOrNull()
-                    val energyValue = energy.toDoubleOrNull()
+                    val chargedEnergy = energy.toDoubleOrNull()
                     val costValue = cost.toDoubleOrNull()
                     val odometerKm = odometer.toDoubleOrNull()
                     errorMessage = when {
                         start == null || start !in 0..100 -> "请输入 0~100 的起始 SOC"
                         end == null || end !in 0..100 -> "请输入 0~100 的结束 SOC"
                         end < start -> "结束 SOC 不能低于起始 SOC"
-                        energyValue == null || energyValue <= 0 -> "充电量必须大于 0"
+                        chargedEnergy == null || chargedEnergy <= 0 -> "桩端 / 电表电量必须大于 0"
+                        pricePerKwh.toDoubleOrNull() == null || pricePerKwh.toDouble() < 0 -> "请输入有效电价"
                         costValue == null || costValue < 0 -> "费用不能小于 0"
                         odometer.isNotBlank() && (odometerKm == null || odometerKm < 0) -> "里程需要是大于等于 0 的数字"
                         else -> null
@@ -271,7 +375,7 @@ fun AddRecordScreen(
                     if (errorMessage == null) {
                         val fix = locationFix
                         onSave(
-                            location.trim().takeIf { it.isNotEmpty() }, start!!, end!!, energyValue!!, costValue!!,
+                            location.trim().takeIf { it.isNotEmpty() }, start!!, end!!, chargedEnergy!!, costValue!!,
                             chargerType, remark.trim().takeIf { it.isNotEmpty() }, chargeTime, odometerKm,
                             fix?.latitude, fix?.longitude, fix?.accuracyMeters?.toDouble()
                         )
@@ -295,42 +399,40 @@ fun AddRecordScreen(
 }
 
 @Composable
-private fun ChargeInputCockpit(startSoc: String, endSoc: String, energy: String, cost: String) {
-    val start = startSoc.toIntOrNull()
-    val end = endSoc.toIntOrNull()
-    val energyValue = energy.toDoubleOrNull()
-    val costValue = cost.toDoubleOrNull()
-    val delta = if (start != null && end != null && end >= start) end - start else null
-    val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
-    val metrics = listOf(
-        "SOC" to (delta?.let { "+$it%" } ?: "--"),
-        "补能" to (energyValue?.let { "${formatOne(it)} kWh" } ?: "--"),
-        "均价" to (unitPrice?.let { "¥ ${formatTwo(it)}" } ?: "--")
-    )
-
-    Surface(modifier = Modifier.fillMaxWidth(), color = Color.Transparent, shape = MaterialTheme.shapes.extraLarge) {
-        Column(
-            Modifier.background(ChargeEntryHeroBrush).padding(MaterialTheme.spacing.lg),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
-                Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text("CHARGE / NEW", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-            }
-            ResponsiveMetricGrid(metrics.size) { index, modifier ->
-                val (label, value) = metrics[index]
-                InputMetric(label, value, modifier)
-            }
+private fun ChargerTypeSelector(selected: String, onSelect: (String) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)
+    ) {
+        ChargerTypeOptions.forEach { option ->
+            FilterChip(
+                selected = selected == option.label,
+                onClick = { onSelect(option.label) },
+                leadingIcon = { Icon(option.icon, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                label = { Text(option.label) }
+            )
         }
     }
 }
 
 @Composable
-private fun InputMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+private fun EnergyEstimateRow(
+    receivedEnergyKwh: Double?,
+    chargedEnergyKwh: Double?,
+    lossEnergyKwh: Double?
+) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        EnergyMetric("车辆接收", receivedEnergyKwh?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+        EnergyMetric("桩端计费", chargedEnergyKwh?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+        EnergyMetric("估算损耗", lossEnergyKwh?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun EnergyMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
     }
 }
 
@@ -338,23 +440,9 @@ private fun InputMetric(label: String, value: String, modifier: Modifier) {
 private fun FormSection(title: String, eyebrow: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
         Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
         Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         content()
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SingleChoiceSegment(options: List<String>, selected: String, onSelect: (String) -> Unit) {
-    SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-        options.forEachIndexed { index, option ->
-            SegmentedButton(
-                selected = selected == option,
-                onClick = { onSelect(option) },
-                shape = SegmentedButtonDefaults.itemShape(index, options.size)
-            ) { Text(option) }
-        }
     }
 }
 
@@ -380,7 +468,20 @@ private fun AddNumberField(
     )
 }
 
+private fun defaultPriceForType(type: String): Double = when (type) {
+    "家充" -> 0.65
+    "公共慢充" -> 1.00
+    "公共快充" -> 1.40
+    "超充" -> 1.80
+    "闪充" -> 2.00
+    else -> 1.00
+}
+
+private fun Double.toEditableNumber(): String {
+    val text = String.format(Locale.US, "%.3f", this)
+    return text.trimEnd('0').trimEnd('.')
+}
+
 private fun formatKm(value: Double) = if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
-private fun formatCoordinate(value: Double) = String.format(Locale.US, "%.6f", value)
 private fun formatOne(value: Double) = String.format(Locale.US, "%.1f", value)
 private fun formatTwo(value: Double) = String.format(Locale.US, "%.2f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -3,24 +3,26 @@ package com.evchargebook.ui.records
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.ElectricBolt
+import androidx.compose.material.icons.filled.EvStation
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -30,15 +32,21 @@ import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
-import com.evchargebook.ui.components.ResponsiveMetricGrid
+import com.evchargebook.domain.charge.ChargeEnergyCalculator
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-private val ChargeEditHeroBrush = Brush.linearGradient(
-    listOf(Color(0xFF06100B), Color(0xFF0B2117), Color(0xFF07120D))
+private data class EditChargerTypeOption(val label: String, val icon: ImageVector)
+
+private val EditChargerTypeOptions = listOf(
+    EditChargerTypeOption("家充", Icons.Default.Home),
+    EditChargerTypeOption("公共慢充", Icons.Default.EvStation),
+    EditChargerTypeOption("公共快充", Icons.Default.Bolt),
+    EditChargerTypeOption("超充", Icons.Default.Speed),
+    EditChargerTypeOption("闪充", Icons.Default.ElectricBolt)
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -56,20 +64,33 @@ fun RecordEditScreen(
     var chargeTime by remember { mutableLongStateOf(record.chargeTimeEpochMillis) }
     var location by remember { mutableStateOf(record.location.orEmpty()) }
     var remark by remember { mutableStateOf(record.remark.orEmpty()) }
-    var energy by remember { mutableStateOf(record.energyKwh.toString()) }
-    var cost by remember { mutableStateOf(record.cost.toString()) }
+    var energy by remember { mutableStateOf(record.energyKwh.toEditableEditNumber()) }
+    var pricePerKwh by remember { mutableStateOf(record.pricePerKwh.toEditableEditNumber()) }
+    var cost by remember { mutableStateOf(record.cost.toEditableEditNumber()) }
+    var costEditedManually by remember { mutableStateOf(false) }
     var startSoc by remember { mutableStateOf(record.startSoc.toString()) }
     var endSoc by remember { mutableStateOf(record.endSoc.toString()) }
-    var odometer by remember { mutableStateOf(record.odometerKm?.toString().orEmpty()) }
+    var odometer by remember { mutableStateOf(record.odometerKm?.toEditableEditNumber().orEmpty()) }
     var chargerType by remember { mutableStateOf(record.chargerType ?: "公共慢充") }
     var error by remember { mutableStateOf<String?>(null) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
+    fun updateCalculatedCost(newEnergy: String = energy, newPrice: String = pricePerKwh) {
+        if (!costEditedManually) {
+            val amount = newEnergy.toDoubleOrNull()
+            val price = newPrice.toDoubleOrNull()
+            if (amount != null && amount > 0.0 && price != null && price >= 0.0) {
+                cost = (amount * price).toEditableEditNumber()
+            }
+        }
+    }
+
     val isDirty = chargeTime != record.chargeTimeEpochMillis ||
         location != record.location.orEmpty() || remark != record.remark.orEmpty() ||
-        energy != record.energyKwh.toString() || cost != record.cost.toString() ||
+        energy != record.energyKwh.toEditableEditNumber() || cost != record.cost.toEditableEditNumber() ||
+        pricePerKwh != record.pricePerKwh.toEditableEditNumber() ||
         startSoc != record.startSoc.toString() || endSoc != record.endSoc.toString() ||
-        odometer != record.odometerKm?.toString().orEmpty() || chargerType != (record.chargerType ?: "公共慢充")
+        odometer != record.odometerKm?.toEditableEditNumber().orEmpty() || chargerType != (record.chargerType ?: "公共慢充")
 
     fun requestBack() {
         if (isDirty) showDiscardConfirm = true else onBack()
@@ -83,10 +104,17 @@ fun RecordEditScreen(
         ChargingRecordRules.previousOdometerKm(records, record.vehicleId, chargeTime, record.id)
     }
     val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometer.toDoubleOrNull())
+    val energyValue = energy.toDoubleOrNull()
+    val estimate = ChargeEnergyCalculator.estimate(
+        batteryCapacityKwh = batteryCapacityKwh,
+        startSoc = startSoc.toIntOrNull(),
+        endSoc = endSoc.toIntOrNull(),
+        chargedEnergyKwh = energyValue
+    )
     val anomalyWarnings = ChargingAnomalyRules.evaluate(
         startSoc = startSoc.toIntOrNull(),
         endSoc = endSoc.toIntOrNull(),
-        energyKwh = energy.toDoubleOrNull(),
+        energyKwh = energyValue,
         cost = cost.toDoubleOrNull(),
         batteryCapacityKwh = batteryCapacityKwh
     )
@@ -107,11 +135,76 @@ fun RecordEditScreen(
         }
     ) { padding ->
         Column(
-            Modifier.fillMaxSize().padding(padding).imePadding().verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md),
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
-            EditChargeSummary(startSoc, endSoc, energy, cost)
+
+            EditSection("充电方式", "CHARGE TYPE") {
+                EditChargerTypeSelector(chargerType) { chargerType = it }
+            }
+
+            EditSection("SOC 与电量", "ENERGY") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    NumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                    NumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
+                }
+                NumberField(
+                    energy,
+                    {
+                        energy = it
+                        updateCalculatedCost(newEnergy = it)
+                    },
+                    "桩端 / 电表电量",
+                    "kWh",
+                    Modifier.fillMaxWidth(),
+                    KeyboardType.Decimal
+                )
+                EditEnergyEstimateRow(estimate.receivedEnergyKwh, estimate.chargedEnergyKwh, estimate.lossEnergyKwh)
+                if (energyValue != null && estimate.receivedEnergyKwh != null && energyValue + 0.05 < estimate.receivedEnergyKwh) {
+                    Text("桩端电量低于按 SOC 估算的车辆接收电量，请检查数据。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
+                }
+                anomalyWarnings.forEach { warning ->
+                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
+                }
+            }
+
+            EditSection("电价与费用", "COST") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    NumberField(
+                        pricePerKwh,
+                        {
+                            pricePerKwh = it
+                            updateCalculatedCost(newPrice = it)
+                        },
+                        "电价",
+                        "元/kWh",
+                        Modifier.weight(1f),
+                        KeyboardType.Decimal
+                    )
+                    NumberField(
+                        cost,
+                        {
+                            cost = it
+                            costEditedManually = true
+                        },
+                        "总费用",
+                        "元",
+                        Modifier.weight(1f),
+                        KeyboardType.Decimal
+                    )
+                }
+                if (costEditedManually) {
+                    TextButton(onClick = { costEditedManually = false; updateCalculatedCost() }, contentPadding = PaddingValues(0.dp)) {
+                        Text("恢复按电价自动计算")
+                    }
+                }
+            }
 
             EditSection("时间与地点", "WHEN & WHERE") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
@@ -133,30 +226,6 @@ fun RecordEditScreen(
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) })
                 )
-            }
-
-            EditSection("充电数据", "ENERGY INPUT") {
-                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-                    val options = listOf("家充", "公共慢充", "公共快充")
-                    options.forEachIndexed { index, option ->
-                        SegmentedButton(
-                            selected = chargerType == option,
-                            onClick = { chargerType = option },
-                            shape = SegmentedButtonDefaults.itemShape(index, options.size)
-                        ) { Text(option) }
-                    }
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    NumberField(startSoc, { startSoc = it.filter(Char::isDigit) }, "起始 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
-                    NumberField(endSoc, { endSoc = it.filter(Char::isDigit) }, "结束 SOC", "%", Modifier.weight(1f), KeyboardType.Number)
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    NumberField(energy, { energy = it }, "充电量", "kWh", Modifier.weight(1f), KeyboardType.Decimal)
-                    NumberField(cost, { cost = it }, "费用", "元", Modifier.weight(1f), KeyboardType.Decimal)
-                }
-                anomalyWarnings.forEach { warning ->
-                    Text(warning.message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.warningColor)
-                }
             }
 
             EditSection("车辆与备注", "VEHICLE CONTEXT") {
@@ -181,14 +250,16 @@ fun RecordEditScreen(
                     focusManager.clearFocus()
                     val start = startSoc.toIntOrNull()
                     val end = endSoc.toIntOrNull()
-                    val energyValue = energy.toDoubleOrNull()
+                    val chargedEnergy = energy.toDoubleOrNull()
+                    val price = pricePerKwh.toDoubleOrNull()
                     val costValue = cost.toDoubleOrNull()
                     val odometerKm = odometer.toDoubleOrNull()
                     error = when {
                         start == null || start !in 0..100 -> "起始 SOC 需要是 0 到 100"
                         end == null || end !in 0..100 -> "结束 SOC 需要是 0 到 100"
                         end < start -> "结束 SOC 不能低于起始 SOC"
-                        energyValue == null || energyValue <= 0 -> "充电量必须大于 0"
+                        chargedEnergy == null || chargedEnergy <= 0 -> "桩端 / 电表电量必须大于 0"
+                        price == null || price < 0 -> "电价需要是大于等于 0 的数字"
                         costValue == null || costValue < 0 -> "费用不能小于 0"
                         odometer.isNotBlank() && (odometerKm == null || odometerKm < 0) -> "里程需要是大于等于 0 的数字"
                         else -> null
@@ -200,7 +271,7 @@ fun RecordEditScreen(
                                 remark = remark.trim().takeIf { it.isNotEmpty() },
                                 startSoc = start!!,
                                 endSoc = end!!,
-                                energyKwh = energyValue!!,
+                                energyKwh = chargedEnergy!!,
                                 cost = costValue!!,
                                 chargerType = chargerType,
                                 chargeTimeEpochMillis = chargeTime,
@@ -227,42 +298,36 @@ fun RecordEditScreen(
 }
 
 @Composable
-private fun EditChargeSummary(startSoc: String, endSoc: String, energy: String, cost: String) {
-    val start = startSoc.toIntOrNull()
-    val end = endSoc.toIntOrNull()
-    val energyValue = energy.toDoubleOrNull()
-    val costValue = cost.toDoubleOrNull()
-    val delta = if (start != null && end != null && end >= start) end - start else null
-    val unitPrice = if (energyValue != null && energyValue > 0 && costValue != null) costValue / energyValue else null
-    val metrics = listOf(
-        "SOC" to (delta?.let { "+$it%" } ?: "--"),
-        "补能" to (energyValue?.let { String.format(Locale.US, "%.1f kWh", it) } ?: "--"),
-        "均价" to (unitPrice?.let { String.format(Locale.US, "¥ %.2f", it) } ?: "--")
-    )
-
-    Surface(modifier = Modifier.fillMaxWidth(), color = Color.Transparent, shape = MaterialTheme.shapes.extraLarge) {
-        Column(
-            Modifier.background(ChargeEditHeroBrush).padding(MaterialTheme.spacing.lg),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
-                Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text("CHARGE / EDIT", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-            }
-            ResponsiveMetricGrid(metrics.size) { index, modifier ->
-                val (label, value) = metrics[index]
-                EditMetric(label, value, modifier)
-            }
+private fun EditChargerTypeSelector(selected: String, onSelect: (String) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)
+    ) {
+        EditChargerTypeOptions.forEach { option ->
+            FilterChip(
+                selected = selected == option.label,
+                onClick = { onSelect(option.label) },
+                leadingIcon = { Icon(option.icon, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                label = { Text(option.label) }
+            )
         }
     }
 }
 
 @Composable
-private fun EditMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+private fun EditEnergyEstimateRow(received: Double?, charged: Double?, loss: Double?) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        EditEnergyMetric("车辆接收", received?.let { "${formatEditOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+        EditEnergyMetric("桩端计费", charged?.let { "${formatEditOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+        EditEnergyMetric("估算损耗", loss?.let { "${formatEditOne(it)} kWh" } ?: "--", Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun EditEnergyMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
     }
 }
 
@@ -270,7 +335,7 @@ private fun EditMetric(label: String, value: String, modifier: Modifier) {
 private fun EditSection(title: String, eyebrow: String, content: @Composable ColumnScope.() -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
         Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
         content()
     }
 }
@@ -297,4 +362,10 @@ private fun NumberField(
     )
 }
 
+private fun Double.toEditableEditNumber(): String {
+    val text = String.format(Locale.US, "%.3f", this)
+    return text.trimEnd('0').trimEnd('.')
+}
+
 private fun formatEditKm(value: Double) = if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
+private fun formatEditOne(value: Double) = String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -1,0 +1,225 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.ui.theme.spacing
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TripReadyScreen(
+    vehicle: VehicleEntity?,
+    currentSoc: Int?,
+    currentMileageKm: Double?,
+    recentTrips: List<TripSessionEntity>,
+    onStart: () -> Unit,
+    onOpenDetail: (Long) -> Unit
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text("行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                        Text("TRIP READY", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+        ) {
+            item { ReadyMapCard() }
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                    Text(
+                        vehicle?.let { "${it.brand} ${it.model}" } ?: "请选择车辆",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        "开始后只记录真实 GPS 轨迹，当前状态会作为本次行程起点。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            item {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    ReadyStateMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--", Modifier.weight(1f))
+                    ReadyStateMetric("当前里程", currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--", Modifier.weight(1f))
+                    ReadyStateMetric("轨迹", "GPS 实录", Modifier.weight(1f))
+                }
+            }
+            item {
+                Button(
+                    onClick = onStart,
+                    enabled = vehicle != null,
+                    modifier = Modifier.fillMaxWidth().height(58.dp),
+                    shape = CircleShape
+                ) {
+                    Icon(Icons.Default.PlayArrow, contentDescription = null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("开始行程", style = MaterialTheme.typography.titleMedium)
+                }
+            }
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text("最近行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                    Text("RECENT TRIPS", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            if (recentTrips.isEmpty()) {
+                item {
+                    Text(
+                        "完成第一段行程后，这里会显示真实距离、SOC 与能耗记录。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = MaterialTheme.spacing.md)
+                    )
+                }
+            } else {
+                items(minOf(recentTrips.size, 3)) { index ->
+                    val trip = recentTrips[index]
+                    ReadyRecentTripRow(trip = trip, onClick = { onOpenDetail(trip.id) })
+                }
+            }
+            item { Spacer(Modifier.height(16.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun ReadyMapCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth().height(210.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+            val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
+            val primary = MaterialTheme.colorScheme.primary
+            Canvas(Modifier.fillMaxSize()) {
+                val spacing = 34.dp.toPx()
+                var x = 0f
+                while (x < size.width) {
+                    drawLine(gridColor, Offset(x, 0f), Offset(x, size.height), strokeWidth = 1f)
+                    x += spacing
+                }
+                var y = 0f
+                while (y < size.height) {
+                    drawLine(gridColor, Offset(0f, y), Offset(size.width, y), strokeWidth = 1f)
+                    y += spacing
+                }
+                val center = Offset(size.width * 0.54f, size.height * 0.52f)
+                drawCircle(primary.copy(alpha = 0.12f), radius = 46.dp.toPx(), center = center)
+                drawCircle(primary.copy(alpha = 0.24f), radius = 23.dp.toPx(), center = center)
+                drawCircle(primary, radius = 7.dp.toPx(), center = center)
+                drawLine(
+                    primary.copy(alpha = 0.55f),
+                    Offset(size.width * 0.12f, size.height * 0.78f),
+                    Offset(center.x - 8.dp.toPx(), center.y + 7.dp.toPx()),
+                    strokeWidth = 3.dp.toPx(),
+                    cap = StrokeCap.Round
+                )
+            }
+            Row(
+                modifier = Modifier.align(Alignment.TopStart).padding(MaterialTheme.spacing.md),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(Modifier.size(8.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("GPS READY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+            }
+            Row(
+                modifier = Modifier.align(Alignment.BottomStart).padding(MaterialTheme.spacing.md),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(Icons.Default.LocationOn, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Column {
+                    Text("当前位置", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("开始后锁定真实起点", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadyStateMetric(label: String, value: String, modifier: Modifier) {
+    Surface(modifier = modifier, color = MaterialTheme.colorScheme.surface, shape = MaterialTheme.shapes.large) {
+        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun ReadyRecentTripRow(trip: TripSessionEntity, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = MaterialTheme.spacing.sm),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .12f)) {
+            Box(Modifier.size(42.dp), contentAlignment = Alignment.Center) {
+                Icon(Icons.Default.Route, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            }
+        }
+        Spacer(Modifier.width(MaterialTheme.spacing.md))
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(trip.startedAtEpochMillis)),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                "${String.format(Locale.US, "%.1f", trip.distanceMeters / 1000.0)} km · ${formatReadyDuration(trip.elapsedSeconds)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            trip.averageConsumptionKwhPer100Km?.let {
+                Text("${String.format(Locale.US, "%.1f", it)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("kWh/100km", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } ?: Text("--", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+private fun formatReadyMileage(value: Double): String =
+    if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
+
+private fun formatReadyDuration(seconds: Long): String {
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -31,6 +31,8 @@ import java.time.ZoneId
 
 data class MainUiState(
     val vehicle: VehicleEntity? = null,
+    val currentSoc: Int? = null,
+    val currentMileageKm: Double? = null,
     val vehicles: List<VehicleEntity> = emptyList(),
     val catalogVehicles: List<VehicleCatalogEntity> = emptyList(),
     val bluetoothSettings: BluetoothPromptSettings = BluetoothPromptSettings(),
@@ -74,6 +76,14 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
         viewModelScope.launch { repository.ensureDefaultVehicle() }
         viewModelScope.launch { repository.bluetoothSettings.collect { settings -> _uiState.value = _uiState.value.copy(bluetoothSettings = settings) } }
         viewModelScope.launch { repository.activeTrip.collect { trip -> _uiState.value = _uiState.value.copy(activeTrip = trip) } }
+        viewModelScope.launch {
+            repository.vehicleState.collect { vehicleState ->
+                _uiState.value = _uiState.value.copy(
+                    currentSoc = vehicleState?.currentSoc,
+                    currentMileageKm = vehicleState?.currentMileage
+                )
+            }
+        }
         viewModelScope.launch {
             selectedTripId.flatMapLatest { tripId -> tripId?.let { repository.observeTripPoints(it) } ?: flowOf(emptyList()) }
                 .collect { points -> _uiState.value = _uiState.value.copy(selectedTripId = selectedTripId.value, selectedTripPoints = points) }

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -159,7 +159,7 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
 
     fun startTrip() { val vehicleId = _uiState.value.vehicle?.id ?: return; viewModelScope.launch { runCatching { repository.startTrip(vehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已开始") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法开始行程") } } }
     fun resumeTrip(tripId: Long) { viewModelScope.launch { runCatching { repository.resumeTrip(tripId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程记录已恢复") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法恢复行程") } } }
-    fun stopTrip() { viewModelScope.launch { runCatching { repository.stopActiveTrip() }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已结束") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法结束行程") } } }
+    fun stopTrip(endSoc: Int, endMileageKm: Double?) { viewModelScope.launch { runCatching { repository.stopActiveTrip(endSoc, endMileageKm) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已结束，车辆状态已更新") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法结束行程") } } }
     fun openTripDetail(tripId: Long) { selectedTripId.value = tripId }
     fun closeTripDetail() { selectedTripId.value = null; _uiState.value = _uiState.value.copy(selectedTripId = null, selectedTripPoints = emptyList()) }
     fun deleteTrip(trip: TripSessionEntity) { viewModelScope.launch { runCatching { repository.deleteTrip(trip) }.onSuccess { if (selectedTripId.value == trip.id) closeTripDetail() }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法删除行程") } } }

--- a/android/app/src/test/java/com/evchargebook/domain/charge/ChargeDefaultResolverTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/charge/ChargeDefaultResolverTest.kt
@@ -1,0 +1,54 @@
+package com.evchargebook.domain.charge
+
+import com.evchargebook.data.entity.ChargingRecordEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChargeDefaultResolverTest {
+    @Test
+    fun `uses current vehicle soc and latest charge defaults`() {
+        val records = listOf(
+            ChargingRecordEntity(
+                id = 2,
+                vehicleId = 1,
+                chargeTimeEpochMillis = 2_000,
+                energyKwh = 30.0,
+                cost = 45.0,
+                startSoc = 40,
+                endSoc = 92,
+                chargerType = "公共快充",
+                location = "公司快充站"
+            ),
+            ChargingRecordEntity(
+                id = 1,
+                vehicleId = 1,
+                chargeTimeEpochMillis = 1_000,
+                energyKwh = 20.0,
+                cost = 12.0,
+                startSoc = 30,
+                endSoc = 80,
+                chargerType = "家充",
+                location = "家"
+            )
+        )
+
+        val result = ChargeDefaultResolver.resolve(currentSoc = 65, records = records)
+
+        assertEquals(65, result.startSoc)
+        assertEquals(92, result.endSoc)
+        assertEquals("公共快充", result.chargerType)
+        assertEquals(1.5, result.pricePerKwh!!, 0.0001)
+        assertEquals("公司快充站", result.location)
+    }
+
+    @Test
+    fun `falls back to 100 end soc without history`() {
+        val result = ChargeDefaultResolver.resolve(currentSoc = null, records = emptyList())
+
+        assertNull(result.startSoc)
+        assertEquals(100, result.endSoc)
+        assertEquals(ChargeDefaultResolver.FALLBACK_CHARGER_TYPE, result.chargerType)
+        assertNull(result.pricePerKwh)
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/charge/ChargeEnergyCalculatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/charge/ChargeEnergyCalculatorTest.kt
@@ -1,0 +1,34 @@
+package com.evchargebook.domain.charge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChargeEnergyCalculatorTest {
+    @Test
+    fun `calculates received energy and loss`() {
+        val result = ChargeEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = 58,
+            endSoc = 100,
+            chargedEnergyKwh = 36.8
+        )
+
+        assertEquals(34.398, result.receivedEnergyKwh!!, 0.001)
+        assertEquals(2.402, result.lossEnergyKwh!!, 0.001)
+        assertEquals(2.402 / 36.8, result.lossRate!!, 0.0001)
+    }
+
+    @Test
+    fun `does not invent energy without soc inputs`() {
+        val result = ChargeEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = null,
+            endSoc = 100,
+            chargedEnergyKwh = 36.8
+        )
+
+        assertNull(result.receivedEnergyKwh)
+        assertNull(result.lossEnergyKwh)
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
@@ -1,0 +1,33 @@
+package com.evchargebook.domain.trip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TripEnergyCalculatorTest {
+    @Test
+    fun `calculates trip energy and consumption from soc delta`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = 82,
+            endSoc = 65,
+            distanceMeters = 80_000.0
+        )
+
+        assertEquals(13.923, result.consumedEnergyKwh!!, 0.001)
+        assertEquals(17.40375, result.averageConsumptionKwhPer100Km!!, 0.0001)
+    }
+
+    @Test
+    fun `does not invent consumption when start soc is unknown`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = null,
+            endSoc = 65,
+            distanceMeters = 80_000.0
+        )
+
+        assertNull(result.consumedEnergyKwh)
+        assertNull(result.averageConsumptionKwhPer100Km)
+    }
+}


### PR DESCRIPTION
## Summary

Connect trip start/end to the shared VehicleState so trip energy can be derived from real SOC change instead of manual energy input.

## Trip lifecycle

- capture current VehicleState SOC and mileage when a trip starts
- require end SOC when completing a trip
- prefill end mileage from start mileage + GPS distance when possible, while allowing correction
- persist start/end SOC and mileage on TripSession
- calculate consumed energy from battery capacity and SOC delta
- calculate average kWh/100km from consumed energy and recorded GPS distance
- update VehicleState SOC/mileage to the trip-end values after completion

## Database / backup

- Room schema 9 -> 10 adds trip SOC, mileage and energy fields
- existing trips retain null values rather than fabricated history
- backup schema preserves the new trip fields while remaining able to read older backups

## UX

- ending a trip now opens a focused completion dialog for end SOC and mileage
- the dialog previews SOC change, consumed kWh and average kWh/100km before save
- if start mileage exists, end mileage is prefilled from GPS distance to reduce repeated input

## Tests

- TripEnergyCalculator covers SOC-delta consumption and unknown-start-SOC behavior

## Stack

This PR is intentionally stacked on PR #81 and should be merged after #79 and #81.