### PR TITLE
docs: sync v0.5 status after Trip energy presentation

### DIFF
--- a/docs/V0.5_IMPLEMENTATION_STATUS.md
+++ b/docs/V0.5_IMPLEMENTATION_STATUS.md
@@ -85,12 +85,35 @@ Implemented:
 - unchanged/increased SOC or insufficient inputs produce unavailable consumption, not a fake zero/positive number
 - trip completion atomically persists Trip end state and updates VehicleState SOC/mileage
 - backup schema preserves the new Trip fields and remains backward-readable
-- Trip detail surfaces start/end SOC, estimated consumed kWh and estimated average kWh/100km
 - Trip READY shows current SOC/current mileage, start CTA and recent trips without drawing a fake pre-start location/route
 - ongoing notification opens the Trip flow instead of directly completing it, because end SOC confirmation is required
 - stale legacy direct-stop intents cannot silently bypass the completion form
 
 PR #84 is closed without merge and superseded by #87.
+
+## Trip Energy Presentation — PR #88
+
+Status: merged to `main` as `2841b78c508af5657b5013cc0c06b3c47bba5f0f`; Android Build #339 green.
+
+Implemented:
+
+- LIVE panel shows the trip-start SOC snapshot without pretending it is live vehicle telemetry
+- LIVE explicitly states that current SOC/realtime energy are not inferred while driving
+- history rows show SOC range and estimated consumption when available
+- Trip detail adds a dedicated `能耗与车辆状态` section for SOC, estimated consumed kWh, estimated kWh/100km and odometer range
+- unchanged/increased SOC remains unavailable rather than becoming fake zero or negative consumption
+- existing GPS gap handling, altitude/address facts, endpoint semantics and trusted speed-colored route rendering are preserved
+
+## Home / Vehicle State Presentation — PR #89
+
+Status: active implementation PR.
+
+Scope:
+
+- Dashboard Hero shows current SOC, current mileage and battery capacity from VehicleState
+- Vehicle page Hero shows the same selected vehicle state
+- unknown values remain `--`
+- generated Hero artwork remains asset-driven; no runtime visual-effect expansion is introduced
 
 ## Current State Consistency Rule
 
@@ -113,9 +136,9 @@ GPS-derived mileage prefill is also an aid, not an odometer fact. Users can corr
 
 Current priority:
 
-1. Physical Trip acceptance for background other-app continuity, stationary red lights, max-speed parity, address/altitude and trusted route colors.
-2. Verify the complete Trip READY -> LIVE -> end SOC -> VehicleState update flow on a real device.
-3. Bind VehicleState into Home/Dashboard and Vehicle pages so current SOC/mileage are consistently visible without re-entry.
+1. Finish PR #89 and verify Home / Vehicle current-state presentation.
+2. Physical Trip acceptance for background other-app continuity, stationary red lights, max-speed parity, address/altitude and trusted route colors.
+3. Verify the complete Trip READY -> LIVE -> end SOC -> VehicleState update flow on a real device.
 4. Review Energy/Statistics presentation using Charge facts and Trip estimates without mixing their semantics.
 5. Replace Hero artwork with generated per-model finished assets and finish five-page physical visual acceptance.
 6. Continue accessibility / large-font / small-screen / TalkBack closeout.


### PR DESCRIPTION
## Summary

Update the v0.5 implementation status after the Trip SOC/energy stack landed.

## Status sync

- PR #87 Trip SOC/energy flow — merged, Build #336 green
- PR #88 Trip energy presentation — merged, Build #339 green
- PR #89 Home/Vehicle current-state presentation — active
- keep physical-device acceptance and data-quality boundaries explicit

Documentation only; no Android runtime changes.