### PR TITLE
docs: sync Trip reliability and speed visualization after physical test

### DIFF
--- a/docs/LOCATION_TRIP.md
+++ b/docs/LOCATION_TRIP.md
@@ -1,6 +1,6 @@
 # EV Charge Book Location / Map / Trip Tracking Design
 
-版本: v1.3.0
+版本: v1.4.0
 更新时间: 2026-08-27
 状态: Authority Subdocument
 
@@ -73,28 +73,48 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 
 ## 4. 采样策略
 
-当前目标:
+### 4.1 callback 与持久化必须分层
 
-- 行驶中目标间隔: 2-5 秒
-- 最小位移参考: 5-10 米
-- 低速/停车时自适应降低频率
-- accuracy 过差点不参与距离聚合
+2026-08-27 真机数据证明，不能同时在 Android LocationManager 层和业务层使用较大的位移门槛，否则停车时可能没有 callback，业务层也就无法证明“定位仍健康但车辆静止”。
 
-禁止默认 1 秒永久高频采样。
+当前实现明确分为两层：
+
+**系统 callback 层：**
+
+- `TripTrackingService` 请求间隔约 4 秒。
+- `SAMPLE_DISTANCE_METERS = 0f`，不再要求至少移动 8m 才允许 callback。
+- 目标是保持时间维度的定位活性与可诊断性，不代表每 4 秒都必须写 Room。
+
+**业务采样 / 写库层：**
+
+- `TripSamplingRules` 继续负责 accuracy、跳点、移动/静止判断与写库节流。
+- 移动判定当前以约 `1 m/s` 报告速度或约 `5m` 位移作为基础条件。
+- 静止状态默认约 15 秒保留一个 heartbeat，避免 4 秒一次永久高频写库。
+- accuracy 过差或不可信跳点不参与可信统计。
+
+因此当前设计不是“0m 高频永久采样”，而是：
+
+```text
+Location callback 保活
+  -> 业务质量过滤
+  -> 移动点正常记录 / 静止 heartbeat 降频
+  -> Room
+```
 
 目的:
 
-- 降低定位耗电
-- 控制 Room 数据量
-- 降低 GPS 抖动造成的假距离
+- 让红灯/停车仍能证明 tracking callback 健康；
+- 降低定位耗电和 Room 数据量；
+- 降低 GPS 抖动造成的假距离；
+- 为后台 callback starvation 提供可诊断证据。
 
 结束行程后可增加轨迹简化用于地图展示；原始点是否长期保留由数据保留策略决定。
 
-### GPS gap 不是普通降频
+### 4.2 GPS gap 不是普通降频
 
-静止降频只能解释短间隔缺点，不能解释十分钟级位置空洞。
+静止降频只能解释正常 heartbeat 间隔，不能解释十分钟级位置空洞。
 
-真实行程已经观察到 12 分钟和 15 分钟级 GPS gap，因此必须逐步补齐：
+真实行程已经观察到 12 分钟、15 分钟，以及 2026-08-27 第二轮实机中的约 10 分 43 秒 / 7 分 45 秒移动空洞。因此必须继续区分：
 
 - lastLocationCallbackAt
 - lastAcceptedPointAt
@@ -103,7 +123,9 @@ MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免�
 - longest gap
 - service lifecycle / re-delivery evidence
 
-PR #36 第一阶段已经实现运行时 GPS health 与 ongoing notification，并在长 gap 时把轨迹拆成多个可信 segment。
+PR #36 已实现运行时 GPS health 与 ongoing notification，并在长 gap 时把轨迹拆成多个可信 segment。
+
+PR #80 进一步移除 LocationManager 的 8m callback 位移门槛，让现有 15s stationary heartbeat 有机会在停车状态真正执行。该代码已进入 `main`；“切换其他 App 后是否持续回调”仍属于 #77 真机验收项，不能由 CI 代替。
 
 ---
 
@@ -115,40 +137,43 @@ Trip 至少区分:
 - moving time: 有效移动时间
 - stopped time: 停车/静止时间
 
-首版停车识别可以采用简单规则:
-
-- speed 低于约 1-2 km/h
-- 持续达到阈值后计为 stopped
-
-阈值需要真机数据调优，不写死成产品事实。
+首版停车识别采用简单可信规则，不把阈值写成不可变产品事实。当前静止 heartbeat 会把可信静止区间累积到 `stoppedSeconds`；后续仍需用城市道路真机数据继续校准。
 
 ### 5.1 当前距离如何计算
 
-当前 `distanceMeters` 来自连续 accepted GPS point 之间的地理直线距离累计。
+当前 `distanceMeters` 来自连续 accepted point 之间的可信地理直线距离累计。
 
-因此它不是道路里程，也不是车辆轮速里程；在以下场景会存在偏差：
+因此它不是道路里程，也不是车辆轮速里程；在以下场景仍会存在偏差：
 
 - 道路连续弯曲但采样点较稀
 - GPS 漂移
 - GPS / Network provider 切换
-- 长时间 GPS gap 后直接把 gap 两端连接
+- 长时间 GPS callback/usable-location 缺失
 
-产品规则：长时间 gap 两端不能继续作为“可信连续距离”直接累计。该规则属于 P0 reliability follow-up；在落地前，平均速度必须被视为基于已记录 GPS 距离的派生值，而不是车辆仪表级事实。
+`TripContinuityRules` 当前已对 `>=120s` 的长 gap 建立 baseline：恢复后的点可以作为新的轨迹起点，但 gap 两端 **不计可信距离、不计该段 moving/stopped duration，也不允许该 gap 直接贡献速度统计**。
+
+因此“长 gap 两端不得直接累计直线距离”的 P0 规则已经落地，不再是 future follow-up。
+
+平均速度仍必须被理解为基于“已记录可信 GPS 距离”的派生值，而不是车辆仪表级道路里程事实。
 
 ### 5.2 当前速度到底来自哪里
 
