### PR TITLE
fix(hero): use GitHub Raw as reliable remote artwork source

### DIFF
--- a/.github/workflows/hero-assets-publish.yml
+++ b/.github/workflows/hero-assets-publish.yml
@@ -1,4 +1,4 @@
-name: Hero Assets Publish
+name: Hero Assets Validate
 
 on:
   pull_request:
@@ -52,102 +52,14 @@ jobs:
           artworks = manifest.get('artworks') or {}
           assert artworks, 'manifest artworks must not be empty'
 
+          prefix = 'https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/'
           for key, item in artworks.items():
               version = item.get('version')
               url = item.get('url', '')
               assert isinstance(version, int) and version > 0, f'{key}: invalid version'
-              assert url.startswith('https://groupim.cn/ev-charge-book/releases/hero-assets/'), f'{key}: invalid URL'
+              assert url.startswith(prefix), f'{key}: invalid URL'
               filename = url.rsplit('/', 1)[-1]
-              assert (root / 'remote' / filename).is_file(), f'{key}: missing {filename}'
+              path = root / 'remote' / filename
+              assert path.is_file(), f'{key}: missing {filename}'
+              assert path.stat().st_size > 0, f'{key}: empty {filename}'
           PY
-
-  publish:
-    name: Publish Hero artwork
-    if: github.event_name != 'pull_request'
-    needs: validate
-    runs-on: ubuntu-latest
-    environment: production
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Prepare remote directories
-        uses: appleboy/ssh-action@v1.2.2
-        with:
-          host: ${{ secrets.COMMON_SERVER_HOST }}
-          username: ${{ secrets.COMMON_SERVER_USER }}
-          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
-          script: |
-            set -eu
-            mkdir -p /opt/ev-charge-book/hero-assets/remote
-            mkdir -p /opt/ev-charge-book/releases/hero-assets
-            mkdir -p /opt/ev-charge-book/release-meta
-            test -w /opt/ev-charge-book/hero-assets
-            test -w /opt/ev-charge-book/releases
-            test -w /opt/ev-charge-book/release-meta
-
-      - name: Upload Hero assets
-        uses: appleboy/scp-action@v1.0.0
-        with:
-          host: ${{ secrets.COMMON_SERVER_HOST }}
-          username: ${{ secrets.COMMON_SERVER_USER }}
-          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
-          source: hero-assets
-          target: /opt/ev-charge-book
-          overwrite: true
-
-      - name: Activate Hero assets atomically
-        uses: appleboy/ssh-action@v1.2.2
-        with:
-          host: ${{ secrets.COMMON_SERVER_HOST }}
-          username: ${{ secrets.COMMON_SERVER_USER }}
-          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
-          script: |
-            set -eu
-            SOURCE=/opt/ev-charge-book/hero-assets
-            PUBLIC_IMAGES=/opt/ev-charge-book/releases/hero-assets
-            PUBLIC_MANIFEST=/opt/ev-charge-book/release-meta/hero-assets-v1.json
-
-            test -s "$SOURCE/manifest-v1.json"
-            find "$SOURCE/remote" -maxdepth 1 -type f -name '*.webp' -exec cp -f {} "$PUBLIC_IMAGES/" \;
-            cp "$SOURCE/manifest-v1.json" "$PUBLIC_MANIFEST.tmp"
-            mv "$PUBLIC_MANIFEST.tmp" "$PUBLIC_MANIFEST"
-
-      - name: Verify public Hero delivery
-        shell: bash
-        run: |
-          set -eu
-          MANIFEST_URL=https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json
-          for attempt in 1 2 3 4 5; do
-            if curl --fail --silent --show-error \
-              --connect-timeout 5 \
-              --max-time 15 \
-              "$MANIFEST_URL" \
-              -o /tmp/hero-manifest.json && \
-              python3 -m json.tool /tmp/hero-manifest.json >/dev/null; then
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "Hero manifest is not publicly reachable after upload"
-              exit 1
-            fi
-            sleep 3
-          done
-
-          python3 - <<'PY' > /tmp/hero-urls.txt
-          import json
-          data = json.load(open('/tmp/hero-manifest.json'))
-          for item in data['artworks'].values():
-              print(item['url'])
-          PY
-
-          while IFS= read -r url; do
-            curl --fail --silent --show-error \
-              --connect-timeout 5 \
-              --max-time 30 \
-              --range 0-31 \
-              "$url" \
-              -o /tmp/hero-probe.bin
-            test -s /tmp/hero-probe.bin
-          done < /tmp/hero-urls.txt

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,7 @@ val hasReleaseSigning = listOf(
 val updateManifestUrl = System.getenv("APP_UPDATE_MANIFEST_URL")
     ?: "https://groupim.cn/ev-charge-book/release-meta/latest.json"
 val heroArtworkManifestUrl = System.getenv("HERO_ARTWORK_MANIFEST_URL")
-    ?: "https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
+    ?: "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/manifest-v1.json"
 
 android {
     namespace = "com.evchargebook"

--- a/docs/HERO_ASSET_DELIVERY_v0.5.md
+++ b/docs/HERO_ASSET_DELIVERY_v0.5.md
@@ -21,16 +21,10 @@ The app always has a local fallback. A first successful network load is cached o
 Default endpoint:
 
 ```text
-https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json
+https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/manifest-v1.json
 ```
 
-The endpoint can be overridden at build time with `HERO_ARTWORK_MANIFEST_URL`.
-
-The public path deliberately reuses the same `release-meta` route already used by the Android updater. Hero binaries reuse the existing public `releases` route:
-
-```text
-https://groupim.cn/ev-charge-book/releases/hero-assets/<file>.webp
-```
+The endpoint can be overridden at build time with `HERO_ARTWORK_MANIFEST_URL`, so a CDN or first-party object store can replace GitHub Raw later without changing the runtime architecture.
 
 Each artwork entry has a stable key, version, and HTTPS URL. Increment the version whenever the remote visual changes so the app gets a new Coil cache key without deleting the old cache globally.
 
@@ -48,7 +42,7 @@ hero-assets/
     xiaomi_yu7_2025.webp
 ```
 
-Files under `hero-assets/remote` are repository/deployment assets only. They are outside `android/app/src/main/res`, so Gradle does not package them into the APK.
+Files under `hero-assets/remote` are network-delivery assets only. They are outside `android/app/src/main/res`, so Gradle does not package them into the APK.
 
 ## APK size effect
 
@@ -59,49 +53,47 @@ The packaged fallback is the existing Compose vehicle icon/gradient and therefor
 ## Caching and offline behavior
 
 1. Resolve the selected vehicle to a stable Hero key.
-2. Read the versioned manifest from the public endpoint.
+2. Read the versioned manifest from GitHub Raw (or a build-time override).
 3. Persist the last valid manifest in app preferences.
 4. Load the resolved artwork with Coil.
 5. Enable Coil memory cache and disk cache with a key containing `vehicleKey + version`.
-6. If the manifest is unavailable, try the repository raw URL as a secondary source.
+6. If the manifest is unavailable, use the catalog's direct GitHub Raw URL for the known vehicle.
 7. If no network/cached image is available, keep the lightweight Compose fallback visible.
 
-No screen should block waiting for artwork.
+No screen blocks waiting for artwork.
 
-## Publishing
+## Updating Hero artwork
 
-`.github/workflows/hero-assets-publish.yml` publishes `hero-assets/**` independently of an APK release. A Hero image can therefore be replaced without rebuilding or releasing the Android app.
+A Hero image can change without rebuilding or releasing the APK:
 
-The workflow first uploads the repository asset package, then activates it into the public directories already used by releases:
+1. replace the matching file under `hero-assets/remote/`;
+2. increment that artwork's `version` in `manifest-v1.json`;
+3. merge the asset change to `main`.
 
-```text
-/opt/ev-charge-book/release-meta/hero-assets-v1.json
-/opt/ev-charge-book/releases/hero-assets/*.webp
-```
+GitHub Raw then serves the new file and the version change creates a fresh Coil disk-cache key on the next manifest refresh.
 
-The manifest is copied last so clients never discover URLs before the corresponding images are present.
+`.github/workflows/hero-assets-publish.yml` is intentionally validation-only. It checks:
 
-The workflow validates:
+- manifest schema version;
+- HTTPS GitHub Raw URLs;
+- manifest/file consistency;
+- non-empty artwork files;
+- remote WebP hard ceiling of 2.5 MB per file.
 
-- manifest schema version
-- HTTPS production URLs
-- manifest/file consistency
-- remote WebP hard ceiling of 2.5 MB per file
-- public manifest reachability after upload
-- every manifest image URL is publicly readable
+A previous first-party-server publishing experiment was not retained because the current public web routing does not expose arbitrary Hero asset paths reliably. The runtime remains ready for a future CDN through `HERO_ARTWORK_MANIFEST_URL`.
 
 ## Local APK budget
 
 Android CI rejects WebP files larger than 350 KB under `android/app/src/main/res/drawable-nodpi`.
 
-Use remote Hero assets for large photographic artwork. Keep only small icons or intentional lightweight fallback assets in APK resources.
+Use remote Hero assets for photographic artwork. Keep only small icons or intentional lightweight fallback assets in APK resources.
 
 ## Recommended future artwork target
 
 Remote artwork should normally be optimized to:
 
-- 1200x900 or 1440x1080
-- WebP lossy
-- roughly 100-350 KB when visual quality allows
+- 1200x900 or 1440x1080;
+- WebP lossy;
+- roughly 100-350 KB when visual quality allows.
 
 The 2.5 MB workflow limit is a safety ceiling, not the target size.

--- a/hero-assets/manifest-v1.json
+++ b/hero-assets/manifest-v1.json
@@ -3,27 +3,27 @@
   "artworks": {
     "byd-seal-2025": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/byd_seal_2025.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/byd_seal_2025.webp"
     },
     "leapmotor-c16-2026": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/leapmotor_c16_2026.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/leapmotor_c16_2026.webp"
     },
     "tesla-model-3": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/tesla_model_3.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/tesla_model_3.webp"
     },
     "xiaomi-su7-2024": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_su7_2024.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/xiaomi_su7_2024.webp"
     },
     "xiaomi-su7-ultra-2024": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_su7_ultra_2024.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/xiaomi_su7_ultra_2024.webp"
     },
     "xiaomi-yu7-2025": {
       "version": 1,
-      "url": "https://groupim.cn/ev-charge-book/releases/hero-assets/xiaomi_yu7_2025.webp"
+      "url": "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/remote/xiaomi_yu7_2025.webp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Make the remote-Hero architecture reliable immediately by using the public GitHub Raw files already committed under `hero-assets/remote`.

## Why

The two first-party deployment attempts successfully copied files to the server, but the current `groupim.cn/ev-charge-book/*` web routing returned non-JSON content for the new Hero manifest paths. The Android updater route is specialized and is not a safe assumption for arbitrary new static asset paths.

## Fix

- default Hero manifest -> GitHub Raw `main/hero-assets/manifest-v1.json`
- every manifest image URL -> GitHub Raw `main/hero-assets/remote/*.webp`
- keep `HERO_ARTWORK_MANIFEST_URL` override so a CDN/first-party object store can be introduced later without changing app code
- turn the Hero workflow into validation-only instead of publishing to a server route that is not publicly exposed
- keep the 2.5 MB remote safety ceiling and the 350 KB packaged-resource CI guard
- update docs with the new asset-update flow: replace file + bump version + merge, no APK release required

## Runtime behavior

Compose fallback renders immediately -> manifest resolves -> Coil loads high-quality network artwork -> Coil memory/disk cache serves subsequent views/offline reuse.

The six ~1.6-2.0 MB Hero files remain outside Android resources, so the APK size saving from #112 is preserved.