### PR TITLE
feat(hero): switch Android to first-party Hero manifest

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,7 @@ val hasReleaseSigning = listOf(
 val updateManifestUrl = System.getenv("APP_UPDATE_MANIFEST_URL")
     ?: "https://groupim.cn/ev-charge-book/release-meta/latest.json"
 val heroArtworkManifestUrl = System.getenv("HERO_ARTWORK_MANIFEST_URL")
-    ?: "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/manifest-v1.json"
+    ?: "https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
 
 android {
     namespace = "com.evchargebook"


### PR DESCRIPTION
## Summary

Switch the Android default Hero artwork manifest from GitHub Raw to the now-deployed first-party runtime manifest:

`https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json`

## Safety

The production Hero Admin deployment has already verified:

- the manifest endpoint returns valid schemaVersion 1 JSON
- the Hero Admin route is protected and returns 401 without credentials
- Nginx configuration validates and reloads successfully

This PR changes only the default manifest URL. Build-time `HERO_ARTWORK_MANIFEST_URL` override remains available.