-当前存在两个完全不同的概念：
+当前存在不同层次的速度概念：
 
-1. `Location.speed`：Android Location 提供的定位时刻速度，当前用于 TripPoint `speedMps`，也是最高速度的主要来源。
-2. `point-to-point distance / time`：可作为轨迹区段速度的派生/校验证据，但不应该冒充瞬时速度。
+1. `Location.speed`：Android Location 提供的定位时刻速度，原始值保存在 TripPoint `speedMps`。
+2. point-to-point distance / time：用于连续性、距离和速度可信度校验证据，不冒充车辆瞬时速度。
+3. route visualization speed：首版使用相邻两端都通过可信 GPS 质量门的 `Location.speed` 做显示派生。
 
-因此：
+PR #82 后，“最高已记录速度”不再允许任意 provider 的原始 `Location.speed` 直接刷新。当前 max-speed candidate 必须满足：
 
-- 当前“最高速度”不是简单用两点直线距离除时间得到的。
-- 当前“全程均速 / 行驶均速”依赖累计 `distanceMeters`，所以会受到 GPS 距离质量影响。
-- 未来“分段速度”不能只用一个单点 `Location.speed`，也不能只用两点直线距离；应结合连续可信点、speed accuracy、provider 与 gap 状态。
+- provider = GPS；
+- horizontal accuracy <= 25m；
+- Android 提供 speed accuracy 时，speed accuracy <= 3 m/s；
+- 同时通过现有连续距离/时间 corroboration。
 
-短时速度峰值存在漏采可能。例如真实峰值只持续约 4 秒，而采样目标同样是 2-5 秒，则可能在峰值时没有产生有效 Location fix。产品上应区分“最高已记录 GNSS 速度”和“车辆真实最高速度”，不能把未采到的峰值推算出来。
+Network fallback 原始速度仍保存在 TripPoint 便于审计，但不能制造新的 `maxSpeedMps`。这正是 2026-08-27 真机中约 122.4 km/h / 142.6 km/h network 粗定位峰值后的修正。
+
+短时速度峰值仍存在漏采可能。例如真实峰值只持续约 4 秒，而定位 callback/accepted point 没有覆盖峰值，则产品不能自行推算。UI 应理解为“最高已记录可信 GNSS 速度”，不是车辆真实最高速度的绝对证明。
 
 ### 5.3 速度 UI
 
@@ -156,22 +181,31 @@ Trip 至少区分:
 
 1. 全程平均速度：total recorded distance / elapsed time
 2. 行驶平均速度：total recorded distance / moving time
-3. 分段平均速度：可信 segment 内的综合速度
-4. 最高已记录速度：经异常过滤后的 Location.speed 峰值
+3. 分段/轨迹速度：可信 route segment 的显示派生
+4. 最高已记录速度：经异常过滤后的可信 GPS `Location.speed` 峰值
 
 PR #36 已把详情页原先模糊的“平均速度”拆成全程均速 / 行驶均速 / 最高速度 / 移动时间。
 
-后续新增 `TripSpeedSegment` 派生模型，不新增 Room 表即可完成首版。
+PR #85 已实现第一版彩色 route preview，不新增 Room 表：
 
-分段速度颜色采用连续渐变，语义为本车速度分布：
+- 只有相邻两点的速度都通过可信 measured-speed 质量门时，该线段才按速度上色；
+- 任一端速度缺失或不可信时保持中性灰色，不把未知速度当成 0 km/h；
+- 长 GPS gap 继续保持断开；
+- 颜色连续映射为深红 -> 红 -> 黄 -> 绿 -> 蓝。
 
-- 深红：极低速
-- 红：低速
-- 黄：较慢
-- 绿：正常/快速
-- 蓝：高速
+当前颜色语义只代表本车可信 GPS 速度分布：
+
+- 0-5 km/h：深红
+- 5-15 km/h：红
+- 15-30 km/h：红 -> 黄
+- 30-50 km/h：黄 -> 绿
+- 50-70 km/h：绿
+- 70-90 km/h：绿 -> 蓝
+- 90+ km/h：蓝 / 深蓝
 
 在未接道路类型 / 限速 / map matching / 实时交通数据前，不展示“严重拥堵 / 拥堵 / 畅通”等交通事实标签。
+
+更长窗口的 `TripSpeedSegmentBuilder`（例如 20-30 秒 / 200-300m 综合 segment）仍属于后续分析能力，不能把 #85 的相邻可信点颜色渲染误写成已经完成完整分段统计模型。
 
 ---
 
@@ -227,6 +261,7 @@ OBD-II 作为 P3 可选增强方向，优先只验证标准 Vehicle Speed 数据
 - 地库/隧道无 GPS
 - foreground service 异常退出
 - foreground service 仍存活但 LocationManager 长时间无 callback
+- foreground service 存活但切换其他 App 后 ROM / 系统限制导致 callback starvation
 
 TripSession 使用 `RECORDING / INTERRUPTED / COMPLETED` 状态。
 
@@ -247,23 +282,24 @@ App 启动时发现未正常结束的 Trip:
 
 ## 8. GPS / Network Provider 质量
 
-当前允许 GPS + Network provider fallback。
+当前允许 GPS + Network provider fallback，但不同 provider 不具备同等统计权限。
 
-后续原则：
+当前原则与已实现基线：
 
