### PR TITLE
feat(ui): converge Dashboard P1 recent trip and vehicle switch

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -197,7 +197,7 @@ private fun TripRouteRail() {
 @Composable
 private fun TripMetric(value: String, label: String, modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.padding(horizontal = 5.dp),
+        modifier = modifier.padding(horizontal = 3.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -294,8 +294,7 @@ private fun formatConsumptionValue(value: Double?): String =
         ?: "--"
 
 private fun formatDistanceValue(meters: Double): String =
-    if (meters >= 1000.0) String.format(Locale.US, "%.1f", meters / 1000.0)
-    else String.format(Locale.US, "%.1f", meters / 1000.0)
+    String.format(Locale.US, "%.1f", meters / 1000.0)
 
 private fun formatDuration(seconds: Long): String {
     val hours = seconds / 3600

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -13,9 +13,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Route
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -28,14 +27,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.location.AndroidGeocoderAddressResolver
-import com.evchargebook.ui.components.ResponsiveMetricGrid
-import com.evchargebook.ui.theme.spacing
+import com.evchargebook.ui.theme.EVDesignTokens
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -47,7 +45,7 @@ fun DashboardRecentTripCard(trip: TripSessionEntity?) {
         return
     }
 
-    val context = LocalContext.current
+    val context = androidx.compose.ui.platform.LocalContext.current
     val resolver = remember(context) { AndroidGeocoderAddressResolver(context) }
     var startAddress by remember(trip.id) { mutableStateOf<String?>(null) }
     var endAddress by remember(trip.id) { mutableStateOf<String?>(null) }
@@ -61,154 +59,173 @@ fun DashboardRecentTripCard(trip: TripSessionEntity?) {
         trip.endLongitude
     ) {
         resolving = true
-        startAddress = resolveEndpoint(
-            resolver = resolver,
-            latitude = trip.startLatitude,
-            longitude = trip.startLongitude
-        )
+        startAddress = resolveEndpoint(resolver, trip.startLatitude, trip.startLongitude)
         endAddress = when {
             trip.endLatitude == null || trip.endLongitude == null -> null
             trip.startLatitude == trip.endLatitude && trip.startLongitude == trip.endLongitude -> startAddress
-            else -> resolveEndpoint(
-                resolver = resolver,
-                latitude = trip.endLatitude,
-                longitude = trip.endLongitude
-            )
+            else -> resolveEndpoint(resolver, trip.endLatitude, trip.endLongitude)
         }
         resolving = false
     }
 
-    val metrics = listOf(
-        "距离" to formatDistance(trip.distanceMeters),
-        "耗时" to formatDuration(trip.elapsedSeconds),
-        "估算能耗" to formatConsumption(trip.averageConsumptionKwhPer100Km)
-    )
-
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = Color(0xFF0A1210)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Column {
-                Text("最近行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                Text("RECENT TRIP", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            Text(
-                formatTime(trip.startedAtEpochMillis),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+            RecentTripHeader()
 
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.large,
-            color = MaterialTheme.colorScheme.surfaceContainerLow
-        ) {
-            Column(
-                modifier = Modifier.padding(MaterialTheme.spacing.md),
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                RouteSummary(
-                    start = endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving),
-                    end = endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)
-                )
-
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .55f))
-
-                ResponsiveMetricGrid(metrics.size) { index, modifier ->
-                    val (label, value) = metrics[index]
-                    RecentTripMetric(label, value, modifier)
-                }
-
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .55f))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+                TripRouteRail()
+                Spacer(Modifier.width(10.dp))
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
                 ) {
-                    RecentTripStateValue(
-                        label = "SOC",
-                        value = formatSocRange(trip.startSoc, trip.endSoc),
-                        modifier = Modifier.weight(1f)
+                    Text(
+                        "${endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)} → ${endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
-                    RecentTripStateValue(
-                        label = "总里程",
-                        value = formatMileageRange(trip.startMileageKm, trip.endMileageKm),
-                        modifier = Modifier.weight(1f)
+                    Text(
+                        formatTime(trip.startedAtEpochMillis),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
+                Spacer(Modifier.width(8.dp))
+                Surface(
+                    shape = CircleShape,
+                    color = EVDesignTokens.Energy.green.copy(alpha = 0.10f)
+                ) {
+                    Text(
+                        "已完成",
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = EVDesignTokens.Energy.green
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.78f))
+                MetricSeparator()
+                TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.82f))
+                MetricSeparator()
+                TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "kWh/100km", Modifier.weight(1.05f))
+                MetricSeparator()
+                TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC 变化", Modifier.weight(1.25f))
+                MetricSeparator()
+                TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程 (km)", Modifier.weight(1.55f))
             }
         }
     }
 }
 
 @Composable
-private fun RouteSummary(start: String, end: String) {
+private fun RecentTripHeader() {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Surface(
-            modifier = Modifier.size(40.dp),
-            shape = CircleShape,
-            color = MaterialTheme.colorScheme.primary.copy(alpha = .10f)
-        ) {
-            Box(contentAlignment = Alignment.Center) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(38.dp)
+                    .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
                     Icons.Default.Route,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = EVDesignTokens.Energy.green,
                     modifier = Modifier.size(20.dp)
                 )
             }
-        }
-        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Spacer(Modifier.width(10.dp))
             Text(
-                start,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
+                "最近行程",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface
             )
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    Icons.Default.ArrowForward,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    end,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "查看全部",
+                style = MaterialTheme.typography.bodyMedium,
+                color = EVDesignTokens.Energy.green
+            )
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
         }
     }
 }
 
 @Composable
-private fun RecentTripMetric(label: String, value: String, modifier: Modifier = Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Spacer(Modifier.height(4.dp))
-        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+private fun TripRouteRail() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
+        Box(
+            Modifier
+                .size(width = 1.dp, height = 18.dp)
+                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f))
+        )
+        Box(Modifier.size(7.dp).background(Color(0xFFFF7373), CircleShape))
     }
 }
 
 @Composable
-private fun RecentTripStateValue(label: String, value: String, modifier: Modifier = Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+private fun TripMetric(value: String, label: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = 5.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
         Spacer(Modifier.height(2.dp))
-        Text(value, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
+}
+
+@Composable
+private fun MetricSeparator() {
+    Box(
+        Modifier
+            .size(width = 1.dp, height = 36.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
+    )
 }
 
 @Composable
@@ -216,26 +233,26 @@ private fun RecentTripEmptyState() {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
+        color = Color(0xFF0A1210)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Box(
-                Modifier.size(40.dp).background(MaterialTheme.colorScheme.primary.copy(alpha = .10f), CircleShape),
-                contentAlignment = Alignment.Center
+            RecentTripHeader()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(Icons.Default.Route, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-            }
-            Column(Modifier.weight(1f)) {
-                Text("最近行程", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                Text(
-                    "完成第一段行程后，这里会显示距离、SOC、里程与可信的能耗估算。",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                TripRouteRail()
+                Spacer(Modifier.width(10.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "完成第一段行程后，这里会显示距离、SOC、里程与可信的能耗估算。",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }
@@ -261,9 +278,9 @@ private fun formatSocRange(start: Int?, end: Int?): String =
     "${start?.let { "$it%" } ?: "--"} → ${end?.let { "$it%" } ?: "--"}"
 
 private fun formatMileageRange(start: Double?, end: Double?): String = when {
-    start != null && end != null -> "${formatMileage(start)} → ${formatMileage(end)} km"
-    start != null -> "${formatMileage(start)} → -- km"
-    end != null -> "-- → ${formatMileage(end)} km"
+    start != null && end != null -> "${formatMileage(start)} → ${formatMileage(end)}"
+    start != null -> "${formatMileage(start)} → --"
+    end != null -> "-- → ${formatMileage(end)}"
     else -> "--"
 }
 
@@ -271,26 +288,35 @@ private fun formatMileage(value: Double): String =
     if (value % 1.0 == 0.0) String.format(Locale.US, "%,.0f", value)
     else String.format(Locale.US, "%,.1f", value)
 
-private fun formatConsumption(value: Double?): String =
+private fun formatConsumptionValue(value: Double?): String =
     value?.takeIf { it.isFinite() && it >= 0.0 }
-        ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
+        ?.let { String.format(Locale.US, "%.1f", it) }
         ?: "--"
 
-private fun formatDistance(meters: Double): String =
-    if (meters >= 1000.0) String.format(Locale.US, "%.1f km", meters / 1000.0)
-    else String.format(Locale.US, "%.0f m", meters)
+private fun formatDistanceValue(meters: Double): String =
+    if (meters >= 1000.0) String.format(Locale.US, "%.1f", meters / 1000.0)
+    else String.format(Locale.US, "%.1f", meters / 1000.0)
 
 private fun formatDuration(seconds: Long): String {
     val hours = seconds / 3600
     val minutes = (seconds % 3600) / 60
     return when {
-        hours > 0 -> "${hours}h ${minutes}m"
+        hours > 0 -> "$hours:${minutes.toString().padStart(2, '0')}"
         minutes > 0 -> "${minutes}m"
         else -> "${seconds}s"
     }
 }
 
-private fun formatTime(epochMillis: Long): String =
-    SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))
+private fun formatTime(epochMillis: Long): String {
+    val event = Date(epochMillis)
+    val now = Date()
+    val day = SimpleDateFormat("yyyyMMdd", Locale.SIMPLIFIED_CHINESE)
+    val time = SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE)
+    return if (day.format(event) == day.format(now)) {
+        "今天 ${time.format(event)}"
+    } else {
+        SimpleDateFormat("M月d日 HH:mm", Locale.SIMPLIFIED_CHINESE).format(event)
+    }
+}
 
 private fun formatCoordinate(value: Double): String = String.format(Locale.US, "%.5f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -63,9 +63,11 @@ fun DashboardScreen(
         item {
             HeroVehicleCard(
                 vehicle = state.vehicle,
+                vehicles = state.vehicles,
                 currentSoc = state.currentSoc,
                 currentMileageKm = state.currentMileageKm,
-                latestTrip = latestCompletedTrip
+                latestTrip = latestCompletedTrip,
+                onSelectVehicle = onSelectVehicle
             )
         }
         item { DashboardRecentTripCard(latestCompletedTrip) }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -43,7 +44,7 @@ fun EnergyCockpitCard(state: MainUiState) {
         Column(
             modifier = Modifier
                 .background(surfaceBrush)
-                .padding(horizontal = 16.dp, vertical = 14.dp),
+                .padding(horizontal = 14.dp, vertical = 13.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             Row(
@@ -80,11 +81,19 @@ fun EnergyCockpitCard(state: MainUiState) {
                         )
                     }
                 }
-                Text(
-                    "${state.chargingCount} 次充电",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = EVDesignTokens.Energy.green
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        "${state.chargingCount} 次充电",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = EVDesignTokens.Energy.green
+                    )
+                    Icon(
+                        Icons.Default.ChevronRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
             }
 
             Row(

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,12 +19,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,11 +57,15 @@ private const val VEHICLE_ARTWORK_TAG = "VehicleArtwork"
 @Composable
 fun HeroVehicleCard(
     vehicle: VehicleEntity?,
+    vehicles: List<VehicleEntity> = emptyList(),
     currentSoc: Int? = null,
     currentMileageKm: Double? = null,
-    latestTrip: TripSessionEntity? = null
+    latestTrip: TripSessionEntity? = null,
+    onSelectVehicle: (Long) -> Unit = {}
 ) {
     val cockpit = LocalCockpitColors.current
+    val selectableVehicles = if (vehicles.isNotEmpty()) vehicles else listOfNotNull(vehicle)
+    var vehicleMenuExpanded by remember { mutableStateOf(false) }
 
     Surface(
         modifier = Modifier
@@ -64,8 +77,6 @@ fun HeroVehicleCard(
         Box(Modifier.fillMaxSize()) {
             VehicleStage(vehicle, Modifier.fillMaxSize())
 
-            // Keep the Hero as one continuous artwork surface. This scrim only protects
-            // text contrast; it must not read as a separate title block.
             Box(
                 Modifier
                     .fillMaxSize()
@@ -111,6 +122,66 @@ fun HeroVehicleCard(
             }
 
             if (vehicle != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 14.dp, end = 14.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .size(width = 54.dp, height = 48.dp)
+                            .clip(CircleShape)
+                            .background(Color(0x8F07110F))
+                            .border(1.dp, Color.White.copy(alpha = 0.12f), CircleShape)
+                            .clickable(enabled = selectableVehicles.isNotEmpty()) {
+                                vehicleMenuExpanded = true
+                            }
+                            .padding(horizontal = 9.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.DirectionsCar,
+                            contentDescription = "切换车辆",
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp)
+                        )
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowDown,
+                            contentDescription = null,
+                            tint = Color.White.copy(alpha = 0.92f),
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+
+                    DropdownMenu(
+                        expanded = vehicleMenuExpanded,
+                        onDismissRequest = { vehicleMenuExpanded = false }
+                    ) {
+                        selectableVehicles.forEach { candidate ->
+                            DropdownMenuItem(
+                                text = {
+                                    Column {
+                                        Text(
+                                            candidate.model,
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            fontWeight = if (candidate.id == vehicle.id) FontWeight.SemiBold else FontWeight.Normal
+                                        )
+                                        Text(
+                                            candidate.brand,
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    vehicleMenuExpanded = false
+                                    onSelectVehicle(candidate.id)
+                                }
+                            )
+                        }
+                    }
+                }
+
                 HeroDynamicStateOverlay(
                     currentSoc = currentSoc,
                     currentMileageKm = currentMileageKm,

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -41,6 +43,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -268,8 +271,10 @@ private fun HeroDynamicStateOverlay(
             )
             MetricDivider()
             HeroMetric(
+                icon = Icons.Default.Speed,
                 label = "当前里程",
                 value = currentMileageKm?.let(::formatMileage) ?: "--",
+                unit = if (currentMileageKm != null) "km" else null,
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 12.dp)
@@ -289,12 +294,30 @@ private fun HeroDynamicStateOverlay(
 private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modifier = Modifier) {
     val cockpit = LocalCockpitColors.current
     Column(modifier = modifier.padding(end = 12.dp)) {
-        Text(
-            safeSoc?.let { "$it%" } ?: "--",
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.SemiBold,
-            color = if (safeSoc != null) EVDesignTokens.Energy.green else cockpit.primaryText
-        )
+        if (safeSoc != null) {
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    safeSoc.toString(),
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = EVDesignTokens.Energy.green
+                )
+                Text(
+                    "%",
+                    modifier = Modifier.padding(bottom = 2.dp),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = cockpit.primaryText
+                )
+            }
+        } else {
+            Text(
+                "--",
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = cockpit.primaryText
+            )
+        }
         Spacer(Modifier.height(8.dp))
         Box(
             Modifier
@@ -316,17 +339,42 @@ private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modi
 }
 
 @Composable
-private fun HeroMetric(label: String, value: String, modifier: Modifier = Modifier) {
+private fun HeroMetric(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    unit: String? = null,
+    modifier: Modifier = Modifier
+) {
     val cockpit = LocalCockpitColors.current
     Column(modifier = modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = cockpit.secondaryText,
+                modifier = Modifier.size(14.dp)
+            )
+            Spacer(Modifier.size(4.dp))
+            Text(label, style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        }
         Spacer(Modifier.height(4.dp))
-        Text(
-            value,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Medium,
-            color = cockpit.primaryText
-        )
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = cockpit.primaryText
+            )
+            if (unit != null) {
+                Spacer(Modifier.size(3.dp))
+                Text(
+                    unit,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = cockpit.primaryText.copy(alpha = 0.86f)
+                )
+            }
+        }
     }
 }
 
@@ -336,29 +384,53 @@ private fun HeroRecentTripMetric(trip: TripSessionEntity?, modifier: Modifier = 
     val distance = trip
         ?.distanceMeters
         ?.takeIf { it.isFinite() && it > 0.0 }
-        ?.let(::formatTripDistance)
-        ?: "--"
     val consumption = trip
         ?.averageConsumptionKwhPer100Km
         ?.takeIf { it.isFinite() && it >= 0.0 }
-        ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
 
     Column(modifier = modifier) {
-        Text("最近行程", style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.Route,
+                contentDescription = null,
+                tint = cockpit.secondaryText,
+                modifier = Modifier.size(14.dp)
+            )
+            Spacer(Modifier.size(4.dp))
+            Text("最近行程", style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
+        }
         Spacer(Modifier.height(4.dp))
-        Text(
-            distance,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Medium,
-            color = cockpit.primaryText
-        )
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                distance?.let(::formatTripDistance) ?: "--",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = cockpit.primaryText
+            )
+            if (distance != null) {
+                Spacer(Modifier.size(3.dp))
+                Text(
+                    if (distance >= 1000.0) "km" else "m",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = cockpit.primaryText.copy(alpha = 0.86f)
+                )
+            }
+        }
         if (consumption != null) {
             Spacer(Modifier.height(2.dp))
-            Text(
-                consumption,
-                style = MaterialTheme.typography.labelSmall,
-                color = EVDesignTokens.Energy.green
-            )
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    String.format(Locale.US, "%.1f", consumption),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = EVDesignTokens.Energy.green
+                )
+                Spacer(Modifier.size(3.dp))
+                Text(
+                    "kWh/100km",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = cockpit.secondaryText
+                )
+            }
         }
     }
 }
@@ -419,14 +491,14 @@ private fun VehicleSilhouetteFallback(modifier: Modifier = Modifier) {
 
 private fun formatMileage(value: Double): String =
     if (value % 1.0 == 0.0) {
-        String.format(Locale.US, "%,.0f km", value)
+        String.format(Locale.US, "%,.0f", value)
     } else {
-        String.format(Locale.US, "%,.1f km", value)
+        String.format(Locale.US, "%,.1f", value)
     }
 
 private fun formatTripDistance(meters: Double): String =
     if (meters >= 1000.0) {
-        String.format(Locale.US, "%.1f km", meters / 1000.0)
+        String.format(Locale.US, "%.1f", meters / 1000.0)
     } else {
-        String.format(Locale.US, "%.0f m", meters)
+        String.format(Locale.US, "%.0f", meters)
     }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -60,10 +60,10 @@ private const val VEHICLE_ARTWORK_TAG = "VehicleArtwork"
 @Composable
 fun HeroVehicleCard(
     vehicle: VehicleEntity?,
-    vehicles: List<VehicleEntity> = emptyList(),
     currentSoc: Int? = null,
     currentMileageKm: Double? = null,
     latestTrip: TripSessionEntity? = null,
+    vehicles: List<VehicleEntity> = emptyList(),
     onSelectVehicle: (Long) -> Unit = {}
 ) {
     val cockpit = LocalCockpitColors.current


### PR DESCRIPTION
## Summary

Continue Dashboard 1:1 convergence after merged P0 PR #104 and the merged #101 visual specification.

### Changes

- add the top-right translucent vehicle switch affordance directly on the Hero, matching the reference car + chevron control;
- reuse the existing real vehicle list and `selectVehicle` flow through a compact dropdown instead of adding parallel navigation;
- refine the Hero glass panel hierarchy: green SOC number + white `%`, small gauge/route header icons, separated value/unit treatment, and green consumption number with muted unit;
- rebuild the Recent Trip card as one dark cockpit card instead of a separate heading + nested card;
- add the reference-style header with route icon, `最近行程`, `查看全部`, and chevron;
- add start/end route rail, one-line route summary, completion status pill, and time line;
- present the five required metric groups in one row: distance / duration / consumption / SOC change / mileage change;
- keep the empty Recent Trip state inside the same visual card family;
- refine Monthly Energy header padding and add the right-side chevron from the reference;
- preserve P0 Hero geometry, compact Monthly Energy body, and 8dp Dashboard rhythm.

## Data integrity

No screenshot sample values are hard-coded. Vehicle selection, trip distance, duration, consumption, SOC, mileage, route endpoints, timestamps, monthly energy, cost and average price continue to use repository state and persisted data.

## Scope

Bottom-navigation dock geometry remains the next isolated pass because it touches `MainActivity` and should be verified separately from these Dashboard-card changes.

## Acceptance

- Android CI green;
- Hero vehicle switch opens and selects an existing vehicle;
- populated Recent Trip keeps all five metric groups on a normal phone-width viewport;
- empty Recent Trip remains truthful and stable;
- Hero glass metric hierarchy visually matches the reference more closely;
- Monthly Energy header/body remain fully visible in the intended first-viewport composition;
- no regression to P0 geometry.

Related: #101, #104