### PR TITLE
ci: speed up Android release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Resolve checked-out commit
         id: source
@@ -71,14 +71,33 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Install Android SDK packages
-        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+      # GitHub-hosted Ubuntu runners already ship with the Android SDK.
+      # Avoid setup-android here because its defaults reinstall command-line tools,
+      # legacy SDK tools and emulator components that this APK build does not use.
+      - name: Ensure required Android SDK packages
+        shell: bash
+        run: |
+          set -eu
+          test -n "${ANDROID_HOME:-}"
+          if command -v sdkmanager >/dev/null 2>&1; then
+            SDKMANAGER="$(command -v sdkmanager)"
+          elif [ -x "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" ]; then
+            SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          else
+            echo "sdkmanager is unavailable on this runner"
+            exit 1
+          fi
+          yes | "$SDKMANAGER" "platforms;android-36" "build-tools;36.0.0" >/dev/null || true
+          test -d "$ANDROID_HOME/platforms/android-36"
+          test -x "$ANDROID_HOME/build-tools/36.0.0/apksigner"
 
       - name: Setup Gradle cache
         uses: gradle/actions/setup-gradle@v4
+        with:
+          # The default on-success cleanup launches another Gradle process after
+          # the release is already published. Keep the restored dependency cache
+          # but skip that release-only post-job cleanup overhead.
+          cache-cleanup: never
 
       - name: Restore signing keystore
         shell: bash
@@ -97,9 +116,8 @@ jobs:
           set -eu
           printf 'sdk.dir=%s\n' "$ANDROID_HOME" > local.properties
           chmod +x gradlew
-          ./gradlew --no-daemon :app:assembleRelease
-          BUILD_TOOLS_VERSION="$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -V | tail -1)"
-          "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner" verify --print-certs app/build/outputs/apk/release/app-release.apk
+          ./gradlew --no-daemon --build-cache :app:assembleRelease
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --print-certs app/build/outputs/apk/release/app-release.apk
 
       - name: Prepare atomic upload
         shell: bash


### PR DESCRIPTION
## Summary

Reduce avoidable overhead in the production Android release workflow without changing signing, artifact retention, or atomic deployment behavior.

### Changes
- use shallow checkout (`fetch-depth: 1`)
- reuse the Android SDK already present on GitHub-hosted Ubuntu runners instead of running `android-actions/setup-android`, which was reinstalling command-line/legacy tools and emulator components
- install/check only `platforms;android-36` and `build-tools;36.0.0`
- keep Gradle cache restore but disable the default post-job cache cleanup (`cache-cleanup: never`)
- enable Gradle build cache for the release build with `--build-cache`
- use the exact required build-tools version for APK signature verification

## Why

Release run 33139006582 took about 3m16s. The largest avoidable overheads were roughly:
- ~28s Android SDK setup/downloading unused packages
- ~15s Gradle post-job cache cleanup
- a few seconds from full-history checkout

The ~48s remote SCP upload remains unchanged in this PR because replacing it would require changing SSH key/host verification handling. That can be optimized separately after this low-risk pass is measured.

## Expected impact

A typical release should save roughly 35–45 seconds before considering any Gradle build-cache hits. The deployment safety model and release artifact format remain unchanged.