-- GPS 高质量点优先作为主轨迹事实
-- Network point 作为 fallback / continuity evidence
-- 不默认将 GPS 与 Network 视为同等质量
-- provider switch 必须可观察
-- 时间非常接近的 GPS / Network point 需要去重/择优，避免重复计距离
-- network 漂移点不能制造假距离或假速度
+- GPS 高质量点优先作为主轨迹事实。
+- Network point 可作为 fallback / continuity evidence。
+- 时间非常接近的 GPS / Network point 通过 continuity rule 做去重/择优基线，避免重复计距离。
+- Network / coarse speed 不允许刷新最高速度。
+- PR #85 后，Network / coarse speed 也不允许给 route speed segment 上色。
+- provider switch 与 rejected point 继续保留诊断价值。
+- 原始 TripPoint 不因派生统计过滤而被重写。
 
 GPS 海拔:
 
-- 保存 raw altitude + vertical accuracy（有则保存）
-- UI 标注“GPS 海拔”
-- 累计爬升/下降必须经过平滑后计算
-- 不宣称测绘级精度
+- 保存 raw altitude + vertical accuracy（有则保存）。
+- PR #83 已在 Trip 详情展示起点 / 终点 / 最低 / 最高海拔。
+- 累计爬升/下降仍必须经过平滑后计算，当前未实现。
+- 不宣称测绘级精度。
 
 ---
 
@@ -280,13 +316,22 @@ PR #36 已增加：
 - 同一条通知周期刷新，不刷屏
 - 不显示经纬度或精确地址
 
-后续继续补：
+PR #80 已增加 callback-liveness 修正：
 
-- service restart / re-delivery evidence
+- LocationManager `minDistance` 从 8m 调整为 0m；
+- 系统 callback 与业务写库节流解耦；
+- 业务层继续使用 stationary heartbeat 控制 Room 写入。
+
+诊断事件已经覆盖 service start / START_REDELIVER_INTENT redelivery / destroy / provider disabled / permission missing / location registration failure 等核心生命周期证据。
+
+仍需继续补或真机确认：
+
 - provider counters
 - longest gap / cumulative gap summary
+- 切换其他 App 5-10 分钟后的真实 callback continuity
+- Android 厂商后台限制/电池优化导致 starvation 时的修复引导
 
-该方向与 Issue #26 的后台活动可见性方案保持一致。
+该方向由 #77 与 #26 分别承担数据可靠性和后台修复 UX。
 
 ---
 
@@ -294,16 +339,16 @@ PR #36 已增加：
 
 禁止将长时间缺失的两个 GPS 点直接画成可信实线。
 
-PR #36 已按 `>=120s` gap 将路线几何拆成多个可信 segment；预览只绘制 segment 内部连续轨迹。
+当前按 `>=120s` gap 将路线几何拆成多个可信 segment；预览只绘制 segment 内部连续轨迹。
 
 ```text
 已知轨迹 ━━━━━     ━━━━━ 已知轨迹
              GPS 缺失
 ```
 
-无 basemap 阶段即可做断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+同时，距离统计已与该语义对齐：长 gap 两端不再直接累计可信直线距离，也不计算该 gap 的移动/静止时长和 aggregate speed。
 
-下一步必须让距离聚合与可视化语义一致：长 gap 两端不能继续直接累计直线距离。
+无 basemap 阶段即可做断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
 
 ---
 
@@ -321,7 +366,7 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 
 ---
 
-## 12. 地点与充电记录
+## 12. 地点与地址展示
 
 新增充电记录支持:
 
@@ -330,6 +375,14 @@ v0.2 不默认实现“检测开车后自动偷偷开始记录”。
 - 地点名称人工编辑
 
 逆地理编码属于独立 provider，不成为保存记录的硬依赖。
+
+PR #83 已把相同的 coordinate-first 原则应用到 Trip 详情：
+
+- WGS84 起终点坐标仍是权威事实；
+- 已完成/中断 Trip 可通过现有 `AndroidGeocoderAddressResolver` 解析起终点地址用于展示；
+- 地址作为主阅读文本，坐标作为技术参数保留；
+- geocoder 失败显示“地址暂不可用”，不得阻止 Trip 完成或虚构地点；
+- RECORDING 中不反复解析实时 endpoint 地址。
 
 后续 ChargingPlace 设计见 `DATA_QUALITY_BACKUP.md`。
 
@@ -359,29 +412,40 @@ Core 已完成：
 - [x] 充电记录可绑定当前位置
 - [x] 用户手动开始/结束行程
 - [x] 经纬度 / GPS 海拔 / 速度 / 精度 / 时间
-- [x] elapsed / moving / stopped time
+- [x] elapsed / moving / stopped time 数据结构与基础累计
 - [x] 距离 / 平均速度 / 最高速度
 - [x] Trip 绑定具体 Vehicle
 - [x] 中断行程恢复
 - [x] 删除 Trip 同步处理 TripPoint
+- [x] Trip 起终点地址展示 + 坐标技术参数
+- [x] Trip 起点圆形 / 终点方形语义标记
+- [x] Trip 起点 / 终点 / 最低 / 最高海拔展示
 
-P0 reliability follow-up：
+P0 reliability：
 
 - [x] 运行时 GPS health / accepted point heartbeat
 - [x] GPS LOST / LONG_GAP ongoing notification
 - [x] long gap 路线断开，不画可信实线
-- [ ] 长 gap 两端不参与可信距离累计
-- [ ] GPS/Network 去重与择优
+- [x] 长 gap 两端不参与可信距离/时长/aggregate speed
+- [x] GPS/Network 时间邻近去重/择优基线
+- [x] service start / destroy / re-delivery 等诊断事件
+- [x] Network / coarse point 不得制造最高速度峰值
 - [ ] longest gap / provider counters / rejected reason 持久摘要
-- [ ] service restart / re-delivery evidence
-- [ ] 锁屏长行程真机复验
+- [ ] 切换其他 App 后后台 callback / 距离连续性真机复验（#77）
+- [ ] 2-3 分钟红灯 stationary heartbeat / stoppedSeconds 真机复验（#77）
+- [ ] 最高已记录速度与车辆实际峰值真机复验（#78）
 
 P1 speed visualization：
 
