### PR TITLE
feat(ui): bind current vehicle state into Home and Vehicle

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -365,6 +365,8 @@ fun MainApp(
                     4 -> VehicleScreen(
                         vehicle = state.vehicle,
                         vehicles = state.vehicles,
+                        currentSoc = state.currentSoc,
+                        currentMileageKm = state.currentMileageKm,
                         onSelect = viewModel::selectVehicle,
                         onAdd = { selectCatalogVehicle = true },
                         onEdit = { editVehicle = true },

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -54,7 +54,7 @@ fun DashboardScreen(
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
     ) {
 //        item { DashboardBrandHeader() }
-        item { HeroVehicleCard(state.vehicle) }
+        item { HeroVehicleCard(state.vehicle, state.currentSoc, state.currentMileageKm) }
         item { EnergyCockpitCard(state) }
         item { RecentChargingHeader(onAddClick) }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -41,7 +41,11 @@ import java.util.Locale
 private const val VEHICLE_ARTWORK_TAG = "VehicleArtwork"
 
 @Composable
-fun HeroVehicleCard(vehicle: VehicleEntity?) {
+fun HeroVehicleCard(
+    vehicle: VehicleEntity?,
+    currentSoc: Int? = null,
+    currentMileageKm: Double? = null
+) {
     val cockpit = LocalCockpitColors.current
     val background = Brush.linearGradient(listOf(Color(0xFF07100C), Color(0xFF0B2417), Color(0xFF07100C)))
     Surface(modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = Color.Transparent) {
@@ -63,11 +67,11 @@ fun HeroVehicleCard(vehicle: VehicleEntity?) {
             VehicleStage(vehicle)
             if (vehicle != null) {
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                    InlineMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--")
+                    MetricDivider()
+                    InlineMetric("当前里程", currentMileageKm?.let { "${one(it)} km" } ?: "--")
+                    MetricDivider()
                     InlineMetric("电池容量", "${one(vehicle.batteryCapacityKwh)} kWh")
-                    MetricDivider()
-                    InlineMetric("标称续航", "${vehicle.rangeKm} km")
-                    MetricDivider()
-                    InlineMetric("状态", "可记录")
                 }
             } else {
                 Text("完成车辆资料后，这里会作为你的车辆主视觉。", style = MaterialTheme.typography.bodyMedium, color = cockpit.secondaryText)

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
@@ -24,6 +24,8 @@ import java.util.Locale
 fun VehicleScreen(
     vehicle: VehicleEntity?,
     vehicles: List<VehicleEntity>,
+    currentSoc: Int? = null,
+    currentMileageKm: Double? = null,
     onSelect: (Long) -> Unit,
     onAdd: () -> Unit,
     onEdit: () -> Unit,
@@ -57,7 +59,7 @@ fun VehicleScreen(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             if (vehicle != null) {
-                item { HeroVehicleCard(vehicle) }
+                item { HeroVehicleCard(vehicle, currentSoc, currentMileageKm) }
                 item {
                     OutlinedButton(onClick = onEdit, modifier = Modifier.fillMaxWidth()) {
                         Icon(Icons.Default.Edit, null)


### PR DESCRIPTION
## Summary

Bind the shared per-vehicle `VehicleState` into the two primary vehicle-context surfaces so current SOC/mileage stop being hidden behind the Charge/Trip flows.

## UI

- Dashboard Hero now shows current SOC, current mileage and battery capacity
- Vehicle page Hero shows the same current SOC/mileage state
- unknown current values remain `--`; no SOC or mileage is fabricated
- switching vehicles continues to use the selected vehicle's own state

## Visual boundary

This keeps the existing Dark First Hero structure and strict local artwork mapping. It does not add runtime glow/reflection complexity; generated finished Hero assets remain the visual direction.

## Scope

Four small Android UI wiring files only; no database/schema/business-rule changes.