### PR TITLE
fix(a11y): harden touch targets and GPS health semantics

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -130,7 +130,7 @@ private fun RecentChargingHeader(onAddClick: () -> Unit) {
         }
         Box(
             modifier = Modifier
-                .size(42.dp)
+                .size(48.dp)
                 .clip(CircleShape)
                 .background(EVDesignTokens.Energy.green)
                 .clickable(onClick = onAddClick),

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -167,7 +167,7 @@ private fun RecordTimelineItem(record: ChargingRecordEntity, onEdit: () -> Unit,
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Text("SOC ${record.startSoc}% → ${record.endSoc}%", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
                 Text("¥ ${two(record.pricePerKwh)}/kWh", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                IconButton(onClick = onDelete, modifier = Modifier.size(34.dp)) {
+                IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
                     Icon(Icons.Default.DeleteOutline, "删除此记录", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
                 }
             }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDiagnosticSummaryCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDiagnosticSummaryCard.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,10 +50,11 @@ fun TripDiagnosticSummaryCard(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                        Modifier
-                            .size(8.dp)
-                            .background(accent, CircleShape)
+                    Icon(
+                        imageVector = if (healthy) Icons.Default.CheckCircle else Icons.Default.WarningAmber,
+                        contentDescription = if (healthy) "GPS 状态正常" else "GPS 存在异常事件",
+                        tint = accent,
+                        modifier = Modifier.size(20.dp)
                     )
                     Spacer(Modifier.width(8.dp))
                     Column {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -67,10 +68,12 @@ fun TripReadyScreen(
                 }
             }
             item {
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    ReadyStateMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--", Modifier.weight(1f))
-                    ReadyStateMetric("当前里程", currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--", Modifier.weight(1f))
-                    ReadyStateMetric("轨迹", "GPS 实录", Modifier.weight(1f))
+                ResponsiveMetricGrid(3) { index, modifier ->
+                    when (index) {
+                        0 -> ReadyStateMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--", modifier)
+                        1 -> ReadyStateMetric("当前里程", currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--", modifier)
+                        else -> ReadyStateMetric("轨迹", "GPS 实录", modifier)
+                    }
                 }
             }
             if (currentSoc == null) {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -8,11 +8,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -306,7 +308,19 @@ private fun ReadyMetric(label: String, value: String, modifier: Modifier) {
 private fun StatusPill(text: String, warning: Boolean) {
     val color = if (warning) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
     Surface(shape = CircleShape, color = color.copy(alpha = .12f)) {
-        Text(text, modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp), style = MaterialTheme.typography.labelMedium, color = color)
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Icon(
+                imageVector = if (warning) Icons.Default.WarningAmber else Icons.Default.CheckCircle,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(14.dp)
+            )
+            Text(text, style = MaterialTheme.typography.labelMedium, color = color)
+        }
     }
 }
 
@@ -333,7 +347,7 @@ private fun TripHistoryRow(trip: TripSessionEntity, onClick: () -> Unit, onDelet
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                     Text(formatTime(trip.startedAtEpochMillis), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
                     if (trip.status == TripStatus.COMPLETED) {
-                        IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+                        IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
                             Icon(Icons.Default.Delete, "删除行程", tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(18.dp))
                         }
                     }


### PR DESCRIPTION
## Summary

Continue #42 accessibility hardening with small code-backed fixes that do not depend on physical-device acceptance.

## Touch targets

- Home `记录充电` circular action grows from 42dp to the 48dp minimum target
- Charge history delete action grows from 34dp to 48dp while keeping the 18dp visual icon
- Trip history delete action grows from 32dp to 48dp while keeping the 18dp visual icon

## GPS / state semantics

- Trip diagnostic health now has explicit healthy/warning icons in addition to text and color
- diagnostic icons carry TalkBack descriptions (`GPS 状态正常` / `GPS 存在异常事件`)
- shared Trip status pills now use check/warning icons plus text and color, including GPS continuity/long-gap states and interrupted Trip state
- event text/detail and existing GPS business rules remain unchanged

## Small-screen / large-font regression guard

- Trip READY current SOC / mileage / GPS metrics now reuse the shared responsive metric grid
- the three metrics switch to the existing 3→2 adaptive layout on narrow screens / larger fontScale instead of staying in a fixed 3-column row

## Boundary

This is not a claim that all #42 TalkBack or Light/Dark/fontScale physical acceptance is complete. It closes concrete code gaps found in the current audit and leaves device acceptance explicit.