### PR TITLE
fix(trip): avoid false service-destroy diagnostics after normal completion

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripServiceLifecycleRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripServiceLifecycleRules.kt
@@ -1,0 +1,8 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripStatus
+
+object TripServiceLifecycleRules {
+    fun shouldRecordUnexpectedDestroy(status: String?): Boolean =
+        status == TripStatus.RECORDING || status == TripStatus.INTERRUPTED
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -32,6 +32,7 @@ import com.evchargebook.domain.TripGpsHealthSnapshot
 import com.evchargebook.domain.TripGpsHealthStatus
 import com.evchargebook.domain.TripRules
 import com.evchargebook.domain.TripSamplingRules
+import com.evchargebook.domain.TripServiceLifecycleRules
 import com.evchargebook.domain.TripSpeedTrustRules
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -91,10 +92,19 @@ class TripTrackingService : Service() {
     override fun onDestroy() {
         currentTripId?.let { tripId ->
             runCatching {
-                AppDatabase.getInstance(applicationContext).openHelper.writableDatabase.execSQL(
-                    "INSERT INTO trip_diagnostic_events (tripId, occurredAtEpochMillis, type, provider, detail) VALUES (?, ?, ?, NULL, ?)",
-                    arrayOf<Any?>(tripId, System.currentTimeMillis(), TripDiagnosticEventType.SERVICE_DESTROY, "service destroyed while trip active")
-                )
+                val database = AppDatabase.getInstance(applicationContext).openHelper.writableDatabase
+                val persistedStatus = database.query(
+                    "SELECT status FROM trip_sessions WHERE id = ? LIMIT 1",
+                    arrayOf<Any?>(tripId)
+                ).use { cursor ->
+                    if (cursor.moveToFirst()) cursor.getString(0) else null
+                }
+                if (TripServiceLifecycleRules.shouldRecordUnexpectedDestroy(persistedStatus)) {
+                    database.execSQL(
+                        "INSERT INTO trip_diagnostic_events (tripId, occurredAtEpochMillis, type, provider, detail) VALUES (?, ?, ?, NULL, ?)",
+                        arrayOf<Any?>(tripId, System.currentTimeMillis(), TripDiagnosticEventType.SERVICE_DESTROY, "service destroyed while trip active")
+                    )
+                }
             }
         }
         healthMonitorJob?.cancel()

--- a/android/app/src/test/java/com/evchargebook/domain/TripServiceLifecycleRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripServiceLifecycleRulesTest.kt
@@ -1,0 +1,28 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripServiceLifecycleRulesTest {
+    @Test
+    fun `recording trip destruction is unexpected`() {
+        assertTrue(TripServiceLifecycleRules.shouldRecordUnexpectedDestroy(TripStatus.RECORDING))
+    }
+
+    @Test
+    fun `interrupted trip destruction is unexpected`() {
+        assertTrue(TripServiceLifecycleRules.shouldRecordUnexpectedDestroy(TripStatus.INTERRUPTED))
+    }
+
+    @Test
+    fun `completed trip normal service stop is not an anomaly`() {
+        assertFalse(TripServiceLifecycleRules.shouldRecordUnexpectedDestroy(TripStatus.COMPLETED))
+    }
+
+    @Test
+    fun `missing trip is not reported as active destruction`() {
+        assertFalse(TripServiceLifecycleRules.shouldRecordUnexpectedDestroy(null))
+    }
+}


### PR DESCRIPTION
## Summary

Fix a Trip lifecycle diagnostic bug found while closing #42 state-safety/accessibility work.

## Problem

Normal Trip completion persists the session as `COMPLETED` and then stops `TripTrackingService`. The service still holds `currentTripId` during `onDestroy`, so the previous code unconditionally inserted `SERVICE_DESTROY` with `service destroyed while trip active` even though the Trip had already completed normally.

That pollutes diagnostic history and can make a healthy Trip look abnormal later.

## Fix

- read the persisted Trip status before writing `SERVICE_DESTROY`
- record the destroy event only when the persisted session is still `RECORDING` or `INTERRUPTED`
- a normal `COMPLETED` stop creates no destroy anomaly
- missing/deleted sessions also do not fabricate an active-destroy event
- keep the end-SOC completion flow unchanged; notification `ACTION_STOP` remains unable to directly complete a Trip

## Tests

Adds a pure lifecycle rule with coverage for RECORDING, INTERRUPTED, COMPLETED, and missing status.

## Scope

No schema change, no UI redesign, no GPS sampling change.