### PR TITLE
feat(android): color Trip route by trusted vehicle speed

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -3,8 +3,8 @@ package com.evchargebook.domain
 object TripSpeedTrustRules {
     const val MIN_CORROBORATING_DISTANCE_METERS = 5.0
     private const val MIN_EXPECTED_DISTANCE_RATIO = 0.25
-    private const val MAX_PEAK_HORIZONTAL_ACCURACY_METERS = 25.0
-    private const val MAX_PEAK_SPEED_ACCURACY_MPS = 3.0
+    private const val MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS = 25.0
+    private const val MAX_TRUSTED_SPEED_ACCURACY_MPS = 3.0
 
     fun eligibleForAggregate(
         reportedSpeedMps: Double?,
@@ -12,7 +12,7 @@ object TripSpeedTrustRules {
         trustedDistanceMeters: Double,
         continuityAllowsSpeed: Boolean
     ): Boolean {
-        if (!continuityAllowsSpeed || reportedSpeedMps == null || reportedSpeedMps < 0.0) return false
+        if (!continuityAllowsSpeed || reportedSpeedMps == null || !reportedSpeedMps.isFinite() || reportedSpeedMps < 0.0) return false
         if (reportedSpeedMps < TripSamplingRules.MOVING_SPEED_MPS) return true
         if (deltaSeconds <= 0) return false
 
@@ -24,6 +24,28 @@ object TripSpeedTrustRules {
         return trustedDistanceMeters >= requiredDistance
     }
 
+    fun eligibleForMeasuredSpeed(
+        reportedSpeedMps: Double?,
+        provider: String?,
+        horizontalAccuracyMeters: Double?,
+        speedAccuracyMps: Double?
+    ): Boolean {
+        if (reportedSpeedMps == null || !reportedSpeedMps.isFinite() || reportedSpeedMps < 0.0) return false
+        if (!provider.equals("gps", ignoreCase = true)) return false
+
+        val horizontalAccuracy = horizontalAccuracyMeters ?: return false
+        if (!horizontalAccuracy.isFinite() || horizontalAccuracy < 0.0 || horizontalAccuracy > MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS) {
+            return false
+        }
+
+        if (speedAccuracyMps != null &&
+            (!speedAccuracyMps.isFinite() || speedAccuracyMps < 0.0 || speedAccuracyMps > MAX_TRUSTED_SPEED_ACCURACY_MPS)
+        ) {
+            return false
+        }
+        return true
+    }
+
     fun eligibleForMaxSpeed(
         reportedSpeedMps: Double?,
         deltaSeconds: Long,
@@ -32,22 +54,16 @@ object TripSpeedTrustRules {
         provider: String?,
         horizontalAccuracyMeters: Double?,
         speedAccuracyMps: Double?
-    ): Boolean {
-        if (!eligibleForAggregate(reportedSpeedMps, deltaSeconds, trustedDistanceMeters, continuityAllowsSpeed)) {
-            return false
-        }
-        if (!provider.equals("gps", ignoreCase = true)) return false
-
-        val horizontalAccuracy = horizontalAccuracyMeters ?: return false
-        if (!horizontalAccuracy.isFinite() || horizontalAccuracy < 0.0 || horizontalAccuracy > MAX_PEAK_HORIZONTAL_ACCURACY_METERS) {
-            return false
-        }
-
-        if (speedAccuracyMps != null &&
-            (!speedAccuracyMps.isFinite() || speedAccuracyMps < 0.0 || speedAccuracyMps > MAX_PEAK_SPEED_ACCURACY_MPS)
-        ) {
-            return false
-        }
-        return true
-    }
+    ): Boolean =
+        eligibleForAggregate(
+            reportedSpeedMps = reportedSpeedMps,
+            deltaSeconds = deltaSeconds,
+            trustedDistanceMeters = trustedDistanceMeters,
+            continuityAllowsSpeed = continuityAllowsSpeed
+        ) && eligibleForMeasuredSpeed(
+            reportedSpeedMps = reportedSpeedMps,
+            provider = provider,
+            horizontalAccuracyMeters = horizontalAccuracyMeters,
+            speedAccuracyMps = speedAccuracyMps
+        )
 }

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripRouteGeometry.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripRouteGeometry.kt
@@ -3,12 +3,14 @@ package com.evchargebook.domain.trip
 data class TripGeoPoint(
     val latitude: Double,
     val longitude: Double,
-    val capturedAtEpochMillis: Long? = null
+    val capturedAtEpochMillis: Long? = null,
+    val speedMps: Double? = null
 )
 
 data class TripRoutePoint(
     val x: Float,
-    val y: Float
+    val y: Float,
+    val speedMps: Double? = null
 )
 
 data class TripRouteGeometry(
@@ -50,7 +52,8 @@ object TripRouteGeometryBuilder {
 
         fun normalize(point: TripGeoPoint) = TripRoutePoint(
             x = ((point.longitude - minLon) / lonSpan).toFloat().coerceIn(0f, 1f),
-            y = (1.0 - (point.latitude - minLat) / latSpan).toFloat().coerceIn(0f, 1f)
+            y = (1.0 - (point.latitude - minLat) / latSpan).toFloat().coerceIn(0f, 1f),
+            speedMps = point.speedMps
         )
 
         val normalizedSegments = sampledSegments.map { segment -> segment.map(::normalize) }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -655,11 +655,8 @@ private fun TripPointEntity.toRouteGeoPoint(): TripGeoPoint {
     )
 }
 
-private fun averageSpeed(first: Double?, second: Double?): Double? = when {
-    first != null && second != null -> (first + second) / 2.0
-    first != null -> first
-    else -> second
-}
+private fun averageSpeed(first: Double?, second: Double?): Double? =
+    if (first != null && second != null) (first + second) / 2.0 else null
 
 private fun speedRouteColor(speedMps: Double?, fallback: Color): Color {
     val kmh = speedMps?.times(3.6)?.takeIf { it.isFinite() && it >= 0.0 } ?: return fallback

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -32,6 +32,7 @@ import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.domain.TripSpeedTrustRules
 import com.evchargebook.domain.trip.TripGeoPoint
 import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.location.AndroidGeocoderAddressResolver
@@ -43,6 +44,12 @@ import java.util.Locale
 private val TripHeroBrush = Brush.linearGradient(
     listOf(Color(0xFF06100B), Color(0xFF0A2116), Color(0xFF07120D))
 )
+private val SpeedDeepRed = Color(0xFF8E1919)
+private val SpeedRed = Color(0xFFE44545)
+private val SpeedYellow = Color(0xFFF2C94C)
+private val SpeedGreen = Color(0xFF35C46A)
+private val SpeedBlue = Color(0xFF3B82F6)
+private val SpeedDeepBlue = Color(0xFF2457C5)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -371,7 +378,7 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
         trip.maxAltitudeMeters
     ).any { it != null }
     val geometry = remember(points) {
-        if (points.size >= 2) TripRouteGeometryBuilder.build(points.map { TripGeoPoint(it.latitude, it.longitude, it.capturedAtEpochMillis) }) else null
+        if (points.size >= 2) TripRouteGeometryBuilder.build(points.map { it.toRouteGeoPoint() }) else null
     }
 
     LaunchedEffect(trip.id, trip.status, firstPoint?.id, lastPoint?.id) {
@@ -544,10 +551,10 @@ private fun SectionHeading(title: String, subtitle: String) {
 @Composable
 private fun TripRoutePreview(points: List<TripPointEntity>) {
     val geometry = remember(points) {
-        TripRouteGeometryBuilder.build(points.map { TripGeoPoint(it.latitude, it.longitude, it.capturedAtEpochMillis) })
+        TripRouteGeometryBuilder.build(points.map { it.toRouteGeoPoint() })
     }
     if (geometry == null || !geometry.isDrawable) return
-    val routeColor = MaterialTheme.colorScheme.primary
+    val fallbackRouteColor = MaterialTheme.colorScheme.outline.copy(alpha = .72f)
     val startColor = MaterialTheme.colorScheme.tertiary
     val endColor = MaterialTheme.colorScheme.error
 
@@ -565,15 +572,18 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
                 Modifier
                     .fillMaxWidth()
                     .height(240.dp)
-                    .semantics { contentDescription = "真实行程轨迹；圆形标记为起点，方形标记为终点" }
+                    .semantics { contentDescription = "真实行程轨迹；轨迹颜色表示本车速度，圆形标记为起点，方形标记为终点" }
             ) {
                 val p = 16.dp.toPx()
                 val w = (size.width - p * 2).coerceAtLeast(1f)
                 val h = (size.height - p * 2).coerceAtLeast(1f)
                 fun offset(point: com.evchargebook.domain.trip.TripRoutePoint) = Offset(p + point.x * w, p + point.y * h)
                 geometry.segments.forEach { segment ->
-                    segment.map(::offset).zipWithNext().forEach { (from, to) ->
-                        drawLine(routeColor, from, to, strokeWidth = 4.dp.toPx(), cap = StrokeCap.Round)
+                    segment.zipWithNext().forEach { (fromPoint, toPoint) ->
+                        val from = offset(fromPoint)
+                        val to = offset(toPoint)
+                        val segmentSpeed = averageSpeed(fromPoint.speedMps, toPoint.speedMps)
+                        drawLine(speedRouteColor(segmentSpeed, fallbackRouteColor), from, to, strokeWidth = 4.dp.toPx(), cap = StrokeCap.Round)
                     }
                 }
                 val start = offset(geometry.points.first())
@@ -585,6 +595,27 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
                     topLeft = Offset(end.x - endSize / 2, end.y - endSize / 2),
                     size = Size(endSize, endSize)
                 )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xxs)) {
+                Text("车辆速度分布", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold)
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .background(
+                            Brush.horizontalGradient(listOf(SpeedDeepRed, SpeedRed, SpeedYellow, SpeedGreen, SpeedBlue, SpeedDeepBlue)),
+                            CircleShape
+                        )
+                )
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("0", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("15", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("30", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("70", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("90+ km/h", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Text("颜色仅表示本车可信 GPS 速度，不代表道路拥堵或交通状态。灰色线段表示速度数据不足。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
 
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
@@ -605,6 +636,52 @@ private fun TripRoutePreview(points: List<TripPointEntity>) {
             Text("基于真实 WGS84 轨迹点绘制，不做道路吸附或虚构路线。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
+}
+
+private fun TripPointEntity.toRouteGeoPoint(): TripGeoPoint {
+    val trustedSpeed = speedMps.takeIf {
+        TripSpeedTrustRules.eligibleForMeasuredSpeed(
+            reportedSpeedMps = speedMps,
+            provider = provider,
+            horizontalAccuracyMeters = horizontalAccuracyMeters,
+            speedAccuracyMps = speedAccuracyMps
+        )
+    }
+    return TripGeoPoint(
+        latitude = latitude,
+        longitude = longitude,
+        capturedAtEpochMillis = capturedAtEpochMillis,
+        speedMps = trustedSpeed
+    )
+}
+
+private fun averageSpeed(first: Double?, second: Double?): Double? = when {
+    first != null && second != null -> (first + second) / 2.0
+    first != null -> first
+    else -> second
+}
+
+private fun speedRouteColor(speedMps: Double?, fallback: Color): Color {
+    val kmh = speedMps?.times(3.6)?.takeIf { it.isFinite() && it >= 0.0 } ?: return fallback
+    return when {
+        kmh <= 5.0 -> SpeedDeepRed
+        kmh <= 15.0 -> SpeedRed
+        kmh <= 30.0 -> blendColor(SpeedRed, SpeedYellow, ((kmh - 15.0) / 15.0).toFloat())
+        kmh <= 50.0 -> blendColor(SpeedYellow, SpeedGreen, ((kmh - 30.0) / 20.0).toFloat())
+        kmh <= 70.0 -> SpeedGreen
+        kmh <= 90.0 -> blendColor(SpeedGreen, SpeedBlue, ((kmh - 70.0) / 20.0).toFloat())
+        else -> blendColor(SpeedBlue, SpeedDeepBlue, ((kmh - 90.0) / 40.0).toFloat().coerceIn(0f, 1f))
+    }
+}
+
+private fun blendColor(from: Color, to: Color, fraction: Float): Color {
+    val value = fraction.coerceIn(0f, 1f)
+    return Color(
+        red = from.red + (to.red - from.red) * value,
+        green = from.green + (to.green - from.green) * value,
+        blue = from.blue + (to.blue - from.blue) * value,
+        alpha = from.alpha + (to.alpha - from.alpha) * value
+    )
 }
 
 private fun formatTime(epochMillis: Long) = SimpleDateFormat("M月d日 HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -97,4 +97,28 @@ class TripSpeedTrustRulesTest {
             )
         )
     }
+
+    @Test
+    fun `accurate gps speed is eligible for visualization`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMeasuredSpeed(
+                reportedSpeedMps = 15.0,
+                provider = "gps",
+                horizontalAccuracyMeters = 6.0,
+                speedAccuracyMps = 1.0
+            )
+        )
+    }
+
+    @Test
+    fun `network speed is not eligible for visualization`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForMeasuredSpeed(
+                reportedSpeedMps = 39.6,
+                provider = "network",
+                horizontalAccuracyMeters = 30.0,
+                speedAccuracyMps = null
+            )
+        )
+    }
 }

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripRouteGeometryTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripRouteGeometryTest.kt
@@ -2,6 +2,7 @@ package com.evchargebook.domain.trip
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -80,5 +81,22 @@ class TripRouteGeometryTest {
 
         assertEquals(1, geometry.segments.size)
         assertEquals(0, geometry.gapCount)
+    }
+
+    @Test
+    fun `trusted speed metadata survives normalization and gap segmentation`() {
+        val geometry = TripRouteGeometryBuilder.build(
+            listOf(
+                TripGeoPoint(31.2000, 121.4000, 0L, 3.0),
+                TripGeoPoint(31.2010, 121.4010, 4_000L, 12.0),
+                TripGeoPoint(31.2500, 121.4500, 180_000L, null),
+                TripGeoPoint(31.2510, 121.4510, 184_000L, 25.0)
+            )
+        )!!
+
+        assertEquals(3.0, geometry.segments[0][0].speedMps!!, 0.0001)
+        assertEquals(12.0, geometry.segments[0][1].speedMps!!, 0.0001)
+        assertNull(geometry.segments[1][0].speedMps)
+        assertEquals(25.0, geometry.segments[1][1].speedMps!!, 0.0001)
     }
 }


### PR DESCRIPTION
## Summary

Implements the missing v0.5 Trip speed-color route preview from the 2026-08-27 physical acceptance feedback.

### Trusted speed input
- reuse the same GPS quality boundary introduced for max-speed hardening
- visualization speed must come from GPS
- horizontal accuracy must be <=25m
- reported speed accuracy, when available, must be <=3m/s
- coarse/network speed remains available in raw TripPoint diagnostics but does not color the route

### Derived route geometry
- add optional speed metadata to the existing derived `TripGeoPoint` / `TripRoutePoint`
- preserve speed through normalization, downsampling and long-gap segmentation
- no Room schema/table change

### Color mapping
Implements the existing `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` semantics:
- 0–5 km/h deep red
- 5–15 km/h red
- 15–30 km/h red -> yellow
- 30–50 km/h yellow -> green
- 50–70 km/h green
- 70–90 km/h green -> blue
- 90+ km/h blue/deep blue

Unknown/untrusted speed segments render neutral gray rather than inventing a speed class.

### Product semantics
The UI explicitly says:
- colors represent this vehicle's trusted GPS speed distribution
- colors do **not** represent road congestion or traffic state
- gray means insufficient trusted speed data

### GPS gaps
Existing >=120s route gaps remain disconnected. This PR does not reconnect or synthesize missing geometry.

## Tests
- network speed is rejected for visualization
- accurate GPS speed is accepted for visualization
- speed metadata survives normalization and GPS-gap segmentation
- existing max-speed and route-continuity tests remain intact

## Related
- #67 trajectory continuity / speed visualization
- #78 max-speed trust hardening
- #42 Trip accessibility / semantic presentation
- `docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`

## Acceptance
- Android CI green
- physical Trip route shows visibly different low/medium/high speed colors
- today's coarse network speed spike cannot create a blue high-speed segment
- GPS long gaps remain disconnected
- start/end semantic markers from #83 remain visible
- dark/light mode route and legend remain readable

Physical visual acceptance remains required before closing #67.