### PR TITLE
fix(hero): publish artwork through existing public release routes

### DIFF
--- a/.github/workflows/hero-assets-publish.yml
+++ b/.github/workflows/hero-assets-publish.yml
@@ -56,7 +56,7 @@ jobs:
               version = item.get('version')
               url = item.get('url', '')
               assert isinstance(version, int) and version > 0, f'{key}: invalid version'
-              assert url.startswith('https://groupim.cn/ev-charge-book/hero-assets/remote/'), f'{key}: invalid URL'
+              assert url.startswith('https://groupim.cn/ev-charge-book/releases/hero-assets/'), f'{key}: invalid URL'
               filename = url.rsplit('/', 1)[-1]
               assert (root / 'remote' / filename).is_file(), f'{key}: missing {filename}'
           PY
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare remote directory
+      - name: Prepare remote directories
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.COMMON_SERVER_HOST }}
@@ -81,7 +81,11 @@ jobs:
           script: |
             set -eu
             mkdir -p /opt/ev-charge-book/hero-assets/remote
+            mkdir -p /opt/ev-charge-book/releases/hero-assets
+            mkdir -p /opt/ev-charge-book/release-meta
             test -w /opt/ev-charge-book/hero-assets
+            test -w /opt/ev-charge-book/releases
+            test -w /opt/ev-charge-book/release-meta
 
       - name: Upload Hero assets
         uses: appleboy/scp-action@v1.0.0
@@ -93,20 +97,57 @@ jobs:
           target: /opt/ev-charge-book
           overwrite: true
 
-      - name: Verify public manifest
+      - name: Activate Hero assets atomically
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.COMMON_SERVER_HOST }}
+          username: ${{ secrets.COMMON_SERVER_USER }}
+          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
+          script: |
+            set -eu
+            SOURCE=/opt/ev-charge-book/hero-assets
+            PUBLIC_IMAGES=/opt/ev-charge-book/releases/hero-assets
+            PUBLIC_MANIFEST=/opt/ev-charge-book/release-meta/hero-assets-v1.json
+
+            test -s "$SOURCE/manifest-v1.json"
+            find "$SOURCE/remote" -maxdepth 1 -type f -name '*.webp' -exec cp -f {} "$PUBLIC_IMAGES/" \;
+            cp "$SOURCE/manifest-v1.json" "$PUBLIC_MANIFEST.tmp"
+            mv "$PUBLIC_MANIFEST.tmp" "$PUBLIC_MANIFEST"
+
+      - name: Verify public Hero delivery
         shell: bash
         run: |
           set -eu
+          MANIFEST_URL=https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json
           for attempt in 1 2 3 4 5; do
             if curl --fail --silent --show-error \
               --connect-timeout 5 \
               --max-time 15 \
-              https://groupim.cn/ev-charge-book/hero-assets/manifest-v1.json \
-              -o /tmp/hero-manifest.json; then
-              python3 -m json.tool /tmp/hero-manifest.json >/dev/null
-              exit 0
+              "$MANIFEST_URL" \
+              -o /tmp/hero-manifest.json && \
+              python3 -m json.tool /tmp/hero-manifest.json >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "Hero manifest is not publicly reachable after upload"
+              exit 1
             fi
             sleep 3
           done
-          echo "Hero manifest is not publicly reachable after upload"
-          exit 1
+
+          python3 - <<'PY' > /tmp/hero-urls.txt
+          import json
+          data = json.load(open('/tmp/hero-manifest.json'))
+          for item in data['artworks'].values():
+              print(item['url'])
+          PY
+
+          while IFS= read -r url; do
+            curl --fail --silent --show-error \
+              --connect-timeout 5 \
+              --max-time 30 \
+              --range 0-31 \
+              "$url" \
+              -o /tmp/hero-probe.bin
+            test -s /tmp/hero-probe.bin
+          done < /tmp/hero-urls.txt

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,7 @@ val hasReleaseSigning = listOf(
 val updateManifestUrl = System.getenv("APP_UPDATE_MANIFEST_URL")
     ?: "https://groupim.cn/ev-charge-book/release-meta/latest.json"
 val heroArtworkManifestUrl = System.getenv("HERO_ARTWORK_MANIFEST_URL")
-    ?: "https://groupim.cn/ev-charge-book/hero-assets/manifest-v1.json"
+    ?: "https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
 
 android {
     namespace = "com.evchargebook"

--- a/docs/HERO_ASSET_DELIVERY_v0.5.md
+++ b/docs/HERO_ASSET_DELIVERY_v0.5.md
@@ -21,10 +21,16 @@ The app always has a local fallback. A first successful network load is cached o
 Default endpoint:
 
 ```text
-https://groupim.cn/ev-charge-book/hero-assets/manifest-v1.json
+https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json
 ```
 
 The endpoint can be overridden at build time with `HERO_ARTWORK_MANIFEST_URL`.
+
+The public path deliberately reuses the same `release-meta` route already used by the Android updater. Hero binaries reuse the existing public `releases` route:
+
+```text
+https://groupim.cn/ev-charge-book/releases/hero-assets/<file>.webp
+```
 
 Each artwork entry has a stable key, version, and HTTPS URL. Increment the version whenever the remote visual changes so the app gets a new Coil cache key without deleting the old cache globally.
 
@@ -66,6 +72,15 @@ No screen should block waiting for artwork.
 
 `.github/workflows/hero-assets-publish.yml` publishes `hero-assets/**` independently of an APK release. A Hero image can therefore be replaced without rebuilding or releasing the Android app.
 
+The workflow first uploads the repository asset package, then activates it into the public directories already used by releases:
+
+```text
+/opt/ev-charge-book/release-meta/hero-assets-v1.json
+/opt/ev-charge-book/releases/hero-assets/*.webp
+```
+
+The manifest is copied last so clients never discover URLs before the corresponding images are present.
+
 The workflow validates:
 
 - manifest schema version
@@ -73,6 +88,7 @@ The workflow validates:
 - manifest/file consistency
 - remote WebP hard ceiling of 2.5 MB per file
 - public manifest reachability after upload
+- every manifest image URL is publicly readable
 
 ## Local APK budget
 

--- a/hero-assets/manifest-v1.json
+++ b/hero-assets/manifest-v1.json
@@ -3,27 +3,27 @@
   "artworks": {
     "byd-seal-2025": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/byd_seal_2025.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/byd_seal_2025.webp"
     },
     "leapmotor-c16-2026": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/leapmotor_c16_2026.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/leapmotor_c16_2026.webp"
     },
     "tesla-model-3": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/tesla_model_3.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/tesla_model_3.webp"
     },
     "xiaomi-su7-2024": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/xiaomi_su7_2024.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_su7_2024.webp"
     },
     "xiaomi-su7-ultra-2024": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/xiaomi_su7_ultra_2024.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_su7_ultra_2024.webp"
     },
     "xiaomi-yu7-2025": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/hero-assets/remote/xiaomi_yu7_2025.webp"
+      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_yu7_2025.webp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow up #112 after the first production Hero upload exposed a serving-path mismatch.

## Observed production failure

The #112 upload itself succeeded, but verification of `https://groupim.cn/ev-charge-book/hero-assets/manifest-v1.json` returned a non-JSON response. The server already exposes the Android updater through `release-meta` and APKs through `releases`, so this change deliberately reuses those known public routes instead of requiring a new nginx location.

## Fix

- Hero manifest public URL becomes `https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json`
- Hero image URLs become `https://groupim.cn/ev-charge-book/releases/hero-assets/*.webp`
- publish job uploads the source package, copies images into `/opt/ev-charge-book/releases/hero-assets`, and activates the manifest into `/opt/ev-charge-book/release-meta` last
- production verification parses the public manifest and probes every image URL
- Android `HERO_ARTWORK_MANIFEST_URL` default follows the corrected route
- docs updated to record the route contract

No APK asset regression, schema change, or charging/trip business change.