-- [x] 全程平均 / 行驶平均明确区分
-- [ ] TripSpeedSegment 派生模型
-- [ ] 连续速度颜色映射
-- [ ] 短时峰值与 segment speed 分开展示
+- [x] 全程平均 / 行驶平均 / 最高速度明确区分
+- [x] 可信 GPS 速度连续颜色 route preview
+- [x] 不可信/未知速度 segment 保持中性灰色
+- [x] 长 GPS gap 不跨缺口上色或画可信实线
+- [x] UI 明确“本车速度分布”，不宣称真实道路拥堵
+- [ ] `TripSpeedSegmentBuilder` 长窗口派生模型
+- [ ] 20-30s / 200-300m 等综合 segment 平均速度与 JVM tests
+- [ ] 短时峰值与综合 segment speed 的进一步分析展示
+- [ ] 彩色 route dark/light 真机视觉验收（#67）
 
 P3 optional vehicle data：
 
@@ -396,6 +460,16 @@ Optional：
 ---
 
 ## 15. 变更记录
+
+### v1.4.0
+
+- 同步 2026-08-27 第二轮真机 Trip 证据与 #77/#78 新 P0 reliability ownership。
+- 同步 PR #80：LocationManager 取消 8m callback 位移门槛，系统 callback 与 15s stationary heartbeat 写库节流解耦。
+- 修正长 gap 状态：`>=120s` 已不计可信距离、duration 与 aggregate speed，不再是 future follow-up。
+- 同步 PR #82：最高已记录速度只允许通过可信 GPS 质量门的 candidate，Network 粗速度保留原始事实但不更新 max。
+- 同步 PR #83：Trip 详情展示起/终/最低/最高海拔，起终点地址作为派生展示、坐标保持权威技术参数，起点圆形/终点方形避免只靠颜色区分。
+- 同步 PR #85：相邻两端都可信时按本车 GPS 速度连续着色；未知/不可信段保持灰色；交通拥堵语义继续禁止。
+- 明确上述 CI/代码完成不等于后台连续性、最高速或彩色轨迹的最终真机验收。
 
 ### v1.3.0
 

--- a/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
+++ b/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
@@ -1,21 +1,30 @@
 # Trip GPS Reliability & Speed Visualization Plan
 
-版本: v1.0.0
+版本: v1.1.0
 更新时间: 2026-08-27
-状态: Design / Future Implementation
+状态: Partially Implemented / Physical Acceptance Pending
 
 ## 1. 背景
 
-2026-08-27 的真实 Trip #7 数据暴露出两个需要优先处理的问题：
+2026-08-27 的真实 Trip 数据连续暴露出两个核心方向：
 
-1. 单一全程平均速度无法表达高速、城市道路、拥堵/低速等不同区段的驾驶特征。
-2. 行程中出现多段明显 GPS 空洞，最长可达十分钟级，不能继续只靠最终 COMPLETED 状态判断记录是否可靠。
+1. 单一全程平均速度无法表达高速、城市道路、停车/低速等不同区段的驾驶特征。
+2. `COMPLETED` 不能证明中间 GPS 连续；后台 callback、provider fallback、业务过滤与真实 GPS loss 必须可区分。
 
-该文档只定义后续实现方向，不修改现有原始 Trip 数据口径。
+本文档最初基于 Trip #7 建立 P0 GPS reliability + P1 speed visualization 方案。第二轮真机 Trip 又确认：
+
+- 切换其他 App 时仍可能出现移动中长时间轨迹空洞；
+- 2-3 分钟红灯可能因 callback/accepted point 间隔被误解为长 gap；
+- Network provider 的粗定位 speed 可以制造 122+ km/h 假峰值；
+- 海拔、地址、起终点标记和速度颜色需要真正落到 Trip 详情。
+
+当前多项代码已经进入 `main`，但后台连续性、最高速度实际一致性与彩色轨迹视觉仍需下一轮真机验收。CI 不能代替这些物理设备结论。
 
 ---
 
 ## 2. 真实数据证据
+
+### 2.1 第一轮：Trip #7
 
 Trip #7：
 
@@ -27,15 +36,42 @@ Trip #7：
 - maxSpeedMps: 25.92 m/s（约 93.3 km/h）
 - status: COMPLETED
 
-但 TripPoint 中存在多段长时间缺口，例如：
+TripPoint 中存在多段长时间缺口，例如：
 
 - Point 64 -> 65 约 749 秒（12 分 29 秒）
 - Point 70 -> 71 约 917 秒（15 分 17 秒）
 
-因此：
+由此确认：
 
 - `COMPLETED` 只能说明 Trip 最终正常收口，不代表中间 GPS 连续。
 - 需要独立的 GPS health / continuity 指标。
+- 长 gap 两端不能被画成可信连续路线。
+
+### 2.2 第二轮：2026-08-27 Trip #2
+
+第二轮实机导出进一步暴露：
+
+- distanceMeters: 约 24.20 km
+- elapsed: 约 83 分 45 秒
+- moving: 约 51 分 25 秒
+- stoppedSeconds: 仅 15 秒，明显不符合城市道路红灯实际
+- maxSpeed: 约 122.4 km/h，但车辆实际返程没有该速度
+- Session 已保存 start/end/min/max altitude，但 UI 当时未展示
+
+典型 continuity 证据：
+
+- Point 42 -> 43：约 643 秒（10 分 43 秒），坐标发生公里级变化，属于真实移动期间记录空洞。
+- Point 109 -> 110：约 465 秒（7 分 45 秒），恢复时先出现 coarse network fallback。
+- 一组红灯样本约 140 秒间隔，起始点 speed=0，符合“车辆静止但系统/业务没有保留足够 heartbeat”的误分类风险。
+
+典型假速度证据：
+
+- provider: `network`
+- horizontal accuracy: 约 100m
+- speed accuracy: null
+- reported speed: 34.005 m/s（约 122.4 km/h）
+
+另有类似 network point 报出约 142.6 km/h，说明不能把 Network `Location.speed` 与高质量 GPS 速度视为同等统计事实。
 
 ---
 
