### PR TITLE
feat(android): derive trip energy from SOC and update vehicle state

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -454,14 +454,25 @@ fun MainApp(
                         if (estimate.consumedEnergyKwh != null) {
                             HorizontalDivider()
                             Text(
-                                "SOC ${active.startSoc}% → ${endSoc}% · 消耗约 ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
+                                "SOC ${active.startSoc}% → ${endSoc}% · 估算消耗 ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
                                 style = MaterialTheme.typography.bodyMedium
                             )
                             Text(
-                                estimate.averageConsumptionKwhPer100Km?.let { "平均能耗 ${String.format(Locale.US, "%.1f", it)} kWh/100km" }
+                                estimate.averageConsumptionKwhPer100Km?.let { "估算平均能耗 ${String.format(Locale.US, "%.1f", it)} kWh/100km" }
                                     ?: "距离不足，暂不能计算平均能耗",
                                 style = MaterialTheme.typography.titleMedium,
                                 color = MaterialTheme.colorScheme.primary
+                            )
+                        } else if (active.startSoc != null && endSoc != null && endSoc in 0..100) {
+                            HorizontalDivider()
+                            Text(
+                                if (endSoc >= active.startSoc) {
+                                    "SOC 未下降或出现回升；可能来自取整、回收制动或补能，本次不强行计算行驶能耗。"
+                                } else {
+                                    "当前数据不足以形成可靠的 SOC 能耗估算。"
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                         tripCompletionError?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
@@ -473,7 +484,6 @@ fun MainApp(
                         val parsedMileage = tripEndMileageText.toDoubleOrNull()
                         tripCompletionError = when {
                             parsedSoc == null || parsedSoc !in 0..100 -> "请输入 0~100 的结束 SOC"
-                            active.startSoc != null && parsedSoc > active.startSoc -> "结束 SOC 不能高于开始 SOC"
                             tripEndMileageText.isNotBlank() && (parsedMileage == null || parsedMileage < 0.0) -> "请输入有效的结束总里程"
                             active.startMileageKm != null && parsedMileage != null && parsedMileage < active.startMileageKm -> "结束里程不能低于开始里程"
                             else -> null

--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -12,13 +12,15 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -27,14 +29,17 @@ import androidx.core.content.ContextCompat
 import com.evchargebook.bluetooth.BluetoothConnectionStateChecker
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.export.ChargingCsvExporter
 import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.ui.dashboard.DashboardScreen
 import com.evchargebook.ui.records.AddRecordScreen
 import com.evchargebook.ui.records.RecordEditScreen
 import com.evchargebook.ui.records.RecordsScreen
 import com.evchargebook.ui.stats.StatsScreen
 import com.evchargebook.ui.theme.EvChargeTheme
+import com.evchargebook.ui.trip.TripReadyScreen
 import com.evchargebook.ui.trip.TripScreen
 import com.evchargebook.ui.vehicle.BluetoothPromptScreen
 import com.evchargebook.ui.vehicle.VehicleCatalogScreen
@@ -104,6 +109,10 @@ fun MainApp(
     var pendingRestoreContent by remember { mutableStateOf<String?>(null) }
     var pendingResumeTripId by remember { mutableStateOf<Long?>(null) }
     var promptedConnectedAddress by remember { mutableStateOf<String?>(null) }
+    var showTripCompletion by remember { mutableStateOf(false) }
+    var tripEndSocText by remember { mutableStateOf("") }
+    var tripEndMileageText by remember { mutableStateOf("") }
+    var tripCompletionError by remember { mutableStateOf<String?>(null) }
 
     fun showBluetoothTripPrompt(message: String) {
         viewModel.closeTripDetail()
@@ -213,6 +222,17 @@ fun MainApp(
         }
     }
 
+    fun requestTripCompletion() {
+        val active = state.activeTrip ?: return
+        tripEndSocText = ""
+        tripEndMileageText = active.startMileageKm
+            ?.plus(active.distanceMeters / 1000.0)
+            ?.let { String.format(Locale.US, "%.1f", it) }
+            .orEmpty()
+        tripCompletionError = null
+        showTripCompletion = true
+    }
+
     val hasOverlayPage = editVehicle || addVehicle || selectCatalogVehicle || bluetoothPrompt || addRecord || editingRecord != null || state.selectedTripId != null
     BackHandler(enabled = hasOverlayPage) {
         when {
@@ -315,20 +335,33 @@ fun MainApp(
                     0 -> DashboardScreen(state, { addRecord = true }, viewModel::selectVehicle)
                     1 -> RecordsScreen(state.chargingRecords, viewModel::deleteChargingRecord, { addRecord = true }, { editingRecord = it })
                     2 -> StatsScreen(state)
-                    3 -> TripScreen(
-                        vehicle = state.vehicle,
-                        vehicles = state.vehicles,
-                        trips = state.trips,
-                        activeTrip = state.activeTrip,
-                        selectedTripId = state.selectedTripId,
-                        selectedTripPoints = state.selectedTripPoints,
-                        onStart = ::startTripWithPermission,
-                        onResume = ::resumeTripWithPermission,
-                        onStop = viewModel::stopTrip,
-                        onOpenDetail = viewModel::openTripDetail,
-                        onCloseDetail = viewModel::closeTripDetail,
-                        onDelete = viewModel::deleteTrip
-                    )
+                    3 -> {
+                        if (state.activeTrip == null && state.selectedTripId == null) {
+                            TripReadyScreen(
+                                vehicle = state.vehicle,
+                                currentSoc = state.currentSoc,
+                                currentMileageKm = state.currentMileageKm,
+                                recentTrips = state.trips.filter { it.status == TripStatus.COMPLETED },
+                                onStart = ::startTripWithPermission,
+                                onOpenDetail = viewModel::openTripDetail
+                            )
+                        } else {
+                            TripScreen(
+                                vehicle = state.vehicle,
+                                vehicles = state.vehicles,
+                                trips = state.trips,
+                                activeTrip = state.activeTrip,
+                                selectedTripId = state.selectedTripId,
+                                selectedTripPoints = state.selectedTripPoints,
+                                onStart = ::startTripWithPermission,
+                                onResume = ::resumeTripWithPermission,
+                                onStop = ::requestTripCompletion,
+                                onOpenDetail = viewModel::openTripDetail,
+                                onCloseDetail = viewModel::closeTripDetail,
+                                onDelete = viewModel::deleteTrip
+                            )
+                        }
+                    }
                     4 -> VehicleScreen(
                         vehicle = state.vehicle,
                         vehicles = state.vehicles,
@@ -374,5 +407,85 @@ fun MainApp(
             confirmButton = { TextButton(onClick = { pendingRestoreContent = null; viewModel.restoreBackup(content) }) { Text("确认恢复", color = MaterialTheme.colorScheme.error) } },
             dismissButton = { TextButton(onClick = { pendingRestoreContent = null }) { Text("取消") } }
         )
+    }
+
+    if (showTripCompletion) {
+        val active = state.activeTrip
+        if (active == null) {
+            showTripCompletion = false
+        } else {
+            val tripVehicle = state.vehicles.firstOrNull { it.id == active.vehicleId } ?: state.vehicle
+            val endSoc = tripEndSocText.toIntOrNull()
+            val estimate = TripEnergyCalculator.estimate(
+                batteryCapacityKwh = tripVehicle?.batteryCapacityKwh,
+                startSoc = active.startSoc,
+                endSoc = endSoc,
+                distanceMeters = active.distanceMeters
+            )
+            AlertDialog(
+                onDismissRequest = { showTripCompletion = false },
+                title = { Text("完成本次行程") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text(
+                            "开始 SOC ${active.startSoc?.let { "$it%" } ?: "未知"} · GPS 距离 ${String.format(Locale.US, "%.1f", active.distanceMeters / 1000.0)} km",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        OutlinedTextField(
+                            value = tripEndSocText,
+                            onValueChange = { tripEndSocText = it.filter(Char::isDigit).take(3); tripCompletionError = null },
+                            label = { Text("结束 SOC") },
+                            suffix = { Text("%") },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        OutlinedTextField(
+                            value = tripEndMileageText,
+                            onValueChange = { tripEndMileageText = it; tripCompletionError = null },
+                            label = { Text("结束总里程") },
+                            suffix = { Text("km") },
+                            supportingText = { Text("已按开始里程 + GPS 距离预填，可修改；留空则保存时自动估算") },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        if (estimate.consumedEnergyKwh != null) {
+                            HorizontalDivider()
+                            Text(
+                                "SOC ${active.startSoc}% → ${endSoc}% · 消耗约 ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                estimate.averageConsumptionKwhPer100Km?.let { "平均能耗 ${String.format(Locale.US, "%.1f", it)} kWh/100km" }
+                                    ?: "距离不足，暂不能计算平均能耗",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                        tripCompletionError?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        val parsedSoc = tripEndSocText.toIntOrNull()
+                        val parsedMileage = tripEndMileageText.toDoubleOrNull()
+                        tripCompletionError = when {
+                            parsedSoc == null || parsedSoc !in 0..100 -> "请输入 0~100 的结束 SOC"
+                            active.startSoc != null && parsedSoc > active.startSoc -> "结束 SOC 不能高于开始 SOC"
+                            tripEndMileageText.isNotBlank() && (parsedMileage == null || parsedMileage < 0.0) -> "请输入有效的结束总里程"
+                            active.startMileageKm != null && parsedMileage != null && parsedMileage < active.startMileageKm -> "结束里程不能低于开始里程"
+                            else -> null
+                        }
+                        if (tripCompletionError == null) {
+                            showTripCompletion = false
+                            viewModel.stopTrip(parsedSoc!!, parsedMileage)
+                        }
+                    }) { Text("保存并结束") }
+                },
+                dismissButton = { TextButton(onClick = { showTripCompletion = false }) { Text("继续行驶") } }
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
+++ b/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
@@ -20,7 +20,7 @@ data class BackupPayload(
 )
 
 object BackupCodec {
-    const val CURRENT_SCHEMA_VERSION = 6
+    const val CURRENT_SCHEMA_VERSION = 7
 
     fun encode(payload: BackupPayload): String = JSONObject().apply {
         put("schemaVersion", payload.schemaVersion)
@@ -87,6 +87,12 @@ object BackupCodec {
                     putNullable("endAltitudeMeters", trip.endAltitudeMeters)
                     putNullable("minAltitudeMeters", trip.minAltitudeMeters)
                     putNullable("maxAltitudeMeters", trip.maxAltitudeMeters)
+                    putNullable("startSoc", trip.startSoc)
+                    putNullable("endSoc", trip.endSoc)
+                    putNullable("startMileageKm", trip.startMileageKm)
+                    putNullable("endMileageKm", trip.endMileageKm)
+                    putNullable("consumedEnergyKwh", trip.consumedEnergyKwh)
+                    putNullable("averageConsumptionKwhPer100Km", trip.averageConsumptionKwhPer100Km)
                     put("status", trip.status)
                 })
             }
@@ -195,6 +201,12 @@ object BackupCodec {
                         endAltitudeMeters = item.optNullableDouble("endAltitudeMeters"),
                         minAltitudeMeters = item.optNullableDouble("minAltitudeMeters"),
                         maxAltitudeMeters = item.optNullableDouble("maxAltitudeMeters"),
+                        startSoc = item.optNullableInt("startSoc"),
+                        endSoc = item.optNullableInt("endSoc"),
+                        startMileageKm = item.optNullableDouble("startMileageKm"),
+                        endMileageKm = item.optNullableDouble("endMileageKm"),
+                        consumedEnergyKwh = item.optNullableDouble("consumedEnergyKwh"),
+                        averageConsumptionKwhPer100Km = item.optNullableDouble("averageConsumptionKwhPer100Km"),
                         status = item.optString("status", TripStatus.COMPLETED)
                     )
                 )
@@ -236,6 +248,8 @@ object BackupCodec {
         require(sessions.all { it.vehicleId in vehicleIds }) { "备份中存在无法关联车辆的行程" }
         require(sessions.all { it.status in setOf(TripStatus.RECORDING, TripStatus.INTERRUPTED, TripStatus.COMPLETED) }) { "备份中存在未知行程状态" }
         require(sessions.all { (it.startLatitude == null) == (it.startLongitude == null) && (it.endLatitude == null) == (it.endLongitude == null) }) { "备份中存在不完整的行程坐标" }
+        require(sessions.all { it.startSoc == null || it.startSoc in 0..100 }) { "备份中存在无效行程开始 SOC" }
+        require(sessions.all { it.endSoc == null || it.endSoc in 0..100 }) { "备份中存在无效行程结束 SOC" }
         require(points.all { it.tripId in tripIds }) { "备份中存在无法关联行程的轨迹点" }
 
         return BackupPayload(
@@ -261,4 +275,7 @@ object BackupCodec {
 
     private fun JSONObject.optNullableLong(name: String): Long? =
         if (!has(name) || isNull(name)) null else getLong(name)
+
+    private fun JSONObject.optNullableInt(name: String): Int? =
+        if (!has(name) || isNull(name)) null else getInt(name)
 }

--- a/android/app/src/main/java/com/evchargebook/data/dao/TripDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/TripDao.kt
@@ -24,6 +24,12 @@ interface TripDao {
     @Query("SELECT * FROM trip_sessions WHERE id = :tripId LIMIT 1")
     suspend fun getSession(tripId: Long): TripSessionEntity?
 
+    @Query("SELECT * FROM trip_sessions WHERE vehicleId = :vehicleId AND status = 'COMPLETED' AND endedAtEpochMillis IS NOT NULL AND endSoc IS NOT NULL ORDER BY endedAtEpochMillis DESC, id DESC LIMIT 1")
+    suspend fun getLatestCompletedWithSocForVehicle(vehicleId: Long): TripSessionEntity?
+
+    @Query("SELECT * FROM trip_sessions WHERE vehicleId = :vehicleId AND status = 'COMPLETED' AND endedAtEpochMillis IS NOT NULL AND endMileageKm IS NOT NULL ORDER BY endedAtEpochMillis DESC, id DESC LIMIT 1")
+    suspend fun getLatestCompletedWithMileageForVehicle(vehicleId: Long): TripSessionEntity?
+
     @Query("SELECT * FROM trip_sessions ORDER BY startedAtEpochMillis")
     suspend fun getAllSessions(): List<TripSessionEntity>
 

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -29,7 +29,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
         TripDiagnosticEventEntity::class,
         VehicleStateEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -140,6 +140,17 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN startSoc INTEGER")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN endSoc INTEGER")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN startMileageKm REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN endMileageKm REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN consumedEnergyKwh REAL")
+                db.execSQL("ALTER TABLE trip_sessions ADD COLUMN averageConsumptionKwhPer100Km REAL")
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -158,7 +169,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_5_6,
                         MIGRATION_6_7,
                         MIGRATION_7_8,
-                        MIGRATION_8_9
+                        MIGRATION_8_9,
+                        MIGRATION_9_10
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/entity/TripSessionEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/TripSessionEntity.kt
@@ -34,5 +34,11 @@ data class TripSessionEntity(
     val endAltitudeMeters: Double? = null,
     val minAltitudeMeters: Double? = null,
     val maxAltitudeMeters: Double? = null,
+    val startSoc: Int? = null,
+    val endSoc: Int? = null,
+    val startMileageKm: Double? = null,
+    val endMileageKm: Double? = null,
+    val consumedEnergyKwh: Double? = null,
+    val averageConsumptionKwhPer100Km: Double? = null,
     val status: String = TripStatus.RECORDING
 )

--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
@@ -36,6 +36,15 @@ import org.json.JSONArray
 private val Context.vehicleSelectionDataStore by preferencesDataStore(name = "vehicle_selection")
 private val selectedVehicleIdKey = longPreferencesKey("selected_vehicle_id")
 
+private data class VehicleStateFact<T>(
+    val value: T,
+    val timestamp: Long,
+    val source: VehicleStateUpdateSource
+)
+
+private fun <T> latestFact(vararg facts: VehicleStateFact<T>?): VehicleStateFact<T>? =
+    facts.filterNotNull().maxByOrNull { it.timestamp }
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChargingRepository(private val database: AppDatabase, private val context: Context) {
     private val vehicleDao = database.vehicleDao()
@@ -111,7 +120,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
             chargingRecordDao.insertAll(payload.chargingRecords)
             tripDao.insertSessions(payload.tripSessions)
             tripDao.insertPoints(payload.tripPoints)
-            payload.vehicles.forEach { rebuildVehicleStateFromChargingRecords(it.id, VehicleStateUpdateSource.IMPORT) }
+            payload.vehicles.forEach { rebuildVehicleStateFromEvents(it.id) }
             require(vehicleDao.getAll().size == payload.vehicles.size) { "车辆恢复数量校验失败" }
             require(chargingRecordDao.getAll().size == payload.chargingRecords.size) { "充电记录恢复数量校验失败" }
             require(tripDao.getAllSessions().size == payload.tripSessions.size) { "行程恢复数量校验失败" }
@@ -171,7 +180,6 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         require(endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
         database.withTransaction {
             val active = tripDao.getActive() ?: error("当前没有进行中的行程")
-            if (active.startSoc != null) require(endSoc <= active.startSoc) { "结束 SOC 不能高于开始 SOC" }
             require(endMileageKm == null || endMileageKm >= 0.0) { "结束里程不能小于 0" }
             if (active.startMileageKm != null && endMileageKm != null) {
                 require(endMileageKm >= active.startMileageKm) { "结束里程不能低于开始里程" }
@@ -197,22 +205,17 @@ class ChargingRepository(private val database: AppDatabase, private val context:
                     status = TripStatus.COMPLETED
                 )
             )
-            vehicleStateDao.upsert(
-                VehicleStateEntity(
-                    vehicleId = active.vehicleId,
-                    currentSoc = endSoc,
-                    currentMileage = derivedEndMileage,
-                    updatedAtEpochMillis = System.currentTimeMillis(),
-                    updateSource = VehicleStateUpdateSource.TRIP_END.name
-                )
-            )
+            rebuildVehicleStateFromEvents(active.vehicleId)
         }
         TripTrackingService.stop(context)
     }
 
     suspend fun deleteTrip(trip: TripSessionEntity) {
         require(trip.status == TripStatus.COMPLETED) { "进行中的行程不能删除" }
-        tripDao.deleteSession(trip)
+        database.withTransaction {
+            tripDao.deleteSession(trip)
+            rebuildVehicleStateFromEvents(trip.vehicleId)
+        }
     }
 
     suspend fun addChargingRecord(
@@ -250,17 +253,14 @@ class ChargingRepository(private val database: AppDatabase, private val context:
                     locationAccuracyMeters = locationAccuracyMeters
                 )
             )
-            writeChargeState(vehicleId, endSoc, odometerKm)
+            rebuildVehicleStateFromEvents(vehicleId)
         }
     }
 
     suspend fun deleteChargingRecord(record: ChargingRecordEntity) {
         database.withTransaction {
             chargingRecordDao.markDeleted(record.id, System.currentTimeMillis())
-            val state = vehicleStateDao.get(record.vehicleId)
-            if (state?.updateSource == VehicleStateUpdateSource.CHARGE_RECORD.name) {
-                rebuildVehicleStateFromChargingRecords(record.vehicleId, VehicleStateUpdateSource.CHARGE_RECORD)
-            }
+            rebuildVehicleStateFromEvents(record.vehicleId)
         }
     }
 
@@ -275,10 +275,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
                     updatedAtEpochMillis = System.currentTimeMillis()
                 )
             )
-            val state = vehicleStateDao.get(record.vehicleId)
-            if (state?.updateSource == VehicleStateUpdateSource.CHARGE_RECORD.name) {
-                rebuildVehicleStateFromChargingRecords(record.vehicleId, VehicleStateUpdateSource.CHARGE_RECORD)
-            }
+            rebuildVehicleStateFromEvents(record.vehicleId)
         }
     }
 
@@ -324,33 +321,60 @@ class ChargingRepository(private val database: AppDatabase, private val context:
 
     private suspend fun ensureVehicleState(vehicleId: Long) {
         if (vehicleStateDao.get(vehicleId) == null) {
-            vehicleStateDao.upsert(VehicleStateEntity(vehicleId = vehicleId))
+            rebuildVehicleStateFromEvents(vehicleId)
         }
     }
 
-    private suspend fun writeChargeState(vehicleId: Long, endSoc: Int, odometerKm: Double?) {
+    private suspend fun rebuildVehicleStateFromEvents(vehicleId: Long) {
         val existing = vehicleStateDao.get(vehicleId)
-        vehicleStateDao.upsert(
-            VehicleStateEntity(
-                vehicleId = vehicleId,
-                currentSoc = endSoc,
-                currentMileage = odometerKm ?: existing?.currentMileage,
-                updatedAtEpochMillis = System.currentTimeMillis(),
-                updateSource = VehicleStateUpdateSource.CHARGE_RECORD.name
-            )
-        )
-    }
+        val manualState = existing?.takeIf { it.updateSource == VehicleStateUpdateSource.MANUAL_UPDATE.name }
 
-    private suspend fun rebuildVehicleStateFromChargingRecords(vehicleId: Long, source: VehicleStateUpdateSource) {
-        val latest = chargingRecordDao.getLatestForVehicle(vehicleId)
-        val latestWithOdometer = chargingRecordDao.getLatestWithOdometerForVehicle(vehicleId)
+        val latestCharge = chargingRecordDao.getLatestForVehicle(vehicleId)
+        val latestTripSoc = tripDao.getLatestCompletedWithSocForVehicle(vehicleId)
+        val socFact = latestFact(
+            latestCharge?.let {
+                VehicleStateFact(it.endSoc, it.chargeTimeEpochMillis, VehicleStateUpdateSource.CHARGE_RECORD)
+            },
+            latestTripSoc?.let {
+                VehicleStateFact(it.endSoc!!, it.endedAtEpochMillis!!, VehicleStateUpdateSource.TRIP_END)
+            },
+            manualState?.currentSoc?.let {
+                VehicleStateFact(it, manualState.updatedAtEpochMillis, VehicleStateUpdateSource.MANUAL_UPDATE)
+            }
+        )
+
+        val latestChargeMileage = chargingRecordDao.getLatestWithOdometerForVehicle(vehicleId)
+        val latestTripMileage = tripDao.getLatestCompletedWithMileageForVehicle(vehicleId)
+        val mileageFact = latestFact(
+            latestChargeMileage?.odometerKm?.let {
+                VehicleStateFact(it, latestChargeMileage.chargeTimeEpochMillis, VehicleStateUpdateSource.CHARGE_RECORD)
+            },
+            latestTripMileage?.endMileageKm?.let {
+                VehicleStateFact(it, latestTripMileage.endedAtEpochMillis!!, VehicleStateUpdateSource.TRIP_END)
+            },
+            manualState?.currentMileage?.let {
+                VehicleStateFact(it, manualState.updatedAtEpochMillis, VehicleStateUpdateSource.MANUAL_UPDATE)
+            }
+        )
+
+        val updatedAt = maxOf(socFact?.timestamp ?: 0L, mileageFact?.timestamp ?: 0L)
+            .takeIf { it > 0L }
+            ?: System.currentTimeMillis()
+        val source = when {
+            socFact == null && mileageFact == null -> VehicleStateUpdateSource.UNKNOWN
+            socFact == null -> mileageFact!!.source
+            mileageFact == null -> socFact.source
+            mileageFact.timestamp > socFact.timestamp -> mileageFact.source
+            else -> socFact.source
+        }
+
         vehicleStateDao.upsert(
             VehicleStateEntity(
                 vehicleId = vehicleId,
-                currentSoc = latest?.endSoc,
-                currentMileage = latestWithOdometer?.odometerKm,
-                updatedAtEpochMillis = System.currentTimeMillis(),
-                updateSource = if (latest == null && latestWithOdometer == null) VehicleStateUpdateSource.UNKNOWN.name else source.name
+                currentSoc = socFact?.value,
+                currentMileage = mileageFact?.value,
+                updatedAtEpochMillis = updatedAt,
+                updateSource = source.name
             )
         )
     }

--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
@@ -22,6 +22,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
 import com.evchargebook.data.entity.VehicleStateUpdateSource
 import com.evchargebook.domain.ChargingRecordRules
 import com.evchargebook.domain.TripRules
+import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.trip.TripTrackingService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -120,9 +121,19 @@ class ChargingRepository(private val database: AppDatabase, private val context:
 
     suspend fun startTrip(vehicleId: Long, startedAtEpochMillis: Long = System.currentTimeMillis()): Long {
         val tripId = database.withTransaction {
-            require(vehicleDao.observeActive().first().any { it.id == vehicleId }) { "当前车辆不可用" }
+            val selectedVehicle = vehicleDao.observeActive().first().firstOrNull { it.id == vehicleId }
+                ?: error("当前车辆不可用")
             TripRules.requireCanStart(tripDao.getActive() != null)
-            tripDao.insertSession(TripSessionEntity(vehicleId = vehicleId, startedAtEpochMillis = startedAtEpochMillis, status = TripStatus.RECORDING))
+            val state = vehicleStateDao.get(vehicleId)
+            tripDao.insertSession(
+                TripSessionEntity(
+                    vehicleId = selectedVehicle.id,
+                    startedAtEpochMillis = startedAtEpochMillis,
+                    startSoc = state?.currentSoc,
+                    startMileageKm = state?.currentMileage,
+                    status = TripStatus.RECORDING
+                )
+            )
         }
         startTrackingOrInterrupt(tripId)
         return tripId
@@ -152,10 +163,49 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         }
     }
 
-    suspend fun stopActiveTrip(endedAtEpochMillis: Long = System.currentTimeMillis()) {
+    suspend fun stopActiveTrip(
+        endSoc: Int,
+        endMileageKm: Double? = null,
+        endedAtEpochMillis: Long = System.currentTimeMillis()
+    ) {
+        require(endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
         database.withTransaction {
             val active = tripDao.getActive() ?: error("当前没有进行中的行程")
-            tripDao.updateSession(active.copy(endedAtEpochMillis = endedAtEpochMillis, elapsedSeconds = TripRules.elapsedSeconds(active.startedAtEpochMillis, endedAtEpochMillis), status = TripStatus.COMPLETED))
+            if (active.startSoc != null) require(endSoc <= active.startSoc) { "结束 SOC 不能高于开始 SOC" }
+            require(endMileageKm == null || endMileageKm >= 0.0) { "结束里程不能小于 0" }
+            if (active.startMileageKm != null && endMileageKm != null) {
+                require(endMileageKm >= active.startMileageKm) { "结束里程不能低于开始里程" }
+            }
+
+            val selectedVehicle = vehicleDao.observeActive().first().firstOrNull { it.id == active.vehicleId }
+                ?: error("行程车辆不可用")
+            val derivedEndMileage = endMileageKm ?: active.startMileageKm?.plus(active.distanceMeters / 1000.0)
+            val estimate = TripEnergyCalculator.estimate(
+                batteryCapacityKwh = selectedVehicle.batteryCapacityKwh,
+                startSoc = active.startSoc,
+                endSoc = endSoc,
+                distanceMeters = active.distanceMeters
+            )
+            tripDao.updateSession(
+                active.copy(
+                    endedAtEpochMillis = endedAtEpochMillis,
+                    elapsedSeconds = TripRules.elapsedSeconds(active.startedAtEpochMillis, endedAtEpochMillis),
+                    endSoc = endSoc,
+                    endMileageKm = derivedEndMileage,
+                    consumedEnergyKwh = estimate.consumedEnergyKwh,
+                    averageConsumptionKwhPer100Km = estimate.averageConsumptionKwhPer100Km,
+                    status = TripStatus.COMPLETED
+                )
+            )
+            vehicleStateDao.upsert(
+                VehicleStateEntity(
+                    vehicleId = active.vehicleId,
+                    currentSoc = endSoc,
+                    currentMileage = derivedEndMileage,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                    updateSource = VehicleStateUpdateSource.TRIP_END.name
+                )
+            )
         }
         TripTrackingService.stop(context)
     }

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
@@ -1,0 +1,37 @@
+package com.evchargebook.domain.trip
+
+data class TripEnergyEstimate(
+    val consumedEnergyKwh: Double?,
+    val averageConsumptionKwhPer100Km: Double?
+)
+
+object TripEnergyCalculator {
+    fun estimate(
+        batteryCapacityKwh: Double?,
+        startSoc: Int?,
+        endSoc: Int?,
+        distanceMeters: Double
+    ): TripEnergyEstimate {
+        val consumed = if (
+            batteryCapacityKwh != null && batteryCapacityKwh > 0.0 &&
+            startSoc != null && endSoc != null &&
+            startSoc in 0..100 && endSoc in 0..100 &&
+            endSoc <= startSoc
+        ) {
+            batteryCapacityKwh * (startSoc - endSoc) / 100.0
+        } else {
+            null
+        }
+
+        val average = if (consumed != null && distanceMeters > 0.0) {
+            consumed / (distanceMeters / 1000.0) * 100.0
+        } else {
+            null
+        }
+
+        return TripEnergyEstimate(
+            consumedEnergyKwh = consumed,
+            averageConsumptionKwhPer100Km = average
+        )
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyCalculator.kt
@@ -16,7 +16,7 @@ object TripEnergyCalculator {
             batteryCapacityKwh != null && batteryCapacityKwh > 0.0 &&
             startSoc != null && endSoc != null &&
             startSoc in 0..100 && endSoc in 0..100 &&
-            endSoc <= startSoc
+            endSoc < startSoc
         ) {
             batteryCapacityKwh * (startSoc - endSoc) / 100.0
         } else {

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -75,7 +75,8 @@ class TripTrackingService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            ACTION_STOP -> stopFromNotification()
+            // Legacy/stale notification PendingIntents must never bypass the end-SOC completion flow.
+            ACTION_STOP -> Unit
             ACTION_START -> {
                 val tripId = intent.getLongExtra(EXTRA_TRIP_ID, 0L)
                 if (tripId > 0L) beginTracking(tripId, flags and START_FLAG_REDELIVERY != 0) else stopSelf()
@@ -421,9 +422,14 @@ class TripTrackingService : Service() {
         .setOnlyAlertOnce(true)
         .setContentIntent(PendingIntent.getActivity(this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
         .addAction(
-            android.R.drawable.ic_media_pause,
-            "结束行程",
-            PendingIntent.getService(this, 1, Intent(this, TripTrackingService::class.java).setAction(ACTION_STOP), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            android.R.drawable.ic_menu_view,
+            "打开行程",
+            PendingIntent.getActivity(
+                this,
+                1,
+                Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
         )
         .build()
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -1,6 +1,5 @@
 package com.evchargebook.ui.trip
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -14,9 +13,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
@@ -55,7 +51,7 @@ fun TripReadyScreen(
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
-            item { ReadyMapCard() }
+            item { ReadyGpsCard() }
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
                     Text(
@@ -64,7 +60,7 @@ fun TripReadyScreen(
                         fontWeight = FontWeight.SemiBold
                     )
                     Text(
-                        "开始后只记录真实 GPS 轨迹，当前状态会作为本次行程起点。",
+                        "开始时会把当前车辆 SOC / 里程快照为本次行程起点；结束 SOC 会回写成新的车辆当前 SOC。",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -75,6 +71,22 @@ fun TripReadyScreen(
                     ReadyStateMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--", Modifier.weight(1f))
                     ReadyStateMetric("当前里程", currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--", Modifier.weight(1f))
                     ReadyStateMetric("轨迹", "GPS 实录", Modifier.weight(1f))
+                }
+            }
+            if (currentSoc == null) {
+                item {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = MaterialTheme.shapes.large,
+                        color = MaterialTheme.colorScheme.surfaceContainerLow
+                    ) {
+                        Text(
+                            "当前 SOC 尚未维护。本次仍可记录行程，但因为开始 SOC 未知，结束后不会虚构平均能耗；录入的结束 SOC 仍会更新车辆当前 SOC。",
+                            modifier = Modifier.padding(MaterialTheme.spacing.md),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
             item {
@@ -116,57 +128,35 @@ fun TripReadyScreen(
 }
 
 @Composable
-private fun ReadyMapCard() {
+private fun ReadyGpsCard() {
     Surface(
-        modifier = Modifier.fillMaxWidth().height(210.dp),
+        modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surface
     ) {
-        Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
-            val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
-            val primary = MaterialTheme.colorScheme.primary
-            Canvas(Modifier.fillMaxSize()) {
-                val spacing = 34.dp.toPx()
-                var x = 0f
-                while (x < size.width) {
-                    drawLine(gridColor, Offset(x, 0f), Offset(x, size.height), strokeWidth = 1f)
-                    x += spacing
-                }
-                var y = 0f
-                while (y < size.height) {
-                    drawLine(gridColor, Offset(0f, y), Offset(size.width, y), strokeWidth = 1f)
-                    y += spacing
-                }
-                val center = Offset(size.width * 0.54f, size.height * 0.52f)
-                drawCircle(primary.copy(alpha = 0.12f), radius = 46.dp.toPx(), center = center)
-                drawCircle(primary.copy(alpha = 0.24f), radius = 23.dp.toPx(), center = center)
-                drawCircle(primary, radius = 7.dp.toPx(), center = center)
-                drawLine(
-                    primary.copy(alpha = 0.55f),
-                    Offset(size.width * 0.12f, size.height * 0.78f),
-                    Offset(center.x - 8.dp.toPx(), center.y + 7.dp.toPx()),
-                    strokeWidth = 3.dp.toPx(),
-                    cap = StrokeCap.Round
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.lg),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+        ) {
+            Box(
+                modifier = Modifier.size(52.dp).background(MaterialTheme.colorScheme.primary.copy(alpha = .12f), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(26.dp)
                 )
             }
-            Row(
-                modifier = Modifier.align(Alignment.TopStart).padding(MaterialTheme.spacing.md),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Box(Modifier.size(8.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
-                Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text("GPS READY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-            }
-            Row(
-                modifier = Modifier.align(Alignment.BottomStart).padding(MaterialTheme.spacing.md),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(Icons.Default.LocationOn, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Column {
-                    Text("当前位置", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    Text("开始后锁定真实起点", style = MaterialTheme.typography.bodyMedium)
-                }
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("GPS 轨迹待开始", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "未开始前不绘制虚拟位置或路线。点击开始后才记录并展示真实定位点。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -1,0 +1,225 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.ui.theme.spacing
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TripReadyScreen(
+    vehicle: VehicleEntity?,
+    currentSoc: Int?,
+    currentMileageKm: Double?,
+    recentTrips: List<TripSessionEntity>,
+    onStart: () -> Unit,
+    onOpenDetail: (Long) -> Unit
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text("行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                        Text("TRIP READY", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+        ) {
+            item { ReadyMapCard() }
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                    Text(
+                        vehicle?.let { "${it.brand} ${it.model}" } ?: "请选择车辆",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        "开始后只记录真实 GPS 轨迹，当前状态会作为本次行程起点。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            item {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    ReadyStateMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--", Modifier.weight(1f))
+                    ReadyStateMetric("当前里程", currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--", Modifier.weight(1f))
+                    ReadyStateMetric("轨迹", "GPS 实录", Modifier.weight(1f))
+                }
+            }
+            item {
+                Button(
+                    onClick = onStart,
+                    enabled = vehicle != null,
+                    modifier = Modifier.fillMaxWidth().height(58.dp),
+                    shape = CircleShape
+                ) {
+                    Icon(Icons.Default.PlayArrow, contentDescription = null)
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    Text("开始行程", style = MaterialTheme.typography.titleMedium)
+                }
+            }
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text("最近行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                    Text("RECENT TRIPS", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            if (recentTrips.isEmpty()) {
+                item {
+                    Text(
+                        "完成第一段行程后，这里会显示真实距离、SOC 与能耗记录。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = MaterialTheme.spacing.md)
+                    )
+                }
+            } else {
+                items(minOf(recentTrips.size, 3)) { index ->
+                    val trip = recentTrips[index]
+                    ReadyRecentTripRow(trip = trip, onClick = { onOpenDetail(trip.id) })
+                }
+            }
+            item { Spacer(Modifier.height(16.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun ReadyMapCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth().height(210.dp),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface)) {
+            val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
+            val primary = MaterialTheme.colorScheme.primary
+            Canvas(Modifier.fillMaxSize()) {
+                val spacing = 34.dp.toPx()
+                var x = 0f
+                while (x < size.width) {
+                    drawLine(gridColor, Offset(x, 0f), Offset(x, size.height), strokeWidth = 1f)
+                    x += spacing
+                }
+                var y = 0f
+                while (y < size.height) {
+                    drawLine(gridColor, Offset(0f, y), Offset(size.width, y), strokeWidth = 1f)
+                    y += spacing
+                }
+                val center = Offset(size.width * 0.54f, size.height * 0.52f)
+                drawCircle(primary.copy(alpha = 0.12f), radius = 46.dp.toPx(), center = center)
+                drawCircle(primary.copy(alpha = 0.24f), radius = 23.dp.toPx(), center = center)
+                drawCircle(primary, radius = 7.dp.toPx(), center = center)
+                drawLine(
+                    primary.copy(alpha = 0.55f),
+                    Offset(size.width * 0.12f, size.height * 0.78f),
+                    Offset(center.x - 8.dp.toPx(), center.y + 7.dp.toPx()),
+                    strokeWidth = 3.dp.toPx(),
+                    cap = StrokeCap.Round
+                )
+            }
+            Row(
+                modifier = Modifier.align(Alignment.TopStart).padding(MaterialTheme.spacing.md),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(Modifier.size(8.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("GPS READY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+            }
+            Row(
+                modifier = Modifier.align(Alignment.BottomStart).padding(MaterialTheme.spacing.md),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(Icons.Default.LocationOn, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Column {
+                    Text("当前位置", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("开始后锁定真实起点", style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadyStateMetric(label: String, value: String, modifier: Modifier) {
+    Surface(modifier = modifier, color = MaterialTheme.colorScheme.surface, shape = MaterialTheme.shapes.large) {
+        Column(Modifier.padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun ReadyRecentTripRow(trip: TripSessionEntity, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = MaterialTheme.spacing.sm),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .12f)) {
+            Box(Modifier.size(42.dp), contentAlignment = Alignment.Center) {
+                Icon(Icons.Default.Route, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            }
+        }
+        Spacer(Modifier.width(MaterialTheme.spacing.md))
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(trip.startedAtEpochMillis)),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                "${String.format(Locale.US, "%.1f", trip.distanceMeters / 1000.0)} km · ${formatReadyDuration(trip.elapsedSeconds)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            trip.averageConsumptionKwhPer100Km?.let {
+                Text("${String.format(Locale.US, "%.1f", it)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("kWh/100km", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            } ?: Text("--", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+private fun formatReadyMileage(value: Double): String =
+    if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
+
+private fun formatReadyDuration(seconds: Long): String {
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -159,7 +159,7 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
 
     fun startTrip() { val vehicleId = _uiState.value.vehicle?.id ?: return; viewModelScope.launch { runCatching { repository.startTrip(vehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已开始") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法开始行程") } } }
     fun resumeTrip(tripId: Long) { viewModelScope.launch { runCatching { repository.resumeTrip(tripId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程记录已恢复") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法恢复行程") } } }
-    fun stopTrip() { viewModelScope.launch { runCatching { repository.stopActiveTrip() }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已结束") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法结束行程") } } }
+    fun stopTrip(endSoc: Int, endMileageKm: Double?) { viewModelScope.launch { runCatching { repository.stopActiveTrip(endSoc, endMileageKm) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "行程已结束，车辆状态已更新") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法结束行程") } } }
     fun openTripDetail(tripId: Long) { selectedTripId.value = tripId }
     fun closeTripDetail() { selectedTripId.value = null; _uiState.value = _uiState.value.copy(selectedTripId = null, selectedTripPoints = emptyList()) }
     fun deleteTrip(trip: TripSessionEntity) { viewModelScope.launch { runCatching { repository.deleteTrip(trip) }.onSuccess { if (selectedTripId.value == trip.id) closeTripDetail() }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法删除行程") } } }

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
@@ -30,4 +30,30 @@ class TripEnergyCalculatorTest {
         assertNull(result.consumedEnergyKwh)
         assertNull(result.averageConsumptionKwhPer100Km)
     }
+
+    @Test
+    fun `unchanged soc is unknown rather than zero consumption`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 67.7,
+            startSoc = 80,
+            endSoc = 80,
+            distanceMeters = 3_000.0
+        )
+
+        assertNull(result.consumedEnergyKwh)
+        assertNull(result.averageConsumptionKwhPer100Km)
+    }
+
+    @Test
+    fun `soc gain from regen or rounding is not forced into consumption`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 67.7,
+            startSoc = 80,
+            endSoc = 81,
+            distanceMeters = 5_000.0
+        )
+
+        assertNull(result.consumedEnergyKwh)
+        assertNull(result.averageConsumptionKwhPer100Km)
+    }
 }

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyCalculatorTest.kt
@@ -1,0 +1,33 @@
+package com.evchargebook.domain.trip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TripEnergyCalculatorTest {
+    @Test
+    fun `calculates trip energy and consumption from soc delta`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = 82,
+            endSoc = 65,
+            distanceMeters = 80_000.0
+        )
+
+        assertEquals(13.923, result.consumedEnergyKwh!!, 0.001)
+        assertEquals(17.40375, result.averageConsumptionKwhPer100Km!!, 0.0001)
+    }
+
+    @Test
+    fun `does not invent consumption when start soc is unknown`() {
+        val result = TripEnergyCalculator.estimate(
+            batteryCapacityKwh = 81.9,
+            startSoc = null,
+            endSoc = 65,
+            distanceMeters = 80_000.0
+        )
+
+        assertNull(result.consumedEnergyKwh)
+        assertNull(result.averageConsumptionKwhPer100Km)
+    }
+}


### PR DESCRIPTION
## Summary

Rebased replacement for #84 on current `main`, preserving the newer Trip reliability/visual work already merged through #80/#82/#83/#85.

## Trip lifecycle

- capture current VehicleState SOC and mileage when a trip starts
- require end SOC when completing a trip
- prefill end mileage from start mileage + GPS distance when possible, while allowing correction
- persist start/end SOC and mileage on TripSession
- calculate estimated consumed energy from battery capacity and a positive SOC drop
- calculate estimated average kWh/100km from consumed energy and recorded GPS distance
- update VehicleState SOC/mileage to the trip-end values after completion

## VehicleState consistency

- rebuild current state from the chronologically latest valid Charge or completed Trip event
- backdated charge creation/edit no longer rewinds current vehicle state
- deleting a charge or completed trip recomputes current state from remaining events
- backup restore rebuilds state from both charge and trip history
- a later manual VehicleState remains authoritative over older events

## Database / backup

- Room schema 9 -> 10 adds trip SOC, mileage and energy fields
- existing trips retain null values rather than fabricated history
- backup schema preserves the new trip fields and remains able to read older backups

## UX / data quality

- READY state uses the dedicated screenshot-aligned TripReadyScreen
- READY does not draw a fake map position or route before GPS recording actually starts
- current SOC/current mileage are shown before departure
- ending a trip opens a focused completion dialog for end SOC and mileage
- the dialog previews SOC change, estimated consumed kWh and estimated average kWh/100km before save
- unchanged SOC is not reported as zero consumption
- SOC gain is allowed because rounding, regenerative driving or real charging can produce it; consumption is left unavailable instead of forced positive/negative
- when start SOC is unknown, the trip is still recordable and end SOC still becomes the new current SOC without inventing energy data
- recent trips surface recorded average consumption only when available

## Safety

This branch was recreated directly from current `main` so it does not revert the already merged stationary heartbeat, trusted max-speed, altitude/address, endpoint-marker or trusted speed-coloring Trip work.

Supersedes #84.