### PR TITLE
feat(ui): match Dashboard bottom navigation dock

### DIFF
--- a/android/app/src/main/java/com/evchargebook/DashboardNavigationDock.kt
+++ b/android/app/src/main/java/com/evchargebook/DashboardNavigationDock.kt
@@ -1,0 +1,75 @@
+package com.evchargebook
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar as MaterialNavigationBar
+import androidx.compose.material3.NavigationBarItem as MaterialNavigationBarItem
+import androidx.compose.material3.NavigationBarItemColors
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Dashboard-specific navigation shell.
+ *
+ * MainActivity lives in the same package, so this intentionally shadows the
+ * Material3 NavigationBar call there while preserving its existing five-tab
+ * semantics and state handling. The visual shell matches the approved
+ * reference dock without duplicating navigation logic.
+ */
+@Composable
+fun NavigationBar(
+    containerColor: Color,
+    tonalElevation: Dp,
+    content: @Composable RowScope.() -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        color = Color(0xFF081216),
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp
+    ) {
+        MaterialNavigationBar(
+            modifier = Modifier.fillMaxWidth(),
+            containerColor = Color.Transparent,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            tonalElevation = 0.dp,
+            content = content
+        )
+    }
+}
+
+/**
+ * Keeps Material3 interaction/accessibility behavior while enlarging the
+ * supplied icon slot slightly. MainActivity already provides the target
+ * selected/unselected colors and a transparent selected indicator.
+ */
+@Composable
+fun RowScope.NavigationBarItem(
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: @Composable () -> Unit,
+    label: @Composable (() -> Unit)?,
+    colors: NavigationBarItemColors
+) {
+    MaterialNavigationBarItem(
+        selected = selected,
+        onClick = onClick,
+        icon = {
+            Box(Modifier.scale(1.14f)) {
+                icon()
+            }
+        },
+        label = label,
+        colors = colors
+    )
+}


### PR DESCRIPTION
## Summary

Isolate the remaining Dashboard bottom-navigation visual convergence into a small follow-up PR.

### Changes

- add a Dashboard navigation shell with the approved dark blue-green dock surface;
- add strongly rounded top corners to match the reference instead of the current flat Material bar;
- preserve the existing five tabs and all current tab state/handlers in `MainActivity`;
- preserve the existing transparent selected indicator and selected/unselected color logic;
- slightly enlarge the rendered icon slot while retaining Material3 interaction/accessibility behavior;
- avoid duplicating or rewriting navigation state by wrapping the existing Material3 components from the app package.

## Why isolated

This keeps the bottom dock change independent from PR #105's Hero / Recent Trip / Monthly Energy work. It can be built and visually verified separately, and it does not touch business state or navigation destinations.

## Acceptance

- Android CI green;
- five tabs remain `总览 / 记录 / 统计 / 行程 / 车辆`;
- selected item stays green and unselected items stay muted gray;
- no Material selected pill appears;
- dock has a dark surface with rounded top corners and no elevation shadow;
- no behavioral regression when switching tabs.

Related: #101, #104, #105