@@ -46,29 +82,32 @@ Trip #7：
 下一次出现断点时，必须能区分：
 
 - Foreground Service 被系统杀/重启
-- LocationManager 长时间没有回调
+- LocationManager 长时间没有 callback
 - GPS provider 不可用
 - network provider fallback
 - Location 被业务过滤
 - 权限或系统定位状态异常
+- 车辆实际静止但 tracking callback 仍健康
 
-### 3.2 需要记录的运行时状态
+### 3.2 运行时状态
 
-建议先以轻量内存状态 + Trip 级派生摘要实现，是否落库后续再决定。
+当前运行时已经覆盖主要 health 信息：
 
-至少包括：
+- `lastLocationCallbackAt`
+- `lastAcceptedPointAt`
+- recent accepted provider
+- rejected point count
+- foreground service lifecycle diagnostic events
 
-- lastLocationCallbackAt
-- lastAcceptedPointAt
-- lastGpsPointAt
-- lastNetworkPointAt
+仍建议继续补充 Trip 级持久摘要：
+
+- lastGpsPointAt / lastNetworkPointAt
 - acceptedPointCount
-- rejectedPointCount
 - rejectedByAccuracyCount
 - rejectedByJumpCount
 - providerSwitchCount
-- serviceStartCount / serviceRestartCount（若能可靠识别）
 - longestLocationGapSeconds
+- cumulative gap summary
 
 ### 3.3 GPS Health 状态
 
@@ -79,78 +118,164 @@ UI / Notification 使用统一派生状态：
 - LOST：> 30s
 - LONG_GAP：> 120s
 
-阈值为初始建议，必须通过真机数据调优，不能作为固定业务事实。
+阈值仍属于可调 reliability 参数，必须通过真实设备继续验证。
 
 ### 3.4 Notification
 
-Foreground notification 后续至少展示：
+Foreground notification 已实现：
 
 - 正在记录行程
-- 已记录时长
-- 已记录距离
-- GPS 状态
+- GPS health
 - 最近有效定位时间
+- recent accepted provider
+- rejected point count
 - 结束行程动作
+- LOST / LONG_GAP 使用同一条 ongoing notification 更新，不刷屏
 
-当 GPS LOST / LONG_GAP 时更新同一条 ongoing notification，不重复刷通知。
+后续 #26 继续补：
+
+- 已记录时长
+- 已记录可信距离
+- 点击通知进入当前 Trip
+- provider/permission/background restriction 修复入口
 
 ### 3.5 Service 生命周期
 
-当前服务已使用 location foreground service + `START_REDELIVER_INTENT`。
+当前服务继续使用 location foreground service + `START_REDELIVER_INTENT`。
 
-后续需要明确记录：
+已记录的关键诊断事件包含：
 
-- onCreate / onStartCommand / onDestroy
-- start reason / restored intent
-- 是否发生 service re-delivery
+- service start
+- START_REDELIVER_INTENT redelivery
+- service destroy
+- provider disabled
+- permission missing
+- location registration failed
+- sampled rejected location event
 
-目的不是永久日志堆积，而是能解释真实行程中的 GPS 空洞。
+这些事件用于解释断点，不用于长期堆积无界日志。
 
-### 3.6 GPS / Network provider 融合
+### 3.6 callback 与 stationary heartbeat
 
-当前允许 GPS + Network provider 同时进入 TripPoint。
+第二轮真机发现了一个明确冲突：
 
-后续原则：
+```text
+LocationManager minDistance = 8m
+        +
+TripSamplingRules stationary heartbeat = 15s
+```
 
-- GPS 高质量点优先作为主轨迹事实
-- Network point 作为 fallback / continuity evidence
-- 不默认把 GPS 与 Network 视为同等质量
-- provider 切换需可观察
-- 避免 network 漂移点制造假距离或假速度
+车辆停在红灯时，如果系统层因为没有移动 8m 而不产生 callback，业务层就无法执行 15s stationary heartbeat。下一次 accepted point 若超过 120s，可能被当成 LONG_GAP。
+
+PR #80 已进入 `main`：
+
+- LocationManager `minDistance` 从 8m 调整为 0m；
+- 保持约 4 秒 callback request interval；
+- Room 写入仍由 `TripSamplingRules` 负责降频；
+- stationary heartbeat 继续约 15 秒一条；
+- JVM test 覆盖 stationary heartbeat 增加 `stoppedSeconds` 而不增加 `movingSeconds`。
+
+该改动解决“代码层两套门槛互相打架”，但仍必须通过 #77 的真机流程验证：切到其他 App 后 callback/距离是否真的持续。
+
+### 3.7 GPS / Network provider 融合
+
+当前允许 GPS + Network provider 进入原始 TripPoint，但统计权限分层：
+
+- GPS 高质量点优先作为主轨迹/速度事实。
+- Network point 保留为 fallback / continuity / diagnostic evidence。
+- 时间非常接近的 GPS / Network point 使用 continuity rule 去重/择优。
+- Network 粗速度不能制造最高速度。
+- Network 粗速度不能给速度彩色轨迹上色。
+- 原始数据不因为统计过滤而被删除或改写。
 
 ---
 
-## 4. P1 - 分段速度模型
+## 4. P0 - 最高速度可信度
 
