### PR TITLE
fix(ui): unblock dashboard navigation and trip deletion

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -343,7 +343,16 @@ fun MainApp(
                 )
                 bluetoothPrompt -> BluetoothPromptScreen(state.bluetoothSettings, state.pairedBluetoothDevices, viewModel::saveBluetoothPrompt) { bluetoothPrompt = false }
                 else -> when (tab) {
-                    0 -> DashboardScreen(state, { addRecord = true }, viewModel::selectVehicle)
+                    0 -> DashboardScreen(
+                        state = state,
+                        onAddClick = { addRecord = true },
+                        onSelectVehicle = viewModel::selectVehicle,
+                        onOpenTrips = {
+                            viewModel.closeTripDetail()
+                            tab = 3
+                        },
+                        onOpenChargingRecords = { tab = 1 }
+                    )
                     1 -> RecordsScreen(state.chargingRecords, viewModel::deleteChargingRecord, { addRecord = true }, { editingRecord = it })
                     2 -> StatsScreen(state)
                     3 -> {
@@ -354,7 +363,8 @@ fun MainApp(
                                 currentMileageKm = state.currentMileageKm,
                                 recentTrips = state.trips.filter { it.status == TripStatus.COMPLETED },
                                 onStart = ::startTripWithPermission,
-                                onOpenDetail = viewModel::openTripDetail
+                                onOpenDetail = viewModel::openTripDetail,
+                                onDelete = viewModel::deleteTrip
                             )
                         } else {
                             TripScreen(

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -1,6 +1,7 @@
 package com.evchargebook.ui.dashboard
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -27,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -39,9 +41,12 @@ import java.util.Date
 import java.util.Locale
 
 @Composable
-fun DashboardRecentTripCard(trip: TripSessionEntity?) {
+fun DashboardRecentTripCard(
+    trip: TripSessionEntity?,
+    onViewAll: () -> Unit = {}
+) {
     if (trip == null) {
-        RecentTripEmptyState()
+        RecentTripEmptyState(onViewAll)
         return
     }
 
@@ -77,7 +82,7 @@ fun DashboardRecentTripCard(trip: TripSessionEntity?) {
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            RecentTripHeader()
+            RecentTripHeader(onViewAll)
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -136,7 +141,7 @@ fun DashboardRecentTripCard(trip: TripSessionEntity?) {
 }
 
 @Composable
-private fun RecentTripHeader() {
+private fun RecentTripHeader(onViewAll: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -165,7 +170,13 @@ private fun RecentTripHeader() {
             )
         }
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier
+                .clip(CircleShape)
+                .clickable(onClick = onViewAll)
+                .padding(start = 10.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             Text(
                 "查看全部",
                 style = MaterialTheme.typography.bodyMedium,
@@ -173,7 +184,7 @@ private fun RecentTripHeader() {
             )
             Icon(
                 Icons.Default.ChevronRight,
-                contentDescription = null,
+                contentDescription = "查看全部行程",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(20.dp)
             )
@@ -229,7 +240,7 @@ private fun MetricSeparator() {
 }
 
 @Composable
-private fun RecentTripEmptyState() {
+private fun RecentTripEmptyState(onViewAll: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -239,7 +250,7 @@ private fun RecentTripEmptyState() {
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            RecentTripHeader()
+            RecentTripHeader(onViewAll)
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -42,7 +42,9 @@ import java.util.Locale
 fun DashboardScreen(
     state: MainUiState,
     onAddClick: () -> Unit,
-    onSelectVehicle: (Long) -> Unit
+    onSelectVehicle: (Long) -> Unit,
+    onOpenTrips: () -> Unit = {},
+    onOpenChargingRecords: () -> Unit = {}
 ) {
     val selectedVehicleId = state.vehicle?.id
     val latestCompletedTrip = state.trips
@@ -70,8 +72,8 @@ fun DashboardScreen(
                 onSelectVehicle = onSelectVehicle
             )
         }
-        item { DashboardRecentTripCard(latestCompletedTrip) }
-        item { EnergyCockpitCard(state) }
+        item { DashboardRecentTripCard(latestCompletedTrip, onOpenTrips) }
+        item { EnergyCockpitCard(state, onOpenChargingRecords) }
         item { RecentChargingHeader(onAddClick) }
 
         if (state.chargingRecords.isEmpty()) {

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -1,6 +1,7 @@
 package com.evchargebook.ui.dashboard
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +32,10 @@ import com.evchargebook.viewmodel.MainUiState
 import java.util.Locale
 
 @Composable
-fun EnergyCockpitCard(state: MainUiState) {
+fun EnergyCockpitCard(
+    state: MainUiState,
+    onOpenRecords: () -> Unit = {}
+) {
     val surfaceBrush = Brush.verticalGradient(
         listOf(Color(0xFF0D1512), Color(0xFF09100E))
     )
@@ -81,7 +85,13 @@ fun EnergyCockpitCard(state: MainUiState) {
                         )
                     }
                 }
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable(onClick = onOpenRecords)
+                        .padding(start = 10.dp, top = 8.dp, bottom = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Text(
                         "${state.chargingCount} 次充电",
                         style = MaterialTheme.typography.bodyMedium,
@@ -89,7 +99,7 @@ fun EnergyCockpitCard(state: MainUiState) {
                     )
                     Icon(
                         Icons.Default.ChevronRight,
-                        contentDescription = null,
+                        contentDescription = "查看充电记录",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp)
                     )

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -3,7 +3,6 @@ package com.evchargebook.ui.dashboard
 import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -21,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DirectionsCar
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.DropdownMenu
@@ -38,15 +36,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
@@ -71,127 +67,120 @@ fun HeroVehicleCard(
     var vehicleMenuExpanded by remember { mutableStateOf(false) }
 
     Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(1.20f),
+        modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = Color.Transparent
+        color = Color(0xFF06100C)
     ) {
-        Box(Modifier.fillMaxSize()) {
-            VehicleStage(vehicle, Modifier.fillMaxSize())
-
+        Column {
             Box(
-                Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(
-                                Color(0x72020806),
-                                Color(0x18020806),
-                                Color.Transparent,
-                                Color(0x3D020806)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1.46f)
+            ) {
+                VehicleStage(vehicle, Modifier.fillMaxSize())
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(
+                                    Color(0x7A020806),
+                                    Color(0x16020806),
+                                    Color.Transparent,
+                                    Color(0x12020806)
+                                )
                             )
                         )
-                    )
-            )
-
-            Column(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(start = 18.dp, top = 16.dp, end = 18.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
-                    Spacer(Modifier.size(8.dp))
-                    Text(
-                        "MY EV",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = cockpit.primaryText
-                    )
-                }
-                Spacer(Modifier.height(18.dp))
-                Text(
-                    vehicle?.brand ?: "EV Charge Book",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = cockpit.primaryText.copy(alpha = 0.88f)
                 )
-                Text(
-                    vehicle?.model ?: "添加你的第一辆车",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = cockpit.primaryText
-                )
-            }
 
-            if (vehicle != null) {
-                Box(
+                Column(
                     modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 14.dp, end = 14.dp)
+                        .align(Alignment.TopStart)
+                        .padding(start = 16.dp, top = 14.dp, end = 72.dp)
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .size(width = 54.dp, height = 48.dp)
-                            .clip(CircleShape)
-                            .background(Color(0x8F07110F))
-                            .border(1.dp, Color.White.copy(alpha = 0.12f), CircleShape)
-                            .clickable(enabled = selectableVehicles.isNotEmpty()) {
-                                vehicleMenuExpanded = true
-                            }
-                            .padding(horizontal = 9.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.DirectionsCar,
-                            contentDescription = "切换车辆",
-                            tint = Color.White,
-                            modifier = Modifier.size(22.dp)
-                        )
-                        Icon(
-                            imageVector = Icons.Default.KeyboardArrowDown,
-                            contentDescription = null,
-                            tint = Color.White.copy(alpha = 0.92f),
-                            modifier = Modifier.size(16.dp)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
+                        Spacer(Modifier.size(8.dp))
+                        Text(
+                            "MY EV",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Medium,
+                            color = cockpit.primaryText
                         )
                     }
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        vehicle?.let { "${it.brand}  ${it.model}" } ?: "EV Charge Book",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = cockpit.primaryText,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
 
-                    DropdownMenu(
-                        expanded = vehicleMenuExpanded,
-                        onDismissRequest = { vehicleMenuExpanded = false }
+                if (vehicle != null) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 12.dp, end = 12.dp)
                     ) {
-                        selectableVehicles.forEach { candidate ->
-                            DropdownMenuItem(
-                                text = {
-                                    Column {
-                                        Text(
-                                            candidate.model,
-                                            style = MaterialTheme.typography.bodyLarge,
-                                            fontWeight = if (candidate.id == vehicle.id) FontWeight.SemiBold else FontWeight.Normal
-                                        )
-                                        Text(
-                                            candidate.brand,
-                                            style = MaterialTheme.typography.labelMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-                                    }
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clip(CircleShape)
+                                .background(Color(0x8F07110F))
+                                .border(1.dp, Color.White.copy(alpha = 0.12f), CircleShape)
+                                .clickable(enabled = selectableVehicles.isNotEmpty()) {
+                                    vehicleMenuExpanded = true
                                 },
-                                onClick = {
-                                    vehicleMenuExpanded = false
-                                    onSelectVehicle(candidate.id)
-                                }
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.DirectionsCar,
+                                contentDescription = "切换车辆",
+                                tint = Color.White,
+                                modifier = Modifier.size(23.dp)
                             )
+                        }
+
+                        DropdownMenu(
+                            expanded = vehicleMenuExpanded,
+                            onDismissRequest = { vehicleMenuExpanded = false }
+                        ) {
+                            selectableVehicles.forEach { candidate ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Column {
+                                            Text(
+                                                candidate.model,
+                                                style = MaterialTheme.typography.bodyLarge,
+                                                fontWeight = if (candidate.id == vehicle.id) FontWeight.SemiBold else FontWeight.Normal
+                                            )
+                                            Text(
+                                                candidate.brand,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    },
+                                    onClick = {
+                                        vehicleMenuExpanded = false
+                                        onSelectVehicle(candidate.id)
+                                    }
+                                )
+                            }
                         }
                     }
                 }
+            }
 
-                HeroDynamicStateOverlay(
+            if (vehicle != null) {
+                HeroDynamicStatePanel(
                     currentSoc = currentSoc,
                     currentMileageKm = currentMileageKm,
                     latestTrip = latestTrip,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = 12.dp, vertical = 12.dp)
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)
                 )
             }
         }
@@ -230,13 +219,18 @@ private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier)
                 alignment = Alignment.Center
             )
         } else {
-            VehicleSilhouetteFallback(Modifier.fillMaxSize())
+            Icon(
+                imageVector = Icons.Default.DirectionsCar,
+                contentDescription = null,
+                tint = EVDesignTokens.Energy.green.copy(alpha = 0.65f),
+                modifier = Modifier.size(72.dp)
+            )
         }
     }
 }
 
 @Composable
-private fun HeroDynamicStateOverlay(
+private fun HeroDynamicStatePanel(
     currentSoc: Int?,
     currentMileageKm: Double?,
     latestTrip: TripSessionEntity?,
@@ -254,9 +248,9 @@ private fun HeroDynamicStateOverlay(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .border(1.dp, Color.White.copy(alpha = 0.14f), panelShape),
+            .border(1.dp, Color.White.copy(alpha = 0.12f), panelShape),
         shape = panelShape,
-        color = Color(0xD9091511)
+        color = Color(0xFF091511)
     ) {
         Row(
             modifier = Modifier
@@ -442,51 +436,6 @@ private fun MetricDivider() {
             .size(width = 1.dp, height = 56.dp)
             .background(LocalCockpitColors.current.secondaryText.copy(alpha = .24f))
     )
-}
-
-@Composable
-private fun VehicleSilhouetteFallback(modifier: Modifier = Modifier) {
-    val energy = EVDesignTokens.Energy.green
-    Canvas(modifier) {
-        val w = size.width
-        val h = size.height
-        drawCircle(
-            brush = Brush.radialGradient(
-                listOf(energy.copy(alpha = 0.16f), Color.Transparent),
-                center = Offset(w * 0.58f, h * 0.60f),
-                radius = w * 0.46f
-            ),
-            radius = w * 0.46f,
-            center = Offset(w * 0.58f, h * 0.60f)
-        )
-        val body = Path().apply {
-            moveTo(w * .10f, h * .68f)
-            cubicTo(w * .16f, h * .61f, w * .23f, h * .57f, w * .30f, h * .55f)
-            cubicTo(w * .36f, h * .39f, w * .43f, h * .31f, w * .54f, h * .30f)
-            lineTo(w * .66f, h * .30f)
-            cubicTo(w * .73f, h * .33f, w * .79f, h * .43f, w * .84f, h * .53f)
-            cubicTo(w * .91f, h * .55f, w * .95f, h * .60f, w * .96f, h * .68f)
-            lineTo(w * .91f, h * .72f)
-            lineTo(w * .14f, h * .72f)
-            close()
-        }
-        drawPath(
-            body,
-            brush = Brush.horizontalGradient(
-                listOf(Color(0xFF0D1713), Color(0xFF173728), Color(0xFF0B1511))
-            )
-        )
-        drawPath(body, color = energy.copy(alpha = .72f), style = Stroke(width = 1.5.dp.toPx()))
-        listOf(w * .27f, w * .78f).forEach { x ->
-            drawCircle(Color(0xFF050807), 16.dp.toPx(), Offset(x, h * .70f))
-            drawCircle(
-                energy.copy(alpha = .55f),
-                10.dp.toPx(),
-                Offset(x, h * .70f),
-                style = Stroke(1.5.dp.toPx())
-            )
-        }
-    }
 }
 
 private fun formatMileage(value: Double): String =

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -4,13 +4,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -31,8 +33,14 @@ fun TripReadyScreen(
     currentMileageKm: Double?,
     recentTrips: List<TripSessionEntity>,
     onStart: () -> Unit,
-    onOpenDetail: (Long) -> Unit
+    onOpenDetail: (Long) -> Unit,
+    onDelete: (TripSessionEntity) -> Unit = {}
 ) {
+    var deleteTarget by remember { mutableStateOf<TripSessionEntity?>(null) }
+    val orderedTrips = remember(recentTrips) {
+        recentTrips.sortedByDescending { it.endedAtEpochMillis ?: it.startedAtEpochMillis }
+    }
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
@@ -106,11 +114,11 @@ fun TripReadyScreen(
             }
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text("最近行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                    Text("RECENT TRIPS", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("全部行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                    Text("TRIP HISTORY", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
-            if (recentTrips.isEmpty()) {
+            if (orderedTrips.isEmpty()) {
                 item {
                     Text(
                         "完成第一段行程后，这里会显示真实距离、SOC 与能耗记录。",
@@ -120,13 +128,37 @@ fun TripReadyScreen(
                     )
                 }
             } else {
-                items(minOf(recentTrips.size, 3)) { index ->
-                    val trip = recentTrips[index]
-                    ReadyRecentTripRow(trip = trip, onClick = { onOpenDetail(trip.id) })
+                items(orderedTrips, key = { it.id }) { trip ->
+                    ReadyRecentTripRow(
+                        trip = trip,
+                        onClick = { onOpenDetail(trip.id) },
+                        onDelete = { deleteTarget = trip }
+                    )
                 }
             }
             item { Spacer(Modifier.height(16.dp)) }
         }
+    }
+
+    deleteTarget?.let { trip ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("删除这条行程？") },
+            text = { Text("行程及关联轨迹点会一并删除，删除后无法恢复。") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDelete(trip)
+                        deleteTarget = null
+                    }
+                ) {
+                    Text("确认删除", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("取消") }
+            }
+        )
     }
 }
 
@@ -176,9 +208,16 @@ private fun ReadyStateMetric(label: String, value: String, modifier: Modifier) {
 }
 
 @Composable
-private fun ReadyRecentTripRow(trip: TripSessionEntity, onClick: () -> Unit) {
+private fun ReadyRecentTripRow(
+    trip: TripSessionEntity,
+    onClick: () -> Unit,
+    onDelete: () -> Unit
+) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = MaterialTheme.spacing.sm),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = MaterialTheme.spacing.sm),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .12f)) {
@@ -204,6 +243,14 @@ private fun ReadyRecentTripRow(trip: TripSessionEntity, onClick: () -> Unit) {
                 Text("${String.format(Locale.US, "%.1f", it)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                 Text("kWh/100km", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             } ?: Text("--", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "删除行程",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(19.dp)
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow up on the latest physical-device Dashboard acceptance screenshot.

### Fixes

- keep Hero labels out of the vehicle body area by collapsing brand/model into a compact top line;
- move the SOC / mileage / recent-trip state panel below the vehicle artwork so it no longer covers the car image;
- remove the extra down chevron from the top-right vehicle switch affordance and keep a single circular car icon;
- wire `最近行程 -> 查看全部` to the Trip tab;
- wire `本月能源 -> N 次充电` to the charging Records tab;
- make the ready-state Trip screen show the complete saved trip history instead of only the latest three;
- expose trip deletion in the normal no-active-trip state;
- require a destructive confirmation dialog before deleting a trip and its related track points.

## Navigation decisions

- Recent Trip `查看全部` -> `行程` tab.
- Monthly Energy `N 次充电` -> `记录` tab, because the trailing affordance represents the underlying charging records rather than the aggregate statistics page.

## Acceptance

- Hero artwork is not covered by the large vehicle title or the state panel;
- vehicle switch shows only the car icon;
- both Dashboard chevrons perform real navigation;
- Trip history is complete and ordered newest-first;
- delete is available for saved trips and always requires confirmation;
- Android CI green.
