### PR TITLE
feat(ui): rebuild Dashboard Hero around dynamic vehicle state

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.viewmodel.MainUiState
@@ -43,6 +44,12 @@ fun DashboardScreen(
     onAddClick: () -> Unit,
     onSelectVehicle: (Long) -> Unit
 ) {
+    val selectedVehicleId = state.vehicle?.id
+    val latestCompletedTrip = state.trips
+        .asSequence()
+        .filter { it.vehicleId == selectedVehicleId && it.status == TripStatus.COMPLETED }
+        .maxByOrNull { it.endedAtEpochMillis ?: it.startedAtEpochMillis }
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -54,7 +61,14 @@ fun DashboardScreen(
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
     ) {
 //        item { DashboardBrandHeader() }
-        item { HeroVehicleCard(state.vehicle, state.currentSoc, state.currentMileageKm) }
+        item {
+            HeroVehicleCard(
+                vehicle = state.vehicle,
+                currentSoc = state.currentSoc,
+                currentMileageKm = state.currentMileageKm,
+                latestTrip = latestCompletedTrip
+            )
+        }
         item { EnergyCockpitCard(state) }
         item { RecentChargingHeader(onAddClick) }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -144,7 +144,7 @@ private fun RecentChargingHeader(onAddClick: () -> Unit) {
         }
         Box(
             modifier = Modifier
-                .size(42.dp)
+                .size(48.dp)
                 .clip(CircleShape)
                 .background(EVDesignTokens.Energy.green)
                 .clickable(onClick = onAddClick),

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -1,9 +1,12 @@
 package com.evchargebook.ui.dashboard
 
 import android.util.Log
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,14 +17,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -31,6 +37,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.LocalCockpitColors
@@ -44,58 +51,247 @@ private const val VEHICLE_ARTWORK_TAG = "VehicleArtwork"
 fun HeroVehicleCard(
     vehicle: VehicleEntity?,
     currentSoc: Int? = null,
-    currentMileageKm: Double? = null
+    currentMileageKm: Double? = null,
+    latestTrip: TripSessionEntity? = null
 ) {
     val cockpit = LocalCockpitColors.current
-    val background = Brush.linearGradient(listOf(Color(0xFF07100C), Color(0xFF0B2417), Color(0xFF07100C)))
-    Surface(modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.large, color = Color.Transparent) {
-        Column(modifier = Modifier.background(background).padding(horizontal = MaterialTheme.spacing.lg, vertical = MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+    val background = Brush.linearGradient(
+        listOf(
+            Color(0xFF06100C),
+            Color(0xFF0A2116),
+            Color(0xFF07110D)
+        )
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = Color.Transparent
+    ) {
+        Column(modifier = Modifier.background(background)) {
+            Column(
+                modifier = Modifier.padding(
+                    start = MaterialTheme.spacing.lg,
+                    end = MaterialTheme.spacing.lg,
+                    top = MaterialTheme.spacing.lg,
+                    bottom = MaterialTheme.spacing.sm
+                )
+            ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
                     Spacer(Modifier.size(MaterialTheme.spacing.xs))
                     Text("MY EV", style = MaterialTheme.typography.labelLarge, color = cockpit.secondaryText)
                 }
-                Surface(color = EVDesignTokens.Energy.green.copy(alpha = 0.12f), shape = CircleShape) {
-                    Text("ACTIVE", modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp), style = MaterialTheme.typography.labelMedium, color = EVDesignTokens.Energy.green)
-                }
+                Spacer(Modifier.height(MaterialTheme.spacing.lg))
+                Text(
+                    vehicle?.brand ?: "EV Charge Book",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = cockpit.secondaryText
+                )
+                Text(
+                    vehicle?.model ?: "添加你的第一辆车",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = cockpit.primaryText
+                )
             }
-            Column {
-                Text(vehicle?.brand ?: "EV Charge Book", style = MaterialTheme.typography.bodyMedium, color = cockpit.secondaryText)
-                Text(vehicle?.model ?: "添加你的第一辆车", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.SemiBold, color = cockpit.primaryText)
-            }
-            VehicleStage(vehicle)
-            if (vehicle != null) {
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                    InlineMetric("当前 SOC", currentSoc?.let { "$it%" } ?: "--")
-                    MetricDivider()
-                    InlineMetric("当前里程", currentMileageKm?.let { "${one(it)} km" } ?: "--")
-                    MetricDivider()
-                    InlineMetric("电池容量", "${one(vehicle.batteryCapacityKwh)} kWh")
+
+            Box(modifier = Modifier.fillMaxWidth().height(304.dp)) {
+                VehicleStage(vehicle, Modifier.fillMaxSize())
+                if (vehicle != null) {
+                    HeroDynamicStateOverlay(
+                        currentSoc = currentSoc,
+                        currentMileageKm = currentMileageKm,
+                        latestTrip = latestTrip,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(horizontal = 12.dp, vertical = 12.dp)
+                    )
                 }
-            } else {
-                Text("完成车辆资料后，这里会作为你的车辆主视觉。", style = MaterialTheme.typography.bodyMedium, color = cockpit.secondaryText)
             }
         }
     }
 }
 
 @Composable
-private fun VehicleStage(vehicle: VehicleEntity?) {
+private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier) {
     val artwork = OfficialVehicleImageCatalog.resolve(vehicle)
     remember(vehicle?.catalogVehicleId, vehicle?.brand, vehicle?.model, artwork?.drawableRes) {
-        Log.d(VEHICLE_ARTWORK_TAG, "vehicle=${vehicle?.brand}/${vehicle?.model} catalog=${vehicle?.catalogVehicleId} drawable=${artwork?.drawableRes}")
+        Log.d(
+            VEHICLE_ARTWORK_TAG,
+            "vehicle=${vehicle?.brand}/${vehicle?.model} catalog=${vehicle?.catalogVehicleId} drawable=${artwork?.drawableRes}"
+        )
         true
     }
-    Box(modifier = Modifier.fillMaxWidth().height(188.dp), contentAlignment = Alignment.Center) {
-        Box(Modifier.fillMaxSize().background(Brush.radialGradient(listOf(EVDesignTokens.Energy.green.copy(alpha = 0.20f), EVDesignTokens.Energy.green.copy(alpha = 0.06f), Color.Transparent), center = Offset.Unspecified, radius = 520f)))
+
+    Box(
+        modifier = modifier.background(
+            Brush.verticalGradient(
+                listOf(
+                    Color(0xFF07110D),
+                    Color(0xFF0A1712),
+                    Color(0xFF06100C)
+                )
+            )
+        ),
+        contentAlignment = Alignment.Center
+    ) {
         if (artwork != null) {
-            Image(painter = painterResource(artwork.drawableRes), contentDescription = "${vehicle?.brand.orEmpty()} ${vehicle?.model.orEmpty()} 车型图", modifier = Modifier.fillMaxWidth().height(184.dp), contentScale = ContentScale.Fit, alignment = Alignment.Center)
+            Image(
+                painter = painterResource(artwork.drawableRes),
+                contentDescription = "${vehicle?.brand.orEmpty()} ${vehicle?.model.orEmpty()} 车型图",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.Center
+            )
         } else {
             VehicleSilhouetteFallback(Modifier.fillMaxSize())
         }
-        Box(Modifier.align(Alignment.BottomCenter).fillMaxWidth(0.82f).height(1.dp).background(Brush.horizontalGradient(listOf(Color.Transparent, EVDesignTokens.Energy.green.copy(alpha = 0.72f), Color.Transparent))))
+
+        // Finished generated artwork owns its aurora/reflection effects. Compose only adds a
+        // restrained edge blend so titles and the translucent state panel remain legible.
+        Box(
+            Modifier.fillMaxSize().background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0x2206100C),
+                        Color.Transparent,
+                        Color(0x5506100C)
+                    )
+                )
+            )
+        )
     }
+}
+
+@Composable
+private fun HeroDynamicStateOverlay(
+    currentSoc: Int?,
+    currentMileageKm: Double?,
+    latestTrip: TripSessionEntity?,
+    modifier: Modifier = Modifier
+) {
+    val cockpit = LocalCockpitColors.current
+    val safeSoc = currentSoc?.coerceIn(0, 100)
+    val targetProgress = safeSoc?.div(100f) ?: 0f
+    val animatedProgress by animateFloatAsState(
+        targetValue = targetProgress,
+        animationSpec = tween(durationMillis = 650),
+        label = "dashboard_hero_soc"
+    )
+    val panelShape = MaterialTheme.shapes.large
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .border(1.dp, Color.White.copy(alpha = 0.14f), panelShape),
+        shape = panelShape,
+        color = Color(0xD9091511)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            Column(modifier = Modifier.weight(0.95f)) {
+                Text(
+                    safeSoc?.let { "$it%" } ?: "--",
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (safeSoc != null) EVDesignTokens.Energy.green else cockpit.primaryText
+                )
+                Spacer(Modifier.height(8.dp))
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(5.dp)
+                        .clip(CircleShape)
+                        .background(cockpit.secondaryText.copy(alpha = 0.24f))
+                ) {
+                    if (safeSoc != null) {
+                        Box(
+                            Modifier
+                                .fillMaxWidth(animatedProgress)
+                                .fillMaxSize()
+                                .background(EVDesignTokens.Energy.green)
+                        )
+                    }
+                }
+            }
+
+            MetricDivider()
+
+            HeroMetric(
+                label = "当前里程",
+                value = currentMileageKm?.let(::formatMileage) ?: "--",
+                modifier = Modifier.weight(1f)
+            )
+
+            MetricDivider()
+
+            HeroRecentTripMetric(
+                trip = latestTrip,
+                modifier = Modifier.weight(1.05f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeroMetric(label: String, value: String, modifier: Modifier = Modifier) {
+    val cockpit = LocalCockpitColors.current
+    Column(modifier = modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            value,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Medium,
+            color = cockpit.primaryText
+        )
+    }
+}
+
+@Composable
+private fun HeroRecentTripMetric(trip: TripSessionEntity?, modifier: Modifier = Modifier) {
+    val cockpit = LocalCockpitColors.current
+    val distance = trip?.distanceMeters
+        ?.takeIf { it.isFinite() && it > 0.0 }
+        ?.let(::formatTripDistance)
+        ?: "--"
+    val consumption = trip?.averageConsumptionKwhPer100Km
+        ?.takeIf { it.isFinite() && it >= 0.0 }
+        ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
+
+    Column(modifier = modifier) {
+        Text("最近行程", style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            distance,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Medium,
+            color = cockpit.primaryText
+        )
+        if (consumption != null) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                consumption,
+                style = MaterialTheme.typography.labelMedium,
+                color = EVDesignTokens.Energy.green
+            )
+        }
+    }
+}
+
+@Composable
+private fun MetricDivider() {
+    Box(
+        Modifier
+            .size(width = 1.dp, height = 54.dp)
+            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .24f))
+    )
 }
 
 @Composable
