### PR TITLE
ops(hero): automate Hero Admin production deployment

### DIFF
--- a/.github/workflows/hero-admin-deploy.yml
+++ b/.github/workflows/hero-admin-deploy.yml
@@ -1,0 +1,148 @@
+name: Hero Admin Deploy
+
+on:
+  pull_request:
+    paths:
+      - 'hero-admin/**'
+      - 'hero-assets/manifest-v1.json'
+      - 'scripts/deploy-hero-admin.sh'
+      - '.github/workflows/hero-admin-deploy.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'hero-admin/**'
+      - 'hero-assets/manifest-v1.json'
+      - 'scripts/deploy-hero-admin.sh'
+      - '.github/workflows/hero-admin-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ev-charge-book-hero-admin-production
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate Hero Admin deployment bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate deploy script
+        shell: bash
+        run: |
+          set -eu
+          bash -n scripts/deploy-hero-admin.sh
+          test -f hero-admin/Dockerfile
+          test -f hero-admin/app.py
+          test -f hero-assets/manifest-v1.json
+
+      - name: Build Hero Admin image
+        run: docker build -t ev-charge-book-hero-admin:deploy-check hero-admin
+
+  deploy:
+    name: Deploy Hero Admin to groupim.cn
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare remote staging directory
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.COMMON_SERVER_HOST }}
+          username: ${{ secrets.COMMON_SERVER_USER }}
+          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
+          script: |
+            set -eu
+            rm -rf /opt/ev-charge-book/hero-admin-deploy
+            mkdir -p /opt/ev-charge-book/hero-admin-deploy
+            test -w /opt/ev-charge-book
+
+      - name: Upload Hero Admin deployment bundle
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ secrets.COMMON_SERVER_HOST }}
+          username: ${{ secrets.COMMON_SERVER_USER }}
+          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
+          source: hero-admin,hero-assets/manifest-v1.json,scripts/deploy-hero-admin.sh
+          target: /opt/ev-charge-book/hero-admin-deploy
+          overwrite: true
+
+      - name: Deploy service and Nginx routes
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.COMMON_SERVER_HOST }}
+          username: ${{ secrets.COMMON_SERVER_USER }}
+          key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
+          script: |
+            set -eu
+            chmod +x /opt/ev-charge-book/hero-admin-deploy/scripts/deploy-hero-admin.sh
+            /opt/ev-charge-book/hero-admin-deploy/scripts/deploy-hero-admin.sh
+
+      - name: Verify public Hero manifest
+        shell: bash
+        run: |
+          set -eu
+          tmp="$(mktemp)"
+          for attempt in 1 2 3 4 5; do
+            if curl --fail --silent --show-error \
+              --location \
+              --max-time 15 \
+              https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json \
+              -o "$tmp"; then
+              if python3 - "$tmp" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          manifest = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+          assert manifest.get('schemaVersion') == 1
+          artworks = manifest.get('artworks')
+          assert isinstance(artworks, dict) and artworks
+          PY
+              then
+                exit 0
+              fi
+            fi
+            sleep 2
+          done
+          echo "Public Hero manifest validation failed" >&2
+          exit 1
+
+      - name: Verify Hero Admin authentication gate
+        shell: bash
+        run: |
+          set -eu
+          for attempt in 1 2 3 4 5; do
+            status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              --max-time 15 \
+              https://groupim.cn/ev-charge-book/hero-admin/ || true)"
+            if [ "$status" = "401" ]; then
+              exit 0
+            fi
+            echo "Attempt $attempt: expected 401, got $status"
+            sleep 2
+          done
+          echo "Hero Admin is not protected by the expected authentication gate" >&2
+          exit 1
+
+      - name: Deployment summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Hero Admin deployment"
+            echo ""
+            echo "- Admin: https://groupim.cn/ev-charge-book/hero-admin/"
+            echo "- Manifest: https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
+            echo "- Server credentials file: /opt/ev-charge-book/hero-admin.env"
+            echo "- The password is never printed into Actions logs."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/deploy-hero-admin.sh
+++ b/scripts/deploy-hero-admin.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/opt/ev-charge-book"
+STAGING_ROOT="${ROOT}/hero-admin-deploy"
+APP_ROOT="/opt/app"
+NGINX_CONF="${APP_ROOT}/nginx.conf"
+NGINX_CONTAINER="nginx"
+NETWORK="app-network"
+IMAGE="ev-charge-book-hero-admin:local"
+CONTAINER="ev-charge-book-hero-admin"
+ENV_FILE="${ROOT}/hero-admin.env"
+MANIFEST="${ROOT}/release-meta/hero-assets-v1.json"
+SEED_MANIFEST="${STAGING_ROOT}/hero-assets/manifest-v1.json"
+HERO_SOURCE="${STAGING_ROOT}/hero-admin"
+
+log() {
+  printf '[hero-admin-deploy] %s\n' "$*"
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    echo "Required file missing: $1" >&2
+    exit 1
+  fi
+}
+
+require_file "${HERO_SOURCE}/Dockerfile"
+require_file "${HERO_SOURCE}/app.py"
+require_file "${SEED_MANIFEST}"
+require_file "${NGINX_CONF}"
+
+mkdir -p "${ROOT}/releases/hero-assets" "${ROOT}/release-meta"
+chmod 755 "${ROOT}/releases" "${ROOT}/releases/hero-assets" "${ROOT}/release-meta"
+
+if [ ! -f "${ENV_FILE}" ]; then
+  log "Creating first-run Hero Admin credentials"
+  umask 077
+  password="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+  cat > "${ENV_FILE}" <<EOF
+HERO_ADMIN_USER=admin
+HERO_ADMIN_PASSWORD=${password}
+HERO_PUBLIC_ORIGIN=https://groupim.cn
+HERO_PUBLIC_ASSET_BASE=https://groupim.cn/ev-charge-book/releases/hero-assets
+EOF
+fi
+chmod 600 "${ENV_FILE}"
+
+if [ ! -f "${MANIFEST}" ]; then
+  log "Seeding runtime Hero manifest"
+  cp "${SEED_MANIFEST}" "${MANIFEST}"
+  chmod 644 "${MANIFEST}"
+fi
+
+log "Building Hero Admin image"
+docker build --pull -t "${IMAGE}" "${HERO_SOURCE}"
+
+log "Starting Hero Admin container"
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER}" \
+  --restart unless-stopped \
+  --network "${NETWORK}" \
+  --env-file "${ENV_FILE}" \
+  -v "${ROOT}/releases:/data/releases" \
+  -v "${ROOT}/release-meta:/data/release-meta" \
+  "${IMAGE}" >/dev/null
+
+healthy=0
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  if docker exec "${CONTAINER}" python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).read()" >/dev/null 2>&1; then
+    healthy=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "${healthy}" -ne 1 ]; then
+  docker logs "${CONTAINER}" || true
+  echo "Hero Admin container did not become healthy" >&2
+  exit 1
+fi
+
+HERO_MARKER="# BEGIN EV CHARGE BOOK HERO ADMIN"
+if ! grep -Fq "${HERO_MARKER}" "${NGINX_CONF}"; then
+  log "Installing Nginx Hero Admin routes"
+  backup="${NGINX_CONF}.hero-admin.$(date +%Y%m%d%H%M%S).bak"
+  cp "${NGINX_CONF}" "${backup}"
+
+  python3 - "${NGINX_CONF}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+
+if "# BEGIN EV CHARGE BOOK HERO ADMIN" in text:
+    raise SystemExit(0)
+
+markers = [
+    "        # =============================\n        # Frontend SPA",
+    "        location / {",
+]
+index = -1
+for marker in markers:
+    index = text.find(marker)
+    if index >= 0:
+        break
+
+if index < 0:
+    raise SystemExit("Could not locate Frontend SPA insertion point in nginx.conf")
+
+block = r'''        # BEGIN EV CHARGE BOOK HERO ADMIN
+        # Mutable runtime Hero manifest. Never cache this pointer as immutable.
+        location = /ev-charge-book/release-meta/hero-assets-v1.json {
+            alias /opt/ev-charge-book/release-meta/hero-assets-v1.json;
+            default_type application/json;
+
+            add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+            add_header Pragma "no-cache" always;
+            expires -1;
+        }
+
+        location = /ev-charge-book/hero-admin {
+            return 301 /ev-charge-book/hero-admin/;
+        }
+
+        location ^~ /ev-charge-book/hero-admin/ {
+            client_max_body_size 12m;
+
+            proxy_pass http://ev-charge-book-hero-admin:8080/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Authorization $http_authorization;
+
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+
+            add_header Cache-Control "no-store" always;
+        }
+        # END EV CHARGE BOOK HERO ADMIN
+
+'''
+
+path.write_text(text[:index] + block + text[index:], encoding="utf-8")
+PY
+
+  if ! docker exec "${NGINX_CONTAINER}" nginx -t; then
+    log "Nginx validation failed; restoring ${backup}"
+    cp "${backup}" "${NGINX_CONF}"
+    docker exec "${NGINX_CONTAINER}" nginx -t || true
+    exit 1
+  fi
+
+  docker exec "${NGINX_CONTAINER}" nginx -s reload
+else
+  log "Nginx Hero Admin routes already installed"
+  docker exec "${NGINX_CONTAINER}" nginx -t
+  docker exec "${NGINX_CONTAINER}" nginx -s reload
+fi
+
+log "Verifying local runtime manifest"
+python3 - "${MANIFEST}" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert manifest.get("schemaVersion") == 1
+artworks = manifest.get("artworks")
+assert isinstance(artworks, dict) and artworks
+PY
+
+log "Hero Admin deployment complete"
+log "Credentials are stored only in ${ENV_FILE}"


### PR DESCRIPTION
## Summary

Automate the one-time and future production deployment of Hero Admin using the same production SSH secrets already used by Android Release.

## Deployment behavior

- validates the deploy script and Hero Admin Docker build on PRs
- on merge to `main`, uploads `hero-admin/`, the seed manifest, and the deploy script to `/opt/ev-charge-book/hero-admin-deploy`
- creates `/opt/ev-charge-book/hero-admin.env` only on first deploy with a random admin password that is never printed in Actions logs
- seeds `/opt/ev-charge-book/release-meta/hero-assets-v1.json` only if it does not already exist
- builds and runs a standalone `ev-charge-book-hero-admin` container on the existing `app-network`
- mounts existing `/opt/ev-charge-book/releases` and `release-meta` directories
- patches the live `/opt/app/nginx.conf` only if the Hero Admin marker is absent
- backs up Nginx before modification, runs `nginx -t`, and restores the backup on validation failure
- reloads Nginx without touching Group-IM application containers
- verifies the public manifest is valid JSON and the admin URL returns `401` without credentials

## Why no docker-compose edit

The current production compose already provides the shared Docker network and Nginx container. Keeping Hero Admin as a standalone restartable container avoids coupling this EV Charge Book utility to Group-IM service lifecycle/configuration.

## Follow-up

After the public admin and manifest endpoints are verified, switch Android's default Hero manifest endpoint in a separate one-line PR.