### PR TITLE
fix(hero): deploy prebuilt Hero Admin image without server pulls

### DIFF
--- a/.github/workflows/hero-admin-deploy.yml
+++ b/.github/workflows/hero-admin-deploy.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: ev-charge-book-hero-admin-production
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -41,7 +41,7 @@ jobs:
           test -f hero-assets/manifest-v1.json
 
       - name: Build Hero Admin image
-        run: docker build -t ev-charge-book-hero-admin:deploy-check hero-admin
+        run: docker build -t ev-charge-book-hero-admin:local hero-admin
 
   deploy:
     name: Deploy Hero Admin to groupim.cn
@@ -53,6 +53,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Build portable Hero Admin image
+        shell: bash
+        run: |
+          set -eu
+          docker build -t ev-charge-book-hero-admin:local hero-admin
+          docker save ev-charge-book-hero-admin:local | gzip -1 > hero-admin-image.tar.gz
+          gzip -t hero-admin-image.tar.gz
+          ls -lh hero-admin-image.tar.gz
 
       - name: Prepare remote staging directory
         uses: appleboy/ssh-action@v1.2.2
@@ -72,7 +81,7 @@ jobs:
           host: ${{ secrets.COMMON_SERVER_HOST }}
           username: ${{ secrets.COMMON_SERVER_USER }}
           key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
-          source: hero-admin,hero-assets/manifest-v1.json,scripts/deploy-hero-admin.sh
+          source: hero-admin-image.tar.gz,hero-assets/manifest-v1.json,scripts/deploy-hero-admin.sh
           target: /opt/ev-charge-book/hero-admin-deploy
           overwrite: true
 
@@ -144,5 +153,6 @@ jobs:
             echo "- Admin: https://groupim.cn/ev-charge-book/hero-admin/"
             echo "- Manifest: https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
             echo "- Server credentials file: /opt/ev-charge-book/hero-admin.env"
+            echo "- Server-side Docker/PyPI network access is not required for deployment."
             echo "- The password is never printed into Actions logs."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/deploy-hero-admin.sh
+++ b/scripts/deploy-hero-admin.sh
@@ -6,13 +6,13 @@ STAGING_ROOT="${ROOT}/hero-admin-deploy"
 APP_ROOT="/opt/app"
 NGINX_CONF="${APP_ROOT}/nginx.conf"
 NGINX_CONTAINER="nginx"
-NETWORK="app-network"
+NETWORK="${HERO_ADMIN_DOCKER_NETWORK:-app_gateway}"
 IMAGE="ev-charge-book-hero-admin:local"
+IMAGE_ARCHIVE="${STAGING_ROOT}/hero-admin-image.tar.gz"
 CONTAINER="ev-charge-book-hero-admin"
 ENV_FILE="${ROOT}/hero-admin.env"
 MANIFEST="${ROOT}/release-meta/hero-assets-v1.json"
 SEED_MANIFEST="${STAGING_ROOT}/hero-assets/manifest-v1.json"
-HERO_SOURCE="${STAGING_ROOT}/hero-admin"
 
 log() {
   printf '[hero-admin-deploy] %s\n' "$*"
@@ -25,10 +25,11 @@ require_file() {
   fi
 }
 
-require_file "${HERO_SOURCE}/Dockerfile"
-require_file "${HERO_SOURCE}/app.py"
+require_file "${IMAGE_ARCHIVE}"
 require_file "${SEED_MANIFEST}"
 require_file "${NGINX_CONF}"
+
+docker network inspect "${NETWORK}" >/dev/null
 
 mkdir -p "${ROOT}/releases/hero-assets" "${ROOT}/release-meta"
 chmod 755 "${ROOT}/releases" "${ROOT}/releases/hero-assets" "${ROOT}/release-meta"
@@ -52,10 +53,16 @@ if [ ! -f "${MANIFEST}" ]; then
   chmod 644 "${MANIFEST}"
 fi
 
-log "Building Hero Admin image"
-docker build --pull -t "${IMAGE}" "${HERO_SOURCE}"
+log "Loading prebuilt Hero Admin image"
+gzip -t "${IMAGE_ARCHIVE}"
+gzip -dc "${IMAGE_ARCHIVE}" | docker load >/dev/null
 
-log "Starting Hero Admin container"
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "Expected image tag was not loaded: ${IMAGE}" >&2
+  exit 1
+fi
+
+log "Starting Hero Admin container on ${NETWORK}"
 docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 docker run -d \
   --name "${CONTAINER}" \


### PR DESCRIPTION
## Summary

Make Hero Admin production deployment independent of Docker Hub/PyPI availability on the Aliyun server.

## Changes

- build the production Hero Admin image on the GitHub runner
- export it as `hero-admin-image.tar.gz` and SCP it with the deployment bundle
- server uses `docker load` instead of `docker build --pull`
- connect the standalone Hero Admin container to the production `app_gateway` network, which is explicitly named in the live compose configuration and already used by Nginx
- set deployment concurrency to `cancel-in-progress: true` so this corrected deployment supersedes a stuck older deployment

## Why

The first production deployment remained stuck inside the server-side build step. The application image already builds successfully on GitHub, so production should not depend on the server reaching Docker Hub or PyPI.