### PR TITLE
fix(ui): refine bottom navigation icon density

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -268,8 +268,16 @@ fun MainApp(
                         NavigationBarItem(
                             selected = tab == index,
                             onClick = { tab = index },
-                            icon = { Icon(icons[index], title) },
-                            label = { Text(title) },
+                            icon = {
+                                Icon(
+                                    imageVector = icons[index],
+                                    contentDescription = title,
+                                    modifier = Modifier
+                                        .size(26.dp)
+                                        .padding(3.dp)
+                                )
+                            },
+                            label = { Text(title, style = MaterialTheme.typography.labelMedium) },
                             colors = NavigationBarItemDefaults.colors(
                                 selectedIconColor = MaterialTheme.colorScheme.primary,
                                 selectedTextColor = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
## Summary

Small v0.5 visual polish for the bottom NavigationBar, following the physical-device feedback that the icons look too full and visually crowded.

### Change
- keep the existing five-tab navigation structure
- keep Material 3 NavigationBarItem behavior and colors
- use a consistent 26dp icon container with 3dp internal padding, giving the vector artwork about 20dp of visual size
- keep selected/unselected icons the same size; selection remains color-based rather than scaling
- use the existing label typography hierarchy

### Boundary
No navigation/business behavior changes. This is intentionally a tiny visual-density patch under #22 / #70 physical UI closeout.

### Acceptance
- icons no longer visually fill their slot edge-to-edge
- Home / History / Stats / Trip / Vehicle have more consistent perceived size
- touch target remains owned by NavigationBarItem and is not reduced
- Android CI green
- physical-device visual pass still required

Related: #22, #70.