-### 4.1 三种速度必须区分
+### 4.1 问题
+
+第二轮实机的 122.4 km/h 最高速来自 coarse `network` point，而非可信 GPS 峰值。
+
+因此“原始 Location.speed 存在”不等于“允许进入 maxSpeedMps”。
+
+### 4.2 已实现质量门
+
+PR #82 已进入 `main`，新增独立 max-speed trust gate。
+
+最高速度 candidate 必须同时满足：
+
+- existing aggregate continuity/distance corroboration；
+- provider = `gps`；
+- horizontal accuracy <= 25m；
+- speedAccuracy 存在时 <= 3 m/s；
+- speed 为 finite 且非负。
+
+Network / coarse point 的原始速度仍保留在 TripPoint，只是不再污染派生最高速度。
+
+JVM regression 已覆盖：
+
+- 122.4 km/h network + 100m accuracy 被拒绝；
+- 合理 GPS highway peak 可以通过；
+- coarse GPS peak 被拒绝。
+
+### 4.3 仍需真机确认
+
+#78 继续保持 open，下一轮需要把 App 的“最高已记录速度”与车辆实际峰值进行对照。
+
+产品文案仍应理解为“最高已记录可信 GNSS 速度”，不是车辆真实最高速度的绝对证明，因为短时峰值可能恰好没有被采到。
+
+---
+
+## 5. P1 - 分段速度模型
+
+### 5.1 三种速度必须区分
 
 Trip UI 至少区分：
 
-1. 全程平均速度：总距离 / elapsed time
-2. 行驶平均速度：总距离 / moving time
-3. 分段平均速度：某一区段内的有效距离 / 时间
+1. 全程平均速度：总可信距离 / elapsed time
+2. 行驶平均速度：总可信距离 / moving time
+3. 分段/轨迹速度：可信 segment 的显示或分析派生
+4. 最高已记录速度：经异常过滤的可信 GNSS `Location.speed` 峰值
 
-现有 `averageSpeedMps` 当前更接近 moving-average 口径，后续 UI 必须明确命名，避免用户把它理解成全程平均。
+当前 UI 已明确显示全程均速 / 行驶均速 / 最高速度 / 移动时间。
 
-### 4.2 TripSpeedSegment
+### 5.2 第一版 route speed visualization 已实现
 
-先做派生模型，不新增 Room 表：
+PR #85 已实现轻量第一版，不新增 Room 表：
+
+```text
+TripPoint[]
+  -> trusted measured-speed gate
+  -> TripGeoPoint(speed?)
+  -> TripRouteGeometryBuilder
+  -> colored route renderer
+```
+
+规则：
+
+- 只有相邻两端都拥有可信 GPS speed，该线段才有速度颜色；
+- 任一端 speed 不可信/缺失，该线段保持中性灰色；
+- 不能把未知速度当作 0 km/h；
+- 长 GPS gap 在 geometry 层仍保持断开；
+- downsample/normalize 后保留可信 speed metadata。
+
+### 5.3 完整 TripSpeedSegment 仍是 future
+
+原计划的更长窗口派生模型仍有价值：
 
 ```text
 TripPoint[]
   -> TripSpeedSegmentBuilder
   -> TripSpeedSegment[]
-  -> UI renderer
+  -> analytics / UI
 ```
 
-推荐区段切分优先按时间/距离混合：
+推荐继续研究：
 
 - 20-30 秒，或
 - 200-300 米
 
-具体阈值通过真实数据调优。
-
-每个 segment 至少包含：
+每个 segment 可包含：
 
 - start/end timestamp
 - distance
@@ -159,25 +284,28 @@ TripPoint[]
 - min/max speed（可选）
 - GPS quality / gap flag
 
+注意：PR #85 的“相邻可信 GPS speed 颜色”不是完整的 `TripSpeedSegmentBuilder`。文档必须保持两者边界。
+
 ---
 
-## 5. P1 - 速度颜色映射
+## 6. P1 - 速度颜色映射
 
-### 5.1 初始视觉语义
+### 6.1 当前视觉语义
 
 在未接道路类型/限速/交通数据前，不使用“严重拥堵 / 畅通”等交通事实词。
 
-先使用本车速度语义：
+当前使用本车速度语义：
 
 - 深红：极低速
 - 红：低速
 - 黄：较慢
 - 绿：正常/快速
 - 蓝：高速
+- 灰：速度数据不足 / 不可信
 
-### 5.2 连续颜色而不是四档硬切
+### 6.2 连续颜色
 
-建议采用连续渐变：
+PR #85 已按以下连续映射实现：
 
 - 0-5 km/h：深红
 - 5-15 km/h：红
@@ -187,9 +315,9 @@ TripPoint[]
 - 70-90 km/h：绿 -> 蓝
 - 90+ km/h：蓝 / 深蓝
 
-最终颜色阈值属于 UI 配置，不写入原始 TripPoint。
+最终颜色只属于 UI 派生，不写回原始 TripPoint。
 
-### 5.3 交通语义边界
+### 6.3 交通语义边界
 
 在没有道路类型 / 限速 / map matching / 实时交通数据前：
 
@@ -197,72 +325,184 @@ TripPoint[]
 - 15 km/h 可能只是小区道路
 - 40 km/h 在城市道路可能畅通，在高速可能拥堵
 
-因此彩色轨迹代表“本车实际速度分布”，不是“道路拥堵等级”。
+因此彩色轨迹代表“本车可信 GPS 速度分布”，不是“道路拥堵等级”。
+
+UI 已明确说明该边界。
 
 ---
 
-## 6. GPS Gap 可视化
+## 7. P1 - Trip detail facts
+
+第二轮真机同时暴露了三个展示缺口，PR #83 已进入 `main`：
+
+### 7.1 海拔
+
+当前 Trip detail 可展示已持久化的：
+
+- 起点海拔
+- 终点海拔
+- 最低海拔
+- 最高海拔
+
+当前不计算累计爬升/下降；raw altitude 需要经过 vertical accuracy / smoothing 后再做高程分析。
+
+### 7.2 起终点地址
+
+- WGS84 坐标继续作为权威事实。
+- 已完成/中断 Trip 使用现有 `AndroidGeocoderAddressResolver` 做展示层 reverse geocoding。
+- 地址作为主阅读文本，坐标保留为技术参数。
+- geocoder 失败显示“地址暂不可用”，不阻止 Trip 完成。
+- RECORDING 状态不反复解析实时 endpoint。
+
+### 7.3 起终点 marker
+
+原先两端仅使用两个同形状、不同颜色的小点，真机不易辨认。
+
+当前改为：
+
+- 起点：圆形 + `起点 · 圆形`
+- 终点：方形 + `终点 · 方形`
+- Canvas accessibility semantics 明确两者含义
+
+因此不再只依赖红/绿颜色区分。
+
+---
+
+## 8. GPS Gap 可视化与统计
 
 禁止把长时间缺失的两端 GPS 点直接连成实线路线。
 
-建议：
+当前规则：
+
+- `>=120s` gap 后 renderer 拆成 disconnected segment；
+- gap 两端不累计可信直线距离；
+- gap duration 不进入 moving/stopped 统计；
+- gap 不允许刷新 aggregate/max speed；
+- speed-colored route 同样不会跨 gap 画线。
 
 ```text
-已知轨迹 ━━━━━ · · · · · ━━━━━ 已知轨迹
-               GPS 缺失
+已知轨迹 ━━━━━     ━━━━━ 已知轨迹
+             GPS 缺失
 ```
 
-规则：
-
-- gap 超过阈值后，renderer 标记为 disconnected segment
-- 无 basemap 阶段可用虚线/断开提示
-- MapLibre 阶段使用独立 dashed polyline
-- 不做假 map matching，不补造路径
+无 basemap 阶段继续使用断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
 
 ---
 
-## 7. 验收标准
+## 9. 当前验收状态
 
 ### P0 GPS Reliability
 
-- [ ] 能显示最近有效定位时间
-- [ ] 能识别 >30s GPS gap
-- [ ] 能统计最长 GPS gap
-- [ ] 能区分 accepted / rejected point
-- [ ] 能区分 GPS / Network provider
-- [ ] 能判断 service 是否发生 restart / re-delivery（若 Android 生命周期允许可靠识别）
-- [ ] GPS 长时间丢失时 ongoing notification 明确提示
-- [ ] 真实锁屏行程完成后能解释轨迹断点原因
+- [x] 显示最近有效定位时间
+- [x] 识别 >30s GPS gap，并提供 LOST / LONG_GAP health
+- [x] 区分 GPS / Network provider 基线
+- [x] rejected point 运行时计数 / sampled diagnostic
+- [x] service start / destroy / redelivery 等生命周期诊断事件
+- [x] GPS 长时间丢失时 ongoing notification 明确提示
+- [x] `>=120s` 长 gap 路线断开且不累计可信距离/时长
+- [x] LocationManager 8m callback gate 移除，stationary heartbeat 可在业务层执行
+- [ ] longest gap / provider counters / rejected reason 的 Trip 级持久摘要
+- [ ] 切换其他 App 5-10 分钟仍持续 callback / 距离更新真机复验（#77）
+- [ ] 2-3 分钟红灯不产生 false LONG_GAP，且 stoppedSeconds 合理真机复验（#77）
 
-### P1 Speed Segmentation
+### P0 Speed Trust
 
-- [ ] UI 区分全程平均 / 行驶平均 / 最高速度
-- [ ] TripSpeedSegment 为派生模型，不改原始点
-- [ ] 分段平均速度有 JVM tests
-- [ ] 轨迹支持连续颜色映射
-- [ ] 长 GPS gap 不画成可信实线
-- [ ] 未接交通数据前不宣称“真实拥堵等级”
+- [x] Network/coarse speed 不得刷新 maxSpeedMps
+- [x] max-speed quality gate 有 JVM regression
+- [ ] 下一次真实行程与车辆仪表峰值对照（#78）
+
+### P1 Speed Visualization
+
+- [x] UI 区分全程平均 / 行驶平均 / 最高速度
+- [x] 可信 GPS route 支持连续颜色映射
+- [x] 不可信/未知 speed segment 使用中性灰色
+- [x] 长 GPS gap 不画成可信实线
+- [x] 未接交通数据前不宣称“真实拥堵等级”
+- [x] trusted speed metadata 经过 geometry normalize/gap segmentation 有 JVM test
+- [ ] `TripSpeedSegmentBuilder` 长窗口派生模型
+- [ ] 分段平均速度综合模型 JVM tests
+- [ ] 彩色路线 dark/light 真机视觉复验（#67）
+
+### P1 Trip detail
+
+- [x] 起/终/最低/最高海拔展示
+- [x] 起终点地址展示，坐标保持技术参数
+- [x] 起点圆形 / 终点方形 + 文本语义
+- [ ] 地址 Geocoder 真实设备成功/失败路径复验（#66）
+- [ ] 海拔与 marker dark/light 真机视觉复验（#69/#42）
 
 ---
 
-## 8. 实施顺序
+## 10. 下一轮真机验收脚本
+
+一次 20-30 分钟测试即可覆盖当前主要 blocker：
+
+1. 前台开始 Trip，正常行驶 3-5 分钟。
+2. 锁屏一段时间，确认 foreground notification 仍存在。
+3. 解锁后切换到抖音/其他 App，保持该 App 前台 5-10 分钟并继续行驶。
+4. 找一次约 2-3 分钟停车/红灯场景。
+5. 恢复行驶，再返回 EV Charge Book 结束 Trip。
+6. 对照车辆仪表记住本次大致最高速度。
+
+必须检查：
+
+- [ ] 切其他 App 时累计距离继续增长，没有新的公里级移动空洞
+- [ ] 红灯期间产生合理 stoppedSeconds，不被误判成 LONG_GAP
+- [ ] 真正 GPS/callback 丢失仍会显示 LOST/LONG_GAP
+- [ ] 最高已记录速度与车辆实际峰值合理接近，不再出现 network 122+ km/h 假峰值
+- [ ] 起/终/最低/最高海拔可见
+- [ ] 起终点优先展示地址，地址失败时仍显示坐标且不虚构地点
+- [ ] 起点圆形 / 终点方形一眼可分
+- [ ] route 能看到低/中/高速度的红黄绿蓝变化
+- [ ] 灰色只用于不可信/缺失速度区间
+- [ ] 长 GPS gap 仍保持断开
+- [ ] Dark / Light 下轨迹和图例都可读
+
+只有真机通过后，才可以关闭 #77/#78/#67 对应 acceptance；不能用 Android CI 直接替代。
+
+---
+
+## 11. 实施顺序
+
+当前已完成代码主线：
 
 ```text
-P0: GPS callback / service lifecycle telemetry
-  -> GPS health state
-  -> notification health display
-  -> provider quality / gap diagnostics
-
-P1: TripSpeedSegmentBuilder
-  -> 全程/行驶平均速度口径
-  -> SpeedColorScale
-  -> 彩色 route preview
-  -> GPS gap dashed/disconnected rendering
-
-P2: MapLibre renderer
-  -> true basemap
-  -> colored polyline
-  -> dashed GPS gaps
+PR #36 GPS health / diagnostics / gap route split
+  -> PR #80 callback liveness + stationary heartbeat enablement
+  -> PR #82 trusted max-speed gate
+  -> PR #83 altitude / address / endpoint semantics
+  -> PR #85 trusted speed-colored route preview
 ```
 
-MapLibre 仍为低优先级，不应阻塞 P0 GPS reliability。
+下一步：
+
+```text
+Physical acceptance #77/#78/#67/#66/#69/#42
+  -> longest gap/provider summary（必要时）
+  -> TripSpeedSegmentBuilder 长窗口分析（P1）
+  -> MapLibre renderer（P2，可选，不阻塞 reliability）
+```
+
+MapLibre 仍为低优先级，不应阻塞 P0 GPS reliability 和当前本地 Trip 体验收口。
+
+---
+
+## 12. 变更记录
+
+### v1.1.0
+
+- 保留 Trip #7 第一轮十分钟级 GPS gap 历史证据。
+- 新增 2026-08-27 Trip #2 第二轮真机证据：后台切 App 空洞、红灯 stationary gap 风险、122.4 km/h network 假峰值、海拔/地址/marker/速度色轨反馈。
+- 同步 PR #80 callback-liveness 修复，并保留 #77 真机验收门。
+- 同步 PR #82 max-speed trusted GPS quality gate，并保留 #78 仪表对照验收门。
+- 同步 PR #83 Trip altitude/address/endpoint marker 实现。
+- 同步 PR #85 trusted GPS speed-colored route；两端都可信才上色，未知段灰色。
+- 明确完整 `TripSpeedSegmentBuilder` 尚未实现，不能把第一版 route visualization 写成完整 segment analytics。
+- 状态从 `Design / Future Implementation` 更新为 `Partially Implemented / Physical Acceptance Pending`。
+
+### v1.0.0
+
+- 基于真实 Trip #7 建立 P0 GPS reliability 与 P1 speed visualization 方案。
+- 明确 COMPLETED 不等于 GPS continuity。
+- 定义 GPS health、provider quality、速度颜色与交通语义边界。
+- 明确长 GPS gap 不得以实线伪造。


### PR DESCRIPTION
## Summary

Synchronize the two Trip authority documents with the 2026-08-27 second physical-device test and the implementation now merged through PRs #80, #82, #83 and #85.

## Documents

### `docs/LOCATION_TRIP.md` -> v1.4.0
- distinguish LocationManager callback liveness from application-level persistence throttling
- record the merged `minDistance=0m` callback change and existing ~15s stationary heartbeat
- correct stale wording: `>=120s` long-gap endpoints already do not contribute trusted distance/duration/aggregate speed
- document trusted max-speed GPS quality rules from #82
- document altitude/address/endpoint semantics from #83
- document trusted speed-colored route behavior from #85
- keep #77/#78/#67 physical-device acceptance explicitly open

### `docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` -> v1.1.0
- preserve the original Trip #7 evidence
- add the second Trip #2 evidence: background app-switch gaps, red-light stationary classification risk, coarse network 122.4km/h peak, and missing display features
- change status from `Design / Future Implementation` to `Partially Implemented / Physical Acceptance Pending`
- record what #80/#82/#83/#85 actually implemented
- keep `TripSpeedSegmentBuilder` long-window analytics clearly future work
- add a compact next physical acceptance script

## Important boundary

This PR does not claim the physical issues are solved merely because code and CI are green.

Still open for real-device verification:
- #77 app-background callback/distance continuity and 2–3 minute stationary stop
- #78 max-speed parity with the vehicle's real peak
- #67 trusted route colors / gray uncertain segments / dark-light readability
- #66 address resolution physical path
- #69 altitude display/elevation follow-up
- #42 endpoint/accessibility visual acceptance

## Conflict boundary

This PR only changes:
- `docs/LOCATION_TRIP.md`
- `docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`

It intentionally does not touch the seven UI/project documents currently owned by open PR #74.