@@ -104,7 +300,15 @@ private fun VehicleSilhouetteFallback(modifier: Modifier = Modifier) {
     Canvas(modifier) {
         val w = size.width
         val h = size.height
-        drawCircle(brush = Brush.radialGradient(listOf(energy.copy(alpha = 0.20f), Color.Transparent), center = Offset(w * 0.58f, h * 0.60f), radius = w * 0.46f), radius = w * 0.46f, center = Offset(w * 0.58f, h * 0.60f))
+        drawCircle(
+            brush = Brush.radialGradient(
+                listOf(energy.copy(alpha = 0.16f), Color.Transparent),
+                center = Offset(w * 0.58f, h * 0.60f),
+                radius = w * 0.46f
+            ),
+            radius = w * 0.46f,
+            center = Offset(w * 0.58f, h * 0.60f)
+        )
         val body = Path().apply {
             moveTo(w * .10f, h * .68f)
             cubicTo(w * .16f, h * .61f, w * .23f, h * .57f, w * .30f, h * .55f)
@@ -116,28 +320,35 @@ private fun VehicleSilhouetteFallback(modifier: Modifier = Modifier) {
             lineTo(w * .14f, h * .72f)
             close()
         }
-        drawPath(body, brush = Brush.horizontalGradient(listOf(Color(0xFF0D1713), Color(0xFF173728), Color(0xFF0B1511))))
-        drawPath(body, color = energy.copy(alpha = .78f), style = Stroke(width = 1.5.dp.toPx()))
+        drawPath(
+            body,
+            brush = Brush.horizontalGradient(
+                listOf(Color(0xFF0D1713), Color(0xFF173728), Color(0xFF0B1511))
+            )
+        )
+        drawPath(body, color = energy.copy(alpha = .72f), style = Stroke(width = 1.5.dp.toPx()))
         listOf(w * .27f, w * .78f).forEach { x ->
             drawCircle(Color(0xFF050807), 16.dp.toPx(), Offset(x, h * .70f))
-            drawCircle(energy.copy(alpha = .60f), 10.dp.toPx(), Offset(x, h * .70f), style = Stroke(1.5.dp.toPx()))
+            drawCircle(
+                energy.copy(alpha = .55f),
+                10.dp.toPx(),
+                Offset(x, h * .70f),
+                style = Stroke(1.5.dp.toPx())
+            )
         }
     }
 }
 
-@Composable
-private fun InlineMetric(label: String, value: String) {
-    val cockpit = LocalCockpitColors.current
-    Column {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
-        Spacer(Modifier.height(2.dp))
-        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = cockpit.primaryText)
+private fun formatMileage(value: Double): String =
+    if (value % 1.0 == 0.0) {
+        String.format(Locale.US, "%,.0f km", value)
+    } else {
+        String.format(Locale.US, "%,.1f km", value)
     }
-}
 
-@Composable
-private fun MetricDivider() {
-    Box(Modifier.size(width = 1.dp, height = 28.dp).background(LocalCockpitColors.current.secondaryText.copy(alpha = .28f)))
-}
-
-private fun one(value: Double) = String.format(Locale.US, "%.1f", value)
+private fun formatTripDistance(meters: Double): String =
+    if (meters >= 1000.0) {
+        String.format(Locale.US, "%.1f km", meters / 1000.0)
+    } else {
+        String.format(Locale.US, "%.0f m", meters)
+    }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -150,8 +149,6 @@ private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier)
             VehicleSilhouetteFallback(Modifier.fillMaxSize())
         }
 
-        // Finished generated artwork owns its aurora/reflection effects. Compose only adds a
-        // restrained edge blend so titles and the translucent state panel remain legible.
         Box(
             Modifier.fillMaxSize().background(
                 Brush.verticalGradient(

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -210,13 +210,15 @@ private fun HeroDynamicStateOverlay(
                             modifier = Modifier.weight(1f)
                         )
                     }
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .height(1.dp)
-                            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .20f))
-                    )
-                    HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.fillMaxWidth())
+                    if (latestTrip != null) {
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(LocalCockpitColors.current.secondaryText.copy(alpha = .20f))
+                        )
+                        HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.fillMaxWidth())
+                    }
                 }
             } else {
                 Row(
@@ -231,8 +233,10 @@ private fun HeroDynamicStateOverlay(
                         value = currentMileageKm?.let(::formatMileage) ?: "--",
                         modifier = Modifier.weight(1f)
                     )
-                    MetricDivider()
-                    HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.weight(1.05f))
+                    if (latestTrip != null) {
+                        MetricDivider()
+                        HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.weight(1.05f))
+                    }
                 }
             }
         }
@@ -285,13 +289,13 @@ private fun HeroMetric(label: String, value: String, modifier: Modifier = Modifi
 }
 
 @Composable
-private fun HeroRecentTripMetric(trip: TripSessionEntity?, modifier: Modifier = Modifier) {
+private fun HeroRecentTripMetric(trip: TripSessionEntity, modifier: Modifier = Modifier) {
     val cockpit = LocalCockpitColors.current
-    val distance = trip?.distanceMeters
-        ?.takeIf { it.isFinite() && it > 0.0 }
+    val distance = trip.distanceMeters
+        .takeIf { it.isFinite() && it > 0.0 }
         ?.let(::formatTripDistance)
         ?: "--"
-    val consumption = trip?.averageConsumptionKwhPer100Km
+    val consumption = trip.averageConsumptionKwhPer100Km
         ?.takeIf { it.isFinite() && it >= 0.0 }
         ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -171,7 +173,6 @@ private fun HeroDynamicStateOverlay(
     latestTrip: TripSessionEntity?,
     modifier: Modifier = Modifier
 ) {
-    val cockpit = LocalCockpitColors.current
     val safeSoc = currentSoc?.coerceIn(0, 100)
     val targetProgress = safeSoc?.div(100f) ?: 0f
     val animatedProgress by animateFloatAsState(
@@ -180,6 +181,7 @@ private fun HeroDynamicStateOverlay(
         label = "dashboard_hero_soc"
     )
     val panelShape = MaterialTheme.shapes.large
+    val fontScale = LocalConfiguration.current.fontScale
 
     Surface(
         modifier = modifier
@@ -188,53 +190,81 @@ private fun HeroDynamicStateOverlay(
         shape = panelShape,
         color = Color(0xD9091511)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(14.dp)
-        ) {
-            Column(modifier = Modifier.weight(0.95f)) {
-                Text(
-                    safeSoc?.let { "$it%" } ?: "--",
-                    style = MaterialTheme.typography.headlineLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (safeSoc != null) EVDesignTokens.Energy.green else cockpit.primaryText
-                )
-                Spacer(Modifier.height(8.dp))
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .height(5.dp)
-                        .clip(CircleShape)
-                        .background(cockpit.secondaryText.copy(alpha = 0.24f))
+        BoxWithConstraints(Modifier.fillMaxWidth()) {
+            val compact = maxWidth < 340.dp || fontScale >= 1.3f
+            if (compact) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    if (safeSoc != null) {
-                        Box(
-                            Modifier
-                                .fillMaxWidth(animatedProgress)
-                                .fillMaxSize()
-                                .background(EVDesignTokens.Energy.green)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        HeroSocMetric(safeSoc, animatedProgress, Modifier.weight(1f))
+                        MetricDivider()
+                        HeroMetric(
+                            label = "当前里程",
+                            value = currentMileageKm?.let(::formatMileage) ?: "--",
+                            modifier = Modifier.weight(1f)
                         )
                     }
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .20f))
+                    )
+                    HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.fillMaxWidth())
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    HeroSocMetric(safeSoc, animatedProgress, Modifier.weight(0.95f))
+                    MetricDivider()
+                    HeroMetric(
+                        label = "当前里程",
+                        value = currentMileageKm?.let(::formatMileage) ?: "--",
+                        modifier = Modifier.weight(1f)
+                    )
+                    MetricDivider()
+                    HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.weight(1.05f))
                 }
             }
+        }
+    }
+}
 
-            MetricDivider()
-
-            HeroMetric(
-                label = "当前里程",
-                value = currentMileageKm?.let(::formatMileage) ?: "--",
-                modifier = Modifier.weight(1f)
-            )
-
-            MetricDivider()
-
-            HeroRecentTripMetric(
-                trip = latestTrip,
-                modifier = Modifier.weight(1.05f)
-            )
+@Composable
+private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modifier = Modifier) {
+    val cockpit = LocalCockpitColors.current
+    Column(modifier = modifier) {
+        Text(
+            safeSoc?.let { "$it%" } ?: "--",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = if (safeSoc != null) EVDesignTokens.Energy.green else cockpit.primaryText
+        )
+        Spacer(Modifier.height(8.dp))
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .height(5.dp)
+                .clip(CircleShape)
+                .background(cockpit.secondaryText.copy(alpha = 0.24f))
+        ) {
+            if (safeSoc != null) {
+                Box(
+                    Modifier
+                        .fillMaxWidth(animatedProgress)
+                        .fillMaxSize()
+                        .background(EVDesignTokens.Energy.green)
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
@@ -60,6 +60,7 @@ fun VehicleScreen(
         ) {
             if (vehicle != null) {
                 item { HeroVehicleCard(vehicle, currentSoc, currentMileageKm) }
+                item { VehicleSpecificationCard(vehicle) }
                 item {
                     OutlinedButton(onClick = onEdit, modifier = Modifier.fillMaxWidth()) {
                         Icon(Icons.Default.Edit, null)
@@ -98,6 +99,35 @@ fun VehicleScreen(
             confirmButton = { TextButton(onClick = { onArchive(candidate); archiveCandidate = null }) { Text("归档") } },
             dismissButton = { TextButton(onClick = { archiveCandidate = null }) { Text("取消") } }
         )
+    }
+}
+
+@Composable
+private fun VehicleSpecificationCard(vehicle: VehicleEntity) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        SettingsSectionTitle("车辆规格", "VEHICLE SPECS")
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainerLow
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+            ) {
+                VehicleSpecValue("电池容量", "${one(vehicle.batteryCapacityKwh)} kWh", Modifier.weight(1f))
+                VehicleSpecValue("标称续航", "${vehicle.rangeKm} km", Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun VehicleSpecValue(label: String, value: String, modifier: Modifier = Modifier) {
+    Column(modifier) {
+        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(4.dp))
+        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
     }
 }
 

--- a/docs/DASHBOARD_APPROVED_VISUAL_BASELINE_V0.5.md
+++ b/docs/DASHBOARD_APPROVED_VISUAL_BASELINE_V0.5.md
@@ -1,0 +1,70 @@
+# EV Charge Book v0.5 Dashboard Approved Visual Baseline
+
+Date: 2026-08-28
+Status: Approved visual baseline for Android implementation
+
+## Dashboard information roles
+
+The Dashboard is split into three clear responsibilities:
+
+1. **Vehicle Hero** — answers: "What is my vehicle's current state?"
+2. **Monthly Energy** — answers: "How much energy/cost did I use this month?"
+3. **Recent Trip** — answers: "What happened on my latest drive?"
+
+Do not mix static vehicle specification facts into the dynamic Dashboard Hero.
+
+## Vehicle Hero
+
+Approved direction:
+
+- Dark First + restrained green accent.
+- No `ACTIVE` badge.
+- Vehicle artwork is a finished generated asset and should visually fill the Hero width.
+- Do not place the vehicle inside a second inset rectangular image frame.
+- Compose must not recreate aurora/reflection/glow effects; those belong in the finished artwork asset.
+- Bottom state panel uses a restrained translucent glass-like surface.
+
+### Dynamic facts
+
+Hero state panel shows:
+
+- current SOC as the dominant value, without a `当前 SOC` title beside the percentage;
+- a slim SOC progress line with one subtle entry fill animation;
+- current mileage;
+- latest completed Trip distance and estimated average consumption when available.
+
+Unknown facts remain `--` or are omitted. Do not fabricate current state.
+
+### Static facts removed from Dashboard Hero
+
+The following belong on the Vehicle page instead:
+
+- battery capacity;
+- rated range;
+- static vehicle specification data.
+
+## Motion
+
+Allowed motion is intentionally minimal:
+
+- SOC linebar may animate from empty to current value on entry, roughly 500–700 ms.
+- no pulse, running-light, flashing ring, or decorative looping animation.
+
+## Recent Trip card follow-up
+
+The standalone recent Trip card should prioritize:
+
+- start -> end location presentation;
+- distance;
+- elapsed duration;
+- start/end SOC;
+- start/end mileage;
+- recorded estimated kWh/100km when available.
+
+Detailed GPS diagnostics remain on Trip detail, not Dashboard.
+
+## Acceptance boundary
+
+Code/CI completion is not physical visual acceptance. Final closeout still requires a real-device pass for scale, crop, spacing, readability and asset fit.
+
+Related: #70, #87, #89, #94, #95.


### PR DESCRIPTION
## Summary

Implements the approved 2026-08-28 Dashboard Hero direction from #94 while keeping static vehicle specifications available on the Vehicle page.

### Dashboard Hero
- removes `ACTIVE`
- removes battery capacity / rated range from Dashboard Hero
- makes the vehicle artwork a full-width finished-asset slot instead of an inset framed image
- adds a restrained translucent bottom state panel

### Dynamic state
- current SOC is the dominant value
- SOC uses a slim 650ms entry fill linebar; no looping decorative animation
- current mileage is shown from VehicleState
- latest completed selected-vehicle Trip distance is shown only when an actual completed Trip exists
- recorded estimated kWh/100km is shown only when available
- unknown SOC/mileage remain `--`; an unavailable recent Trip is omitted rather than pretending `--` means a real lookup result
- overlay switches to a two-row layout on narrow screens / larger fontScale instead of forcing three columns

### Vehicle page boundary
- battery capacity and rated range are intentionally removed only from the Dashboard Hero
- Vehicle page now has an explicit `VEHICLE SPECS` card preserving battery capacity and rated range
- the shared Hero does not show a fake empty recent-Trip metric when Vehicle page has not supplied one

### Data boundary
- no database/schema/business-rule changes
- existing #87 Trip energy facts are reused
- existing #89 VehicleState facts are reused

### Artwork boundary
Compose does not recreate aurora/reflection/glow. Those effects belong in generated finished Hero assets. This PR only provides the full-bleed crop/alignment slot and readability overlays.

### Docs
Adds `docs/DASHBOARD_APPROVED_VISUAL_BASELINE_V0.5.md` so future UI work does not drift from the approved direction.

This PR implements the code scope for #94. Keep #94 open after merge until the new Hero passes a physical-device visual check for crop, scale, spacing and readability.

Related: #70, #87, #89, #94, #95, #42.