### PR TITLE
docs: sync v0.5 status after state and stats closeout

### DIFF
--- a/docs/V0.5_IMPLEMENTATION_STATUS.md
+++ b/docs/V0.5_IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # EV Charge Book v0.5 Implementation Status
 
-Last synced: 2026-08-27
-Status: Core state flows implemented / physical acceptance pending
+Last synced: 2026-08-28
+Status: Core state/data semantics implemented / physical acceptance pending
 
 ## Baseline
 
@@ -11,7 +11,7 @@ Status: Core state flows implemented / physical acceptance pending
 
 ## Documentation
 
-PR #76 is documentation-only and defines the VehicleState / Charge / Trip state direction:
+PR #76 defines the VehicleState / Charge / Trip state direction, with later implementation-state synchronization through PR #90 and the current status document:
 
 - `VEHICLE_STATE_ARCHITECTURE_v0.5.md`
 - `CHARGE_TRIP_UX_FLOW_v0.5.md`
@@ -22,6 +22,8 @@ Trip reliability authority remains:
 
 - `LOCATION_TRIP.md`
 - `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
+
+Old PR #74 is closed without merge. It was based on the immediate post-#71 snapshot and is now too far behind current `main` to safely rewrite the authority/UI documents. Still-valid status is carried forward through small current-main syncs instead.
 
 ## Vehicle State Foundation — PR #79
 
@@ -106,14 +108,30 @@ Implemented:
 
 ## Home / Vehicle State Presentation — PR #89
 
-Status: active implementation PR.
+Status: merged to `main` as `9287e84033e031a65e493d2b3b2f186937e787c1`; Android Build #342 green.
 
-Scope:
+Implemented:
 
 - Dashboard Hero shows current SOC, current mileage and battery capacity from VehicleState
 - Vehicle page Hero shows the same selected vehicle state
 - unknown values remain `--`
+- switching vehicles uses the selected vehicle's own state
 - generated Hero artwork remains asset-driven; no runtime visual-effect expansion is introduced
+
+## Statistics Energy Semantics — PR #91
+
+Status: merged to `main` as `bdfe2043430025f0063e8f19efa4b23d768eac10`; Android Build #344 green.
+
+Implemented:
+
+- charging kWh is explicitly presented as charger/meter/grid-side energy (`电网补能` / `桩端电量`)
+- Charge-to-Charge interval analytics is labeled as replenished energy per 100 km, not vehicle driving consumption
+- completed Trip SOC-derived energy is presented in a separate `TRIP / SOC ESTIMATE` section
+- monthly and lifetime Trip estimates show eligible distance, estimated energy and sample coverage
+- aggregate Trip average consumption is calculated from total estimated energy divided by total valid distance rather than averaging rounded per-Trip averages
+- completed Trips with unavailable/non-positive SOC-derived energy or unusable distance are excluded from the energy average and counted separately
+- the UI explicitly states that charge-side facts and Trip SOC estimates are not directly subtracted or mixed into a fabricated efficiency metric
+- unit tests cover weighted aggregation, exclusion rules and time-window filtering
 
 ## Current State Consistency Rule
 
@@ -132,16 +150,18 @@ Short trips and integer SOC rounding can make the estimate unreliable. Regenerat
 
 GPS-derived mileage prefill is also an aid, not an odometer fact. Users can correct end mileage before completion.
 
+Charge-side energy and Trip energy use different measurement semantics: charger/meter kWh is a recorded charging fact, while Trip kWh is a vehicle-side estimate inferred from configured battery capacity and SOC delta. They stay separated in Statistics.
+
 ## Remaining v0.5 Work
 
 Current priority:
 
-1. Finish PR #89 and verify Home / Vehicle current-state presentation.
-2. Physical Trip acceptance for background other-app continuity, stationary red lights, max-speed parity, address/altitude and trusted route colors.
-3. Verify the complete Trip READY -> LIVE -> end SOC -> VehicleState update flow on a real device.
-4. Review Energy/Statistics presentation using Charge facts and Trip estimates without mixing their semantics.
-5. Replace Hero artwork with generated per-model finished assets and finish five-page physical visual acceptance.
-6. Continue accessibility / large-font / small-screen / TalkBack closeout.
+1. Physical Trip acceptance for background other-app continuity, stationary red lights, max-speed parity, address/altitude and trusted route colors.
+2. Verify the complete Trip READY -> LIVE -> end SOC -> VehicleState update flow on a real device.
+3. Complete five-page physical visual acceptance for Dashboard / Records / Stats / Trip / Vehicle, including Light mode contrast.
+4. Replace Hero artwork with generated per-model finished assets as those assets become available; keep Android rendering simple.
+5. Continue accessibility / large-font / small-screen / TalkBack closeout.
+6. Resolve any remaining stale issue/PR status discovered during acceptance without reopening superseded architecture work.
 
 Cloud sync expansion remains deferred until local v0.5 experience is stable.
 


### PR DESCRIPTION
## Summary

Synchronize the single v0.5 implementation-status document with the code now merged through #89 and #91.

## Updates

- mark Home/Vehicle VehicleState presentation (#89) merged with Build #342 green
- mark Statistics charge-vs-Trip energy semantics (#91) merged with Build #344 green
- record weighted Trip aggregation and explicit charger-side vs SOC-estimate data boundaries
- remove already-completed Home/Vehicle and Statistics work from the remaining-priority list
- keep physical Trip acceptance, five-page visual acceptance, generated Hero asset replacement, and accessibility closeout as the remaining v0.5 work
- record old PR #74 as closed/superseded rather than an authority source

Documentation only; no Android runtime change.