### PR TITLE
fix(ui): close dashboard interaction and data guardrail gaps

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -351,7 +351,12 @@ fun MainApp(
                             viewModel.closeTripDetail()
                             tab = 3
                         },
-                        onOpenChargingRecords = { tab = 1 }
+                        onOpenTripDetail = { tripId ->
+                            viewModel.openTripDetail(tripId)
+                            tab = 3
+                        },
+                        onOpenChargingRecords = { tab = 1 },
+                        onEditChargingRecord = { editingRecord = it }
                     )
                     1 -> RecordsScreen(state.chargingRecords, viewModel::deleteChargingRecord, { addRecord = true }, { editingRecord = it })
                     2 -> StatsScreen(state)

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -43,7 +43,8 @@ import java.util.Locale
 @Composable
 fun DashboardRecentTripCard(
     trip: TripSessionEntity?,
-    onViewAll: () -> Unit = {}
+    onViewAll: () -> Unit = {},
+    onOpenTrip: (Long) -> Unit = {}
 ) {
     if (trip == null) {
         RecentTripEmptyState(onViewAll)
@@ -80,61 +81,70 @@ fun DashboardRecentTripCard(
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             RecentTripHeader(onViewAll)
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(MaterialTheme.shapes.medium)
+                    .clickable { onOpenTrip(trip.id) }
+                    .padding(vertical = 2.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                TripRouteRail()
-                Spacer(Modifier.width(10.dp))
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        "${endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)} → ${endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)}",
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Text(
-                        formatTime(trip.startedAtEpochMillis),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    TripRouteRail()
+                    Spacer(Modifier.width(10.dp))
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Text(
+                            "${endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)} → ${endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)}",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            formatTime(trip.startedAtEpochMillis),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Surface(
+                        shape = CircleShape,
+                        color = EVDesignTokens.Energy.green.copy(alpha = 0.10f)
+                    ) {
+                        Text(
+                            "已完成",
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = EVDesignTokens.Energy.green
+                        )
+                    }
                 }
-                Spacer(Modifier.width(8.dp))
-                Surface(
-                    shape = CircleShape,
-                    color = EVDesignTokens.Energy.green.copy(alpha = 0.10f)
-                ) {
-                    Text(
-                        "已完成",
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = EVDesignTokens.Energy.green
-                    )
-                }
-            }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.78f))
-                MetricSeparator()
-                TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.82f))
-                MetricSeparator()
-                TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "kWh/100km", Modifier.weight(1.05f))
-                MetricSeparator()
-                TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC 变化", Modifier.weight(1.25f))
-                MetricSeparator()
-                TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程 (km)", Modifier.weight(1.55f))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.8f))
+                    MetricSeparator()
+                    TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.82f))
+                    MetricSeparator()
+                    TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "能耗", Modifier.weight(0.9f))
+                    MetricSeparator()
+                    TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1.2f))
+                    MetricSeparator()
+                    TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程", Modifier.weight(1.45f))
+                }
             }
         }
     }
@@ -208,13 +218,13 @@ private fun TripRouteRail() {
 @Composable
 private fun TripMetric(value: String, label: String, modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.padding(horizontal = 3.dp),
+        modifier = modifier.padding(horizontal = 2.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -225,7 +235,7 @@ private fun TripMetric(value: String, label: String, modifier: Modifier = Modifi
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Clip
         )
     }
 }
@@ -234,7 +244,7 @@ private fun TripMetric(value: String, label: String, modifier: Modifier = Modifi
 private fun MetricSeparator() {
     Box(
         Modifier
-            .size(width = 1.dp, height = 36.dp)
+            .size(width = 1.dp, height = 34.dp)
             .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
     )
 }
@@ -286,18 +296,18 @@ private fun endpointText(address: String?, latitude: Double?, longitude: Double?
 }
 
 private fun formatSocRange(start: Int?, end: Int?): String =
-    "${start?.let { "$it%" } ?: "--"} → ${end?.let { "$it%" } ?: "--"}"
+    "${start?.let { "$it%" } ?: "--"}→${end?.let { "$it%" } ?: "--"}"
 
 private fun formatMileageRange(start: Double?, end: Double?): String = when {
-    start != null && end != null -> "${formatMileage(start)} → ${formatMileage(end)}"
-    start != null -> "${formatMileage(start)} → --"
-    end != null -> "-- → ${formatMileage(end)}"
+    start != null && end != null -> "${formatMileage(start)}→${formatMileage(end)}"
+    start != null -> "${formatMileage(start)}→--"
+    end != null -> "--→${formatMileage(end)}"
     else -> "--"
 }
 
 private fun formatMileage(value: Double): String =
-    if (value % 1.0 == 0.0) String.format(Locale.US, "%,.0f", value)
-    else String.format(Locale.US, "%,.1f", value)
+    if (value % 1.0 == 0.0) String.format(Locale.US, "%.0f", value)
+    else String.format(Locale.US, "%.1f", value)
 
 private fun formatConsumptionValue(value: Double?): String =
     value?.takeIf { it.isFinite() && it >= 0.0 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -44,7 +45,9 @@ fun DashboardScreen(
     onAddClick: () -> Unit,
     onSelectVehicle: (Long) -> Unit,
     onOpenTrips: () -> Unit = {},
-    onOpenChargingRecords: () -> Unit = {}
+    onOpenTripDetail: (Long) -> Unit = {},
+    onOpenChargingRecords: () -> Unit = {},
+    onEditChargingRecord: (ChargingRecordEntity) -> Unit = {}
 ) {
     val selectedVehicleId = state.vehicle?.id
     val latestCompletedTrip = state.trips
@@ -69,18 +72,25 @@ fun DashboardScreen(
                 currentSoc = state.currentSoc,
                 currentMileageKm = state.currentMileageKm,
                 latestTrip = latestCompletedTrip,
+                vehicleSwitchEnabled = state.activeTrip == null,
                 onSelectVehicle = onSelectVehicle
             )
         }
-        item { DashboardRecentTripCard(latestCompletedTrip, onOpenTrips) }
+        item {
+            DashboardRecentTripCard(
+                trip = latestCompletedTrip,
+                onViewAll = onOpenTrips,
+                onOpenTrip = onOpenTripDetail
+            )
+        }
         item { EnergyCockpitCard(state, onOpenChargingRecords) }
-        item { RecentChargingHeader(onAddClick) }
+        item { RecentChargingHeader(onOpenChargingRecords, onAddClick) }
 
         if (state.chargingRecords.isEmpty()) {
             item { EmptyChargingTimeline(onAddClick) }
         } else {
             items(state.chargingRecords.take(3), key = { it.id }) { record ->
-                ChargingTimelineRow(record)
+                ChargingTimelineRow(record, onEdit = { onEditChargingRecord(record) })
             }
         }
         item { Spacer(Modifier.height(16.dp)) }
@@ -88,7 +98,10 @@ fun DashboardScreen(
 }
 
 @Composable
-private fun RecentChargingHeader(onAddClick: () -> Unit) {
+private fun RecentChargingHeader(
+    onViewAll: () -> Unit,
+    onAddClick: () -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -102,19 +115,41 @@ private fun RecentChargingHeader(onAddClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(CircleShape)
-                .background(EVDesignTokens.Energy.green)
-                .clickable(onClick = onAddClick),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Default.Add,
-                contentDescription = "记录充电",
-                tint = MaterialTheme.colorScheme.onPrimary
-            )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .clickable(onClick = onViewAll)
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "查看全部",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = EVDesignTokens.Energy.green
+                )
+                Icon(
+                    Icons.Default.ChevronRight,
+                    contentDescription = "查看全部充电记录",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Spacer(Modifier.size(4.dp))
+            Box(
+                modifier = Modifier
+                    .size(42.dp)
+                    .clip(CircleShape)
+                    .background(EVDesignTokens.Energy.green)
+                    .clickable(onClick = onAddClick),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = "记录充电",
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
         }
     }
 }
@@ -153,10 +188,14 @@ private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
 }
 
 @Composable
-private fun ChargingTimelineRow(record: ChargingRecordEntity) {
+private fun ChargingTimelineRow(
+    record: ChargingRecordEntity,
+    onEdit: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(onClick = onEdit)
             .padding(vertical = MaterialTheme.spacing.sm),
         verticalAlignment = Alignment.Top
     ) {

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -26,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.viewmodel.MainUiState
@@ -49,7 +49,7 @@ fun EnergyCockpitCard(
             modifier = Modifier
                 .background(surfaceBrush)
                 .padding(horizontal = 14.dp, vertical = 13.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -95,7 +95,8 @@ fun EnergyCockpitCard(
                     Text(
                         "${state.chargingCount} 次充电",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = EVDesignTokens.Energy.green
+                        color = EVDesignTokens.Energy.green,
+                        maxLines = 1
                     )
                     Icon(
                         Icons.Default.ChevronRight,
@@ -115,7 +116,7 @@ fun EnergyCockpitCard(
                     value = one(state.monthEnergy),
                     unit = "kWh",
                     highlightUnit = true,
-                    modifier = Modifier.weight(1.18f)
+                    modifier = Modifier.weight(1.15f)
                 )
                 EnergyDivider()
                 EnergyMetric(
@@ -123,20 +124,19 @@ fun EnergyCockpitCard(
                     value = "¥ ${two(state.monthCost)}",
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 12.dp)
+                        .padding(horizontal = 10.dp)
                 )
                 EnergyDivider()
                 EnergyMetric(
                     label = "平均电价",
                     value = "¥ ${two(state.averagePrice)}",
                     unit = "/kWh",
+                    compact = true,
                     modifier = Modifier
-                        .weight(1f)
-                        .padding(start = 12.dp)
+                        .weight(1.08f)
+                        .padding(start = 10.dp)
                 )
             }
-
-            MonthlyEnergyProgress(state.monthEnergy)
         }
     }
 }
@@ -147,28 +147,34 @@ private fun EnergyMetric(
     value: String,
     unit: String? = null,
     highlightUnit: Boolean = false,
+    compact: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
         Text(
             label,
             style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1
         )
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.size(4.dp))
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
                 value,
-                style = MaterialTheme.typography.titleLarge,
+                style = if (compact) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Clip
             )
             if (unit != null) {
                 Spacer(Modifier.size(3.dp))
                 Text(
                     unit,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (highlightUnit) EVDesignTokens.Energy.green else MaterialTheme.colorScheme.onSurfaceVariant
+                    style = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodyMedium,
+                    color = if (highlightUnit) EVDesignTokens.Energy.green else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Clip
                 )
             }
         }
@@ -182,28 +188,6 @@ private fun EnergyDivider() {
             .size(width = 1.dp, height = 52.dp)
             .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
     )
-}
-
-@Composable
-private fun MonthlyEnergyProgress(monthEnergy: Double) {
-    val normalized = (monthEnergy / 100.0).toFloat().coerceIn(0f, 1f)
-    val visibleProgress = if (normalized <= 0f) 0.012f else normalized.coerceAtLeast(0.03f)
-
-    Box(
-        Modifier
-            .fillMaxWidth()
-            .height(5.dp)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.22f))
-    ) {
-        Box(
-            Modifier
-                .fillMaxWidth(visibleProgress)
-                .height(5.dp)
-                .clip(CircleShape)
-                .background(EVDesignTokens.Energy.green)
-        )
-    }
 }
 
 private fun one(value: Double) = String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -60,10 +60,12 @@ fun HeroVehicleCard(
     currentMileageKm: Double? = null,
     latestTrip: TripSessionEntity? = null,
     vehicles: List<VehicleEntity> = emptyList(),
+    vehicleSwitchEnabled: Boolean = true,
     onSelectVehicle: (Long) -> Unit = {}
 ) {
     val cockpit = LocalCockpitColors.current
     val selectableVehicles = if (vehicles.isNotEmpty()) vehicles else listOfNotNull(vehicle)
+    val canSwitchVehicle = vehicleSwitchEnabled && selectableVehicles.size > 1
     var vehicleMenuExpanded by remember { mutableStateOf(false) }
 
     Surface(
@@ -131,21 +133,21 @@ fun HeroVehicleCard(
                                 .clip(CircleShape)
                                 .background(Color(0x8F07110F))
                                 .border(1.dp, Color.White.copy(alpha = 0.12f), CircleShape)
-                                .clickable(enabled = selectableVehicles.isNotEmpty()) {
+                                .clickable(enabled = canSwitchVehicle) {
                                     vehicleMenuExpanded = true
                                 },
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
                                 imageVector = Icons.Default.DirectionsCar,
-                                contentDescription = "切换车辆",
-                                tint = Color.White,
+                                contentDescription = if (vehicleSwitchEnabled) "切换车辆" else "行程进行中不可切换车辆",
+                                tint = Color.White.copy(alpha = if (vehicleSwitchEnabled) 1f else 0.45f),
                                 modifier = Modifier.size(23.dp)
                             )
                         }
 
                         DropdownMenu(
-                            expanded = vehicleMenuExpanded,
+                            expanded = vehicleMenuExpanded && canSwitchVehicle,
                             onDismissRequest = { vehicleMenuExpanded = false }
                         ) {
                             selectableVehicles.forEach { candidate ->

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -144,7 +144,11 @@ fun TripReadyScreen(
         AlertDialog(
             onDismissRequest = { deleteTarget = null },
             title = { Text("删除这条行程？") },
-            text = { Text("行程及关联轨迹点会一并删除，删除后无法恢复。") },
+            text = {
+                Text(
+                    "行程及关联轨迹点会一并删除，删除后无法恢复。若这条行程提供了最新 SOC 或里程，车辆当前状态会根据剩余记录重新计算。"
+                )
+            },
             confirmButton = {
                 TextButton(
                     onClick = {


### PR DESCRIPTION
## Summary

Follow-up to the latest Dashboard/device acceptance pass. This PR closes interaction gaps and removes misleading visual data.

### Dashboard / Hero
- disable vehicle switching while a trip is active, so the visible current vehicle cannot diverge from the vehicle that owns the live trip;
- keep the vehicle switch icon visible but disabled/dimmed during an active trip;
- tapping the latest-trip body opens that exact trip detail; `查看全部` still opens the full trip list;
- compact the five latest-trip metrics to avoid unit/label truncation on narrower screens and larger font scales.

### Charging interactions
- make Dashboard recent charging rows tappable and open the existing record edit screen;
- add a real `查看全部` action for recent charging;
- keep the `+` action dedicated to creating a new charging record.

### Monthly energy
- remove the previous `monthEnergy / 100` progress bar because 100 kWh was not a real target or baseline;
- keep only factual monthly energy/cost/average-price metrics;
- force average price and `/kWh` to remain single-line with a compact typography treatment.

### Trip deletion guardrail
- deletion confirmation now explains that deleting the latest SOC/odometer-bearing trip can cause the vehicle current SOC/mileage to be recalculated from the remaining records.

## Acceptance
- active trip => vehicle switch cannot be opened;
- Dashboard latest trip body => exact trip detail;
- Dashboard latest trip `查看全部` => trip list;
- Dashboard recent charging row => record edit;
- Dashboard recent charging `查看全部` => records tab;
- monthly energy shows no fake progress percentage;
- average price does not split `/kWh` across lines;
- trip deletion retains explicit destructive confirmation and explains state recalculation;
- Android CI green.