### PR TITLE
feat(ui): converge Dashboard P0 toward 1:1 reference

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -55,12 +55,11 @@ fun DashboardScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
         contentPadding = PaddingValues(
-            horizontal = MaterialTheme.spacing.md,
-            vertical = MaterialTheme.spacing.md
+            horizontal = 8.dp,
+            vertical = 8.dp
         ),
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-//        item { DashboardBrandHeader() }
         item {
             HeroVehicleCard(
                 vehicle = state.vehicle,
@@ -80,51 +79,7 @@ fun DashboardScreen(
                 ChargingTimelineRow(record)
             }
         }
-        item { Spacer(Modifier.height(24.dp)) }
-    }
-}
-
-@Composable
-private fun DashboardBrandHeader() {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    "EV Charge Book",
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onBackground
-                )
-                Spacer(Modifier.size(MaterialTheme.spacing.xs))
-                Text(
-                    "v0.5",
-                    style = MaterialTheme.typography.labelLarge,
-                    color = EVDesignTokens.Energy.green
-                )
-            }
-            Text(
-                "DRIVE · CHARGE · REVIEW",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-        Box(
-            modifier = Modifier
-                .size(38.dp)
-                .background(EVDesignTokens.Energy.green.copy(alpha = 0.10f), CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Default.Bolt,
-                contentDescription = null,
-                tint = EVDesignTokens.Energy.green,
-                modifier = Modifier.size(20.dp)
-            )
-        }
+        item { Spacer(Modifier.height(16.dp)) }
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -20,20 +20,19 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.evchargebook.domain.MonthlyChargingBucket
 import com.evchargebook.ui.theme.EVDesignTokens
-import com.evchargebook.ui.theme.spacing
 import com.evchargebook.viewmodel.MainUiState
 import java.util.Locale
 
 @Composable
 fun EnergyCockpitCard(state: MainUiState) {
     val surfaceBrush = Brush.verticalGradient(
-        listOf(Color(0xFF0D1512), Color(0xFF0A100E))
+        listOf(Color(0xFF0D1512), Color(0xFF09100E))
     )
 
     Surface(
@@ -44,8 +43,8 @@ fun EnergyCockpitCard(state: MainUiState) {
         Column(
             modifier = Modifier
                 .background(surfaceBrush)
-                .padding(MaterialTheme.spacing.lg),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -55,7 +54,7 @@ fun EnergyCockpitCard(state: MainUiState) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Box(
                         modifier = Modifier
-                            .size(34.dp)
+                            .size(36.dp)
                             .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
                         contentAlignment = Alignment.Center
                     ) {
@@ -63,25 +62,26 @@ fun EnergyCockpitCard(state: MainUiState) {
                             Icons.Default.Bolt,
                             contentDescription = null,
                             tint = EVDesignTokens.Energy.green,
-                            modifier = Modifier.size(19.dp)
+                            modifier = Modifier.size(20.dp)
                         )
                     }
-                    Spacer(Modifier.size(MaterialTheme.spacing.sm))
+                    Spacer(Modifier.size(10.dp))
                     Column {
                         Text(
                             "ENERGY FLOW",
-                            style = MaterialTheme.typography.labelLarge,
+                            style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
                             "本月能源",
-                            style = MaterialTheme.typography.titleMedium,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Medium,
                             color = MaterialTheme.colorScheme.onSurface
                         )
                     }
                 }
                 Text(
-                    "${state.chargingCount} 次",
+                    "${state.chargingCount} 次充电",
                     style = MaterialTheme.typography.bodyMedium,
                     color = EVDesignTokens.Energy.green
                 )
@@ -89,132 +89,100 @@ fun EnergyCockpitCard(state: MainUiState) {
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Bottom
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Column {
-                    Text(
-                        "本月用电",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Row(verticalAlignment = Alignment.Bottom) {
-                        Text(
-                            one(state.monthEnergy),
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(Modifier.size(MaterialTheme.spacing.xs))
-                        Text(
-                            "kWh",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = EVDesignTokens.Energy.green
-                        )
-                    }
-                }
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        "本月费用",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        "¥ ${two(state.monthCost)}",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-            }
-
-            MonthlyEnergyBars(state.monthlyTrend)
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                FlatMetric("平均电价", "¥ ${two(state.averagePrice)}/kWh")
-                FlatMetric(
-                    "区间电耗",
-                    state.intervalEnergyPer100Km?.let { "${one(it)} kWh/100km" } ?: "--"
+                EnergyMetric(
+                    label = "本月用电",
+                    value = one(state.monthEnergy),
+                    unit = "kWh",
+                    highlightUnit = true,
+                    modifier = Modifier.weight(1.18f)
                 )
-                FlatMetric("充电次数", "${state.chargingCount} 次")
+                EnergyDivider()
+                EnergyMetric(
+                    label = "本月费用",
+                    value = "¥ ${two(state.monthCost)}",
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 12.dp)
+                )
+                EnergyDivider()
+                EnergyMetric(
+                    label = "平均电价",
+                    value = "¥ ${two(state.averagePrice)}",
+                    unit = "/kWh",
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 12.dp)
+                )
             }
+
+            MonthlyEnergyProgress(state.monthEnergy)
         }
     }
 }
 
 @Composable
-private fun MonthlyEnergyBars(months: List<MonthlyChargingBucket>) {
-    val values = if (months.isEmpty()) List(6) { 0.0 } else months.takeLast(6).map { it.energyKwh }
-    val max = (values.maxOrNull() ?: 0.0).coerceAtLeast(1.0)
-    val labels = if (months.isEmpty()) List(6) { "--" } else months.takeLast(6).map { "${it.month}月" }
-
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
-        Text(
-            "近 6 个月",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(74.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.Bottom
-        ) {
-            values.forEachIndexed { index, value ->
-                val ratio = (value / max).toFloat().coerceIn(0f, 1f)
-                val barHeight = (6 + 50 * ratio).dp
-                Column(
-                    modifier = Modifier.weight(1f),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Bottom
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(barHeight)
-                            .background(
-                                if (index == values.lastIndex) {
-                                    Brush.verticalGradient(
-                                        listOf(EVDesignTokens.Energy.green, EVDesignTokens.Energy.green.copy(alpha = 0.28f))
-                                    )
-                                } else {
-                                    Brush.verticalGradient(
-                                        listOf(Color(0xFF355347), Color(0xFF18231F))
-                                    )
-                                },
-                                MaterialTheme.shapes.small
-                            )
-                    )
-                    Spacer(Modifier.height(5.dp))
-                    Text(
-                        labels.getOrElse(index) { "--" },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FlatMetric(label: String, value: String) {
-    Column {
+private fun EnergyMetric(
+    label: String,
+    value: String,
+    unit: String? = null,
+    highlightUnit: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
         Text(
             label,
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        Spacer(Modifier.height(2.dp))
-        Text(
-            value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
+        Spacer(Modifier.height(4.dp))
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (unit != null) {
+                Spacer(Modifier.size(3.dp))
+                Text(
+                    unit,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (highlightUnit) EVDesignTokens.Energy.green else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EnergyDivider() {
+    Box(
+        Modifier
+            .size(width = 1.dp, height = 52.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
+    )
+}
+
+@Composable
+private fun MonthlyEnergyProgress(monthEnergy: Double) {
+    val normalized = (monthEnergy / 100.0).toFloat().coerceIn(0f, 1f)
+    val visibleProgress = if (normalized <= 0f) 0.012f else normalized.coerceAtLeast(0.03f)
+
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(5.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.22f))
+    ) {
+        Box(
+            Modifier
+                .fillMaxWidth(visibleProgress)
+                .height(5.dp)
+                .clip(CircleShape)
+                .background(EVDesignTokens.Energy.green)
         )
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -7,12 +7,11 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -34,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -42,7 +40,6 @@ import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.LocalCockpitColors
-import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.vehicle.OfficialVehicleImageCatalog
 import java.util.Locale
 
@@ -56,38 +53,54 @@ fun HeroVehicleCard(
     latestTrip: TripSessionEntity? = null
 ) {
     val cockpit = LocalCockpitColors.current
-    val background = Brush.linearGradient(
-        listOf(
-            Color(0xFF06100C),
-            Color(0xFF0A2116),
-            Color(0xFF07110D)
-        )
-    )
 
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1.20f),
         shape = MaterialTheme.shapes.large,
         color = Color.Transparent
     ) {
-        Column(modifier = Modifier.background(background)) {
+        Box(Modifier.fillMaxSize()) {
+            VehicleStage(vehicle, Modifier.fillMaxSize())
+
+            // Keep the Hero as one continuous artwork surface. This scrim only protects
+            // text contrast; it must not read as a separate title block.
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                Color(0x72020806),
+                                Color(0x18020806),
+                                Color.Transparent,
+                                Color(0x3D020806)
+                            )
+                        )
+                    )
+            )
+
             Column(
-                modifier = Modifier.padding(
-                    start = MaterialTheme.spacing.lg,
-                    end = MaterialTheme.spacing.lg,
-                    top = MaterialTheme.spacing.lg,
-                    bottom = MaterialTheme.spacing.sm
-                )
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(start = 18.dp, top = 16.dp, end = 18.dp)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
-                    Spacer(Modifier.size(MaterialTheme.spacing.xs))
-                    Text("MY EV", style = MaterialTheme.typography.labelLarge, color = cockpit.secondaryText)
+                    Spacer(Modifier.size(8.dp))
+                    Text(
+                        "MY EV",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = cockpit.primaryText
+                    )
                 }
-                Spacer(Modifier.height(MaterialTheme.spacing.lg))
+                Spacer(Modifier.height(18.dp))
                 Text(
                     vehicle?.brand ?: "EV Charge Book",
                     style = MaterialTheme.typography.bodyLarge,
-                    color = cockpit.secondaryText
+                    color = cockpit.primaryText.copy(alpha = 0.88f)
                 )
                 Text(
                     vehicle?.model ?: "添加你的第一辆车",
@@ -97,18 +110,15 @@ fun HeroVehicleCard(
                 )
             }
 
-            Box(modifier = Modifier.fillMaxWidth().height(304.dp)) {
-                VehicleStage(vehicle, Modifier.fillMaxSize())
-                if (vehicle != null) {
-                    HeroDynamicStateOverlay(
-                        currentSoc = currentSoc,
-                        currentMileageKm = currentMileageKm,
-                        latestTrip = latestTrip,
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(horizontal = 12.dp, vertical = 12.dp)
-                    )
-                }
+            if (vehicle != null) {
+                HeroDynamicStateOverlay(
+                    currentSoc = currentSoc,
+                    currentMileageKm = currentMileageKm,
+                    latestTrip = latestTrip,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 12.dp, vertical = 12.dp)
+                )
             }
         }
     }
@@ -148,18 +158,6 @@ private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier)
         } else {
             VehicleSilhouetteFallback(Modifier.fillMaxSize())
         }
-
-        Box(
-            Modifier.fillMaxSize().background(
-                Brush.verticalGradient(
-                    listOf(
-                        Color(0x2206100C),
-                        Color.Transparent,
-                        Color(0x5506100C)
-                    )
-                )
-            )
-        )
     }
 }
 
@@ -178,7 +176,6 @@ private fun HeroDynamicStateOverlay(
         label = "dashboard_hero_soc"
     )
     val panelShape = MaterialTheme.shapes.large
-    val fontScale = LocalConfiguration.current.fontScale
 
     Surface(
         modifier = modifier
@@ -187,55 +184,32 @@ private fun HeroDynamicStateOverlay(
         shape = panelShape,
         color = Color(0xD9091511)
     ) {
-        BoxWithConstraints(Modifier.fillMaxWidth()) {
-            val compact = maxWidth < 340.dp || fontScale >= 1.3f
-            if (compact) {
-                Column(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        HeroSocMetric(safeSoc, animatedProgress, Modifier.weight(1f))
-                        MetricDivider()
-                        HeroMetric(
-                            label = "当前里程",
-                            value = currentMileageKm?.let(::formatMileage) ?: "--",
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    if (latestTrip != null) {
-                        Box(
-                            Modifier
-                                .fillMaxWidth()
-                                .height(1.dp)
-                                .background(LocalCockpitColors.current.secondaryText.copy(alpha = .20f))
-                        )
-                        HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.fillMaxWidth())
-                    }
-                }
-            } else {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(14.dp)
-                ) {
-                    HeroSocMetric(safeSoc, animatedProgress, Modifier.weight(0.95f))
-                    MetricDivider()
-                    HeroMetric(
-                        label = "当前里程",
-                        value = currentMileageKm?.let(::formatMileage) ?: "--",
-                        modifier = Modifier.weight(1f)
-                    )
-                    if (latestTrip != null) {
-                        MetricDivider()
-                        HeroRecentTripMetric(trip = latestTrip, modifier = Modifier.weight(1.05f))
-                    }
-                }
-            }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HeroSocMetric(
+                safeSoc = safeSoc,
+                animatedProgress = animatedProgress,
+                modifier = Modifier.weight(0.92f)
+            )
+            MetricDivider()
+            HeroMetric(
+                label = "当前里程",
+                value = currentMileageKm?.let(::formatMileage) ?: "--",
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 12.dp)
+            )
+            MetricDivider()
+            HeroRecentTripMetric(
+                trip = latestTrip,
+                modifier = Modifier
+                    .weight(1.08f)
+                    .padding(start = 12.dp)
+            )
         }
     }
 }
@@ -243,7 +217,7 @@ private fun HeroDynamicStateOverlay(
 @Composable
 private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modifier = Modifier) {
     val cockpit = LocalCockpitColors.current
-    Column(modifier = modifier) {
+    Column(modifier = modifier.padding(end = 12.dp)) {
         Text(
             safeSoc?.let { "$it%" } ?: "--",
             style = MaterialTheme.typography.headlineLarge,
@@ -278,7 +252,7 @@ private fun HeroMetric(label: String, value: String, modifier: Modifier = Modifi
         Spacer(Modifier.height(4.dp))
         Text(
             value,
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Medium,
             color = cockpit.primaryText
         )
@@ -286,13 +260,15 @@ private fun HeroMetric(label: String, value: String, modifier: Modifier = Modifi
 }
 
 @Composable
-private fun HeroRecentTripMetric(trip: TripSessionEntity, modifier: Modifier = Modifier) {
+private fun HeroRecentTripMetric(trip: TripSessionEntity?, modifier: Modifier = Modifier) {
     val cockpit = LocalCockpitColors.current
-    val distance = trip.distanceMeters
-        .takeIf { it.isFinite() && it > 0.0 }
+    val distance = trip
+        ?.distanceMeters
+        ?.takeIf { it.isFinite() && it > 0.0 }
         ?.let(::formatTripDistance)
         ?: "--"
-    val consumption = trip.averageConsumptionKwhPer100Km
+    val consumption = trip
+        ?.averageConsumptionKwhPer100Km
         ?.takeIf { it.isFinite() && it >= 0.0 }
         ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
 
@@ -301,7 +277,7 @@ private fun HeroRecentTripMetric(trip: TripSessionEntity, modifier: Modifier = M
         Spacer(Modifier.height(4.dp))
         Text(
             distance,
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Medium,
             color = cockpit.primaryText
         )
@@ -309,7 +285,7 @@ private fun HeroRecentTripMetric(trip: TripSessionEntity, modifier: Modifier = M
             Spacer(Modifier.height(2.dp))
             Text(
                 consumption,
-                style = MaterialTheme.typography.labelMedium,
+                style = MaterialTheme.typography.labelSmall,
                 color = EVDesignTokens.Energy.green
             )
         }
@@ -320,7 +296,7 @@ private fun HeroRecentTripMetric(trip: TripSessionEntity, modifier: Modifier = M
 private fun MetricDivider() {
     Box(
         Modifier
-            .size(width = 1.dp, height = 54.dp)
+            .size(width = 1.dp, height = 56.dp)
             .background(LocalCockpitColors.current.secondaryText.copy(alpha = .24f))
     )
 }


### PR DESCRIPTION
## Summary

Implement the first P0 convergence pass from the latest running BYD Seal Dashboard toward the approved 1:1 reference defined in #101.

### Changes

- make the Hero a single continuous artwork surface instead of a separate title block + image block;
- reduce Hero height to the reference-like proportion using the existing finished vehicle artwork;
- overlay `MY EV / brand / model` directly on the Hero artwork with a restrained readability scrim;
- keep the Hero state panel permanently three-column: SOC / current mileage / latest trip, even when trip data is missing;
- tighten Dashboard outer gutter and vertical card spacing from generic page spacing to the reference-specific 8dp rhythm;
- simplify Monthly Energy to the reference first-viewport structure: header, three metrics, and a thin progress line;
- remove the six-month bar chart and extra Dashboard-only energy metrics from this card so the complete monthly summary can remain visible above bottom navigation.

## Data integrity

No screenshot values are hard-coded. SOC, mileage, trip, energy, cost, average price, and charging count remain sourced from `MainUiState` / persisted data. Missing trip data renders `--` while preserving layout geometry.

## Scope

This is the first implementation pass only. It intentionally focuses on the P0 geometry/layout blockers identified in #101. Recent Trip populated styling, Hero switch affordance, icon fidelity, bottom-nav dock geometry, and fine typography/color tuning remain follow-up work after screenshot/device verification.

## Acceptance

- Android CI must pass.
- Verify on a representative emulator/physical device.
- Capture a populated fixture screenshot and an empty/real-data screenshot.
- Compare both against the approved reference and record the remaining P1/P2 visual gaps before merge.

Related: #101