### PR TITLE
fix(android): activate release APK auto-update prompt

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -45,6 +45,7 @@ import com.evchargebook.ui.vehicle.BluetoothPromptScreen
 import com.evchargebook.ui.vehicle.VehicleCatalogScreen
 import com.evchargebook.ui.vehicle.VehicleEditScreen
 import com.evchargebook.ui.vehicle.VehicleScreen
+import com.evchargebook.update.AppUpdatePrompt
 import com.evchargebook.viewmodel.MainViewModel
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -245,6 +246,8 @@ fun MainApp(
             editVehicle -> editVehicle = false
         }
     }
+
+    AppUpdatePrompt()
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,


### PR DESCRIPTION
## Summary

Wire the already implemented release-only APK updater into the root Compose tree.

The updater infrastructure already existed (`AppUpdateManager`, `AppUpdatePrompt`, release manifest publication, SHA-256 verification and Android installer handoff), but `MainApp` never composed `AppUpdatePrompt()`, so production users could not discover updates.

## Change

- import `AppUpdatePrompt`
- compose it once at the `MainApp` root before the main `Scaffold`

`AppUpdatePrompt` itself remains responsible for:

- doing nothing in debug/dev builds
- checking `latest.json` once per app-process composition
- silently ignoring update-service failures
- prompting only when `versionCode` increases
- DownloadManager download + SHA-256 verification
- Android unknown-source permission + system installer handoff

No background polling or silent installation is introduced.

Refs #102

## Acceptance

- Android compile/test must be green
- Debug APK must continue to build normally
- Issue #102 remains open until an older production-signed APK successfully upgrades to a newer production release on a physical device.