### PR TITLE
feat(admin): manage vehicle catalog from Hero Admin

### DIFF
--- a/.github/workflows/hero-admin-deploy.yml
+++ b/.github/workflows/hero-admin-deploy.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'hero-admin/**'
       - 'hero-assets/manifest-v1.json'
+      - 'vehicle-catalog/**'
       - 'scripts/deploy-hero-admin.sh'
       - '.github/workflows/hero-admin-deploy.yml'
   push:
@@ -12,6 +13,7 @@ on:
     paths:
       - 'hero-admin/**'
       - 'hero-assets/manifest-v1.json'
+      - 'vehicle-catalog/**'
       - 'scripts/deploy-hero-admin.sh'
       - '.github/workflows/hero-admin-deploy.yml'
   workflow_dispatch:
@@ -25,13 +27,13 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate Hero Admin deployment bundle
+    name: Validate EV resource admin deployment bundle
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate deploy script
+      - name: Validate deploy script and seeds
         shell: bash
         run: |
           set -eu
@@ -39,12 +41,23 @@ jobs:
           test -f hero-admin/Dockerfile
           test -f hero-admin/app.py
           test -f hero-assets/manifest-v1.json
+          test -f vehicle-catalog/catalog-v1.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          hero = json.loads(Path('hero-assets/manifest-v1.json').read_text())
+          catalog = json.loads(Path('vehicle-catalog/catalog-v1.json').read_text())
+          assert hero.get('schemaVersion') == 1 and hero.get('artworks')
+          assert catalog.get('schemaVersion') == 1 and catalog.get('vehicles')
+          ids = [v['catalogId'] for v in catalog['vehicles']]
+          assert len(ids) == len(set(ids))
+          PY
 
-      - name: Build Hero Admin image
+      - name: Build admin image
         run: docker build -t ev-charge-book-hero-admin:local hero-admin
 
   deploy:
-    name: Deploy Hero Admin to groupim.cn
+    name: Deploy EV resource admin to groupim.cn
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: validate
     runs-on: ubuntu-latest
@@ -54,7 +67,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build portable Hero Admin image
+      - name: Build portable admin image
         shell: bash
         run: |
           set -eu
@@ -75,13 +88,13 @@ jobs:
             mkdir -p /opt/ev-charge-book/hero-admin-deploy
             test -w /opt/ev-charge-book
 
-      - name: Upload Hero Admin deployment bundle
+      - name: Upload admin deployment bundle
         uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.COMMON_SERVER_HOST }}
           username: ${{ secrets.COMMON_SERVER_USER }}
           key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
-          source: hero-admin-image.tar.gz,hero-assets/manifest-v1.json,scripts/deploy-hero-admin.sh
+          source: hero-admin-image.tar.gz,hero-assets/manifest-v1.json,vehicle-catalog/catalog-v1.json,scripts/deploy-hero-admin.sh
           target: /opt/ev-charge-book/hero-admin-deploy
           overwrite: true
 
@@ -96,43 +109,43 @@ jobs:
             chmod +x /opt/ev-charge-book/hero-admin-deploy/scripts/deploy-hero-admin.sh
             /opt/ev-charge-book/hero-admin-deploy/scripts/deploy-hero-admin.sh
 
-      - name: Verify public Hero manifest
+      - name: Verify public runtime metadata
         shell: bash
         run: |
           set -eu
-          tmp="$(mktemp)"
-          for attempt in 1 2 3 4 5; do
-            if curl --fail --silent --show-error \
-              --location \
-              --max-time 15 \
-              https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json \
-              -o "$tmp"; then
-              if python3 - "$tmp" <<'PY'
+          for path in hero-assets-v1.json vehicle-catalog-v1.json; do
+            tmp="$(mktemp)"
+            ok=0
+            for attempt in 1 2 3 4 5; do
+              if curl --fail --silent --show-error --location --max-time 15 \
+                "https://groupim.cn/ev-charge-book/release-meta/$path" -o "$tmp"; then
+                if python3 - "$tmp" "$path" <<'PY'
           import json
           import sys
           from pathlib import Path
-
-          manifest = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
-          assert manifest.get('schemaVersion') == 1
-          artworks = manifest.get('artworks')
-          assert isinstance(artworks, dict) and artworks
+          data = json.loads(Path(sys.argv[1]).read_text(encoding='utf-8'))
+          assert data.get('schemaVersion') == 1
+          if sys.argv[2] == 'hero-assets-v1.json':
+              assert isinstance(data.get('artworks'), dict) and data['artworks']
+          else:
+              assert isinstance(data.get('vehicles'), list) and data['vehicles']
           PY
-              then
-                exit 0
+                then
+                  ok=1
+                  break
+                fi
               fi
-            fi
-            sleep 2
+              sleep 2
+            done
+            test "$ok" -eq 1 || { echo "Public metadata validation failed: $path" >&2; exit 1; }
           done
-          echo "Public Hero manifest validation failed" >&2
-          exit 1
 
-      - name: Verify Hero Admin authentication gate
+      - name: Verify admin authentication gate
         shell: bash
         run: |
           set -eu
           for attempt in 1 2 3 4 5; do
-            status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
-              --max-time 15 \
+            status="$(curl --silent --output /dev/null --write-out '%{http_code}' --max-time 15 \
               https://groupim.cn/ev-charge-book/hero-admin/ || true)"
             if [ "$status" = "401" ]; then
               exit 0
@@ -140,7 +153,7 @@ jobs:
             echo "Attempt $attempt: expected 401, got $status"
             sleep 2
           done
-          echo "Hero Admin is not protected by the expected authentication gate" >&2
+          echo "Admin is not protected by the expected authentication gate" >&2
           exit 1
 
       - name: Deployment summary
@@ -148,11 +161,11 @@ jobs:
         shell: bash
         run: |
           {
-            echo "## Hero Admin deployment"
+            echo "## EV resource admin deployment"
             echo ""
             echo "- Admin: https://groupim.cn/ev-charge-book/hero-admin/"
-            echo "- Manifest: https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
+            echo "- Hero manifest: https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
+            echo "- Vehicle catalog: https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json"
             echo "- Server credentials file: /opt/ev-charge-book/hero-admin.env"
             echo "- Server-side Docker/PyPI network access is not required for deployment."
-            echo "- The password is never printed into Actions logs."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hero-admin.yml
+++ b/.github/workflows/hero-admin.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'hero-admin/**'
+      - 'vehicle-catalog/**'
       - '.github/workflows/hero-admin.yml'
   push:
     branches: [main]
     paths:
       - 'hero-admin/**'
+      - 'vehicle-catalog/**'
       - '.github/workflows/hero-admin.yml'
   workflow_dispatch:
 
@@ -17,14 +19,14 @@ permissions:
 
 jobs:
   verify:
-    name: Verify Hero Admin publisher
+    name: Verify EV resource admin
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Hero Admin container
+      - name: Build admin container
         run: docker build -t ev-charge-book-hero-admin:test hero-admin
 
       - name: Prepare isolated runtime directories
@@ -33,8 +35,9 @@ jobs:
           set -eu
           mkdir -p .hero-admin-test/releases .hero-admin-test/release-meta
           cp hero-assets/manifest-v1.json .hero-admin-test/release-meta/hero-assets-v1.json
+          cp vehicle-catalog/catalog-v1.json .hero-admin-test/release-meta/vehicle-catalog-v1.json
 
-      - name: Start Hero Admin
+      - name: Start admin
         shell: bash
         run: |
           set -eu
@@ -53,9 +56,61 @@ jobs:
             fi
             sleep 1
           done
-
           docker logs ev-charge-book-hero-admin-test
           exit 1
+
+      - name: Exercise vehicle catalog lifecycle
+        shell: bash
+        run: |
+          set -eu
+          cat > .hero-admin-test/new-vehicle.json <<'JSON'
+          {
+            "catalogId": "test-ev-2026-long-range",
+            "brand": "测试品牌",
+            "series": "TEST EV",
+            "modelName": "TEST EV 2026款",
+            "modelYear": 2026,
+            "trimName": "长续航",
+            "powertrainType": "BEV",
+            "batteryCapacityKwh": 88.8,
+            "rangeKm": 688,
+            "heroArtworkKey": "test-ev-2026"
+          }
+          JSON
+
+          curl --fail --silent --show-error \
+            -u admin:test-only-password \
+            -H 'Origin: http://127.0.0.1:18080' \
+            -H 'X-Hero-Admin-Request: 1' \
+            -H 'Content-Type: application/json' \
+            --data-binary @.hero-admin-test/new-vehicle.json \
+            http://127.0.0.1:18080/api/catalog/save \
+            -o .hero-admin-test/catalog-created.json
+
+          for active in false true; do
+            curl --fail --silent --show-error \
+              -u admin:test-only-password \
+              -H 'Origin: http://127.0.0.1:18080' \
+              -H 'X-Hero-Admin-Request: 1' \
+              -H 'Content-Type: application/json' \
+              --data "{\"catalogId\":\"test-ev-2026-long-range\",\"isActive\":$active}" \
+              http://127.0.0.1:18080/api/catalog/status >/dev/null
+          done
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          result = json.loads(Path('.hero-admin-test/catalog-created.json').read_text())
+          assert result['ok'] is True and result['action'] == 'created'
+          catalog = json.loads(Path('.hero-admin-test/release-meta/vehicle-catalog-v1.json').read_text())
+          item = next(v for v in catalog['vehicles'] if v['catalogId'] == 'test-ev-2026-long-range')
+          assert item['isActive'] is True
+          assert item['heroArtworkKey'] == 'test-ev-2026'
+          assert item['batteryCapacityKwh'] == 88.8
+          assert catalog['catalogVersion'] == 4
+          backup = json.loads(Path('.hero-admin-test/release-meta/vehicle-catalog-v1.json.bak').read_text())
+          assert next(v for v in backup['vehicles'] if v['catalogId'] == 'test-ev-2026-long-range')['isActive'] is False
+          PY
 
       - name: Generate valid 1600x1100 PNG fixture
         shell: bash
@@ -64,22 +119,50 @@ jobs:
           import struct
           import zlib
           from pathlib import Path
-
           width, height = 1600, 1100
           signature = b'\x89PNG\r\n\x1a\n'
-
           def chunk(kind, payload):
               body = kind + payload
               return struct.pack('>I', len(payload)) + body + struct.pack('>I', zlib.crc32(body) & 0xffffffff)
-
           ihdr = struct.pack('>IIBBBBB', width, height, 8, 2, 0, 0, 0)
           row = b'\x00' + (b'\x08\x18\x12' * width)
-          pixels = row * height
-          png = signature + chunk(b'IHDR', ihdr) + chunk(b'IDAT', zlib.compress(pixels, 9)) + chunk(b'IEND', b'')
+          png = signature + chunk(b'IHDR', ihdr) + chunk(b'IDAT', zlib.compress(row * height, 9)) + chunk(b'IEND', b'')
           Path('.hero-admin-test/fixture.png').write_bytes(png)
           PY
 
-      - name: Publish through HTTP API
+      - name: Publish new Hero key through HTTP API
+        shell: bash
+        run: |
+          set -eu
+          curl --fail --silent --show-error \
+            -u admin:test-only-password \
+            -H 'Origin: http://127.0.0.1:18080' \
+            -H 'X-Hero-Admin-Request: 1' \
+            -F 'artworkKey=test-ev-2026' \
+            -F 'file=@.hero-admin-test/fixture.png;type=image/png' \
+            http://127.0.0.1:18080/api/publish \
+            -o .hero-admin-test/result-new.json
+
+      - name: Verify immutable WebP and new manifest entry
+        shell: bash
+        run: |
+          set -eu
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          result = json.loads(Path('.hero-admin-test/result-new.json').read_text())
+          assert result['ok'] is True
+          assert result['version'] == 1
+          assert result['filename'] == 'test_ev_2026_v1.webp'
+          assert result['outputWidth'] == 1600 and result['outputHeight'] == 1100
+          image = Path('.hero-admin-test/releases/hero-assets/test_ev_2026_v1.webp').read_bytes()
+          assert image[:4] == b'RIFF' and image[8:12] == b'WEBP'
+          assert len(image) <= 2_621_440
+          manifest = json.loads(Path('.hero-admin-test/release-meta/hero-assets-v1.json').read_text())
+          assert manifest['artworks']['test-ev-2026']['version'] == 1
+          PY
+
+      - name: Verify existing Hero still increments
         shell: bash
         run: |
           set -eu
@@ -90,35 +173,14 @@ jobs:
             -F 'artworkKey=leapmotor-c16-2026' \
             -F 'file=@.hero-admin-test/fixture.png;type=image/png' \
             http://127.0.0.1:18080/api/publish \
-            -o .hero-admin-test/result.json
-          cat .hero-admin-test/result.json
-
-      - name: Verify immutable WebP and manifest switch
-        shell: bash
-        run: |
-          set -eu
+            -o .hero-admin-test/result-existing.json
           python3 - <<'PY'
           import json
           from pathlib import Path
-
-          result = json.loads(Path('.hero-admin-test/result.json').read_text())
-          assert result['ok'] is True
+          result = json.loads(Path('.hero-admin-test/result-existing.json').read_text())
           assert result['version'] == 2
-          assert result['outputWidth'] == 1600
-          assert result['outputHeight'] == 1100
-          assert result['filename'] == 'leapmotor_c16_2026_v2.webp'
-
-          image = Path('.hero-admin-test/releases/hero-assets/leapmotor_c16_2026_v2.webp').read_bytes()
-          assert image[:4] == b'RIFF' and image[8:12] == b'WEBP'
-          assert len(image) <= 2_621_440
-
           manifest = json.loads(Path('.hero-admin-test/release-meta/hero-assets-v1.json').read_text())
-          item = manifest['artworks']['leapmotor-c16-2026']
-          assert item['version'] == 2
-          assert item['url'].endswith('/leapmotor_c16_2026_v2.webp')
-
-          backup = json.loads(Path('.hero-admin-test/release-meta/hero-assets-v1.json.bak').read_text())
-          assert backup['artworks']['leapmotor-c16-2026']['version'] == 1
+          assert manifest['artworks']['leapmotor-c16-2026']['version'] == 2
           PY
 
       - name: Stop test container

--- a/hero-admin/app.py
+++ b/hero-admin/app.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 import urllib.request
 from functools import wraps
 from pathlib import Path
@@ -28,9 +29,14 @@ MANIFEST_SEED_URL = os.environ.get(
     "HERO_MANIFEST_SEED_URL",
     "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/hero-assets/manifest-v1.json",
 )
+CATALOG_SEED_URL = os.environ.get(
+    "VEHICLE_CATALOG_SEED_URL",
+    "https://raw.githubusercontent.com/Assembles-J/EV-Charge-Book/main/vehicle-catalog/catalog-v1.json",
+)
 RELEASE_ROOT = Path(os.environ.get("HERO_RELEASE_ROOT", "/data/releases"))
 META_ROOT = Path(os.environ.get("HERO_META_ROOT", "/data/release-meta"))
 MANIFEST_PATH = META_ROOT / "hero-assets-v1.json"
+CATALOG_PATH = META_ROOT / "vehicle-catalog-v1.json"
 HERO_DIR = RELEASE_ROOT / "hero-assets"
 
 TARGET_SIZE = (1600, 1100)
@@ -40,12 +46,13 @@ MIN_RATIO = 1.40
 MAX_RATIO = 1.55
 MAX_OUTPUT_BYTES = 2_621_440  # 2.5 MiB
 ALLOWED_INPUT_FORMATS = {"PNG", "WEBP"}
-KEY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{1,80}$")
+KEY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{1,100}$")
+POWERTRAIN_TYPES = {"BEV", "PHEV", "REEV"}
 
 
 def _startup_guard() -> None:
     if not ADMIN_PASSWORD:
-        raise RuntimeError("HERO_ADMIN_PASSWORD must be set; refusing to start an open upload service")
+        raise RuntimeError("HERO_ADMIN_PASSWORD must be set; refusing to start an open admin service")
     HERO_DIR.mkdir(parents=True, exist_ok=True)
     META_ROOT.mkdir(parents=True, exist_ok=True)
 
@@ -69,7 +76,7 @@ def require_auth(view):
             return Response(
                 "Authentication required",
                 401,
-                {"WWW-Authenticate": 'Basic realm="EV Charge Book Hero Admin"'},
+                {"WWW-Authenticate": 'Basic realm="EV Charge Book Admin"'},
             )
         return view(*args, **kwargs)
 
@@ -85,6 +92,26 @@ def require_admin_post() -> Response | None:
     return None
 
 
+def _write_atomic(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            os.fchmod(handle.fileno(), 0o644)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _load_seed(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
 def _validate_manifest(manifest: dict) -> dict:
     if manifest.get("schemaVersion") != 1:
         raise ValueError("unsupported Hero manifest schemaVersion")
@@ -98,11 +125,12 @@ def _ensure_manifest() -> None:
     if MANIFEST_PATH.is_file():
         return
     try:
-        with urllib.request.urlopen(MANIFEST_SEED_URL, timeout=10) as response:
-            seed = json.loads(response.read().decode("utf-8"))
+        seed = _load_seed(MANIFEST_SEED_URL)
         _validate_manifest(seed)
-        payload = (json.dumps(seed, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
-        _write_atomic(MANIFEST_PATH, payload)
+        _write_atomic(
+            MANIFEST_PATH,
+            (json.dumps(seed, ensure_ascii=False, indent=2) + "\n").encode("utf-8"),
+        )
     except Exception as exc:
         raise FileNotFoundError(
             f"Hero manifest is missing and seed download failed: {MANIFEST_SEED_URL}"
@@ -111,8 +139,123 @@ def _ensure_manifest() -> None:
 
 def _load_manifest() -> dict:
     _ensure_manifest()
-    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    return _validate_manifest(manifest)
+    return _validate_manifest(json.loads(MANIFEST_PATH.read_text(encoding="utf-8")))
+
+
+def _write_manifest_atomic(manifest: dict) -> None:
+    if MANIFEST_PATH.exists():
+        shutil.copy2(MANIFEST_PATH, MANIFEST_PATH.with_suffix(".json.bak"))
+    _write_atomic(
+        MANIFEST_PATH,
+        (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8"),
+    )
+
+
+def _validate_catalog(catalog: dict) -> dict:
+    if catalog.get("schemaVersion") != 1:
+        raise ValueError("unsupported vehicle catalog schemaVersion")
+    vehicles = catalog.get("vehicles")
+    if not isinstance(vehicles, list) or not vehicles:
+        raise ValueError("vehicle catalog has no vehicles")
+    seen: set[str] = set()
+    for item in vehicles:
+        if not isinstance(item, dict):
+            raise ValueError("vehicle catalog contains an invalid item")
+        catalog_id = str(item.get("catalogId") or "")
+        if not KEY_PATTERN.fullmatch(catalog_id) or catalog_id in seen:
+            raise ValueError(f"invalid or duplicate catalogId: {catalog_id}")
+        seen.add(catalog_id)
+    return catalog
+
+
+def _ensure_catalog() -> None:
+    if CATALOG_PATH.is_file():
+        return
+    try:
+        seed = _load_seed(CATALOG_SEED_URL)
+        _validate_catalog(seed)
+        _write_atomic(
+            CATALOG_PATH,
+            (json.dumps(seed, ensure_ascii=False, indent=2) + "\n").encode("utf-8"),
+        )
+    except Exception as exc:
+        raise FileNotFoundError(
+            f"vehicle catalog is missing and seed download failed: {CATALOG_SEED_URL}"
+        ) from exc
+
+
+def _load_catalog() -> dict:
+    _ensure_catalog()
+    return _validate_catalog(json.loads(CATALOG_PATH.read_text(encoding="utf-8")))
+
+
+def _write_catalog_atomic(catalog: dict) -> None:
+    if CATALOG_PATH.exists():
+        shutil.copy2(CATALOG_PATH, CATALOG_PATH.with_suffix(".json.bak"))
+    _write_atomic(
+        CATALOG_PATH,
+        (json.dumps(catalog, ensure_ascii=False, indent=2) + "\n").encode("utf-8"),
+    )
+
+
+def _catalog_number(value, name: str, *, integer: bool = False):
+    if value in (None, ""):
+        return None
+    try:
+        result = int(value) if integer else float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} 格式不正确") from exc
+    if result <= 0:
+        raise ValueError(f"{name} 必须大于 0")
+    return result
+
+
+def _normalize_catalog_item(payload: dict, existing: dict | None = None) -> dict:
+    catalog_id = str(payload.get("catalogId") or "").strip().lower()
+    if not KEY_PATTERN.fullmatch(catalog_id):
+        raise ValueError("catalogId 只允许小写字母、数字和连字符")
+    if existing is not None and catalog_id != existing.get("catalogId"):
+        raise ValueError("catalogId 是稳定标识，已有车型不能改 ID；请新建车型后下架旧项")
+
+    brand = str(payload.get("brand") or "").strip()
+    series = str(payload.get("series") or "").strip()
+    model_name = str(payload.get("modelName") or "").strip()
+    trim_name = str(payload.get("trimName") or "").strip() or None
+    powertrain = str(payload.get("powertrainType") or "").strip().upper()
+    hero_key = str(payload.get("heroArtworkKey") or "").strip().lower() or None
+
+    if not brand or not series or not model_name:
+        raise ValueError("品牌、车系、车型名称不能为空")
+    if powertrain not in POWERTRAIN_TYPES:
+        raise ValueError("动力类型只能是 BEV / PHEV / REEV")
+    if hero_key is not None and not KEY_PATTERN.fullmatch(hero_key):
+        raise ValueError("Hero key 只允许小写字母、数字和连字符")
+
+    model_year = _catalog_number(payload.get("modelYear"), "年款", integer=True)
+    if model_year is not None and not (1990 <= model_year <= 2100):
+        raise ValueError("年款超出合理范围")
+
+    now = int(time.time() * 1000)
+    return {
+        "catalogId": catalog_id,
+        "source": "managed-v1",
+        "brand": brand,
+        "series": series,
+        "modelName": model_name,
+        "modelYear": model_year,
+        "trimName": trim_name,
+        "powertrainType": powertrain,
+        "batteryCapacityKwh": _catalog_number(payload.get("batteryCapacityKwh"), "电池容量"),
+        "rangeKm": _catalog_number(payload.get("rangeKm"), "标称续航", integer=True),
+        "heroArtworkKey": hero_key,
+        "isActive": bool(existing.get("isActive", True) if existing else True),
+        "sourceUpdatedAtEpochMillis": now,
+    }
+
+
+def _bump_catalog(catalog: dict) -> None:
+    catalog["catalogVersion"] = max(0, int(catalog.get("catalogVersion") or 0)) + 1
+    catalog["updatedAtEpochMillis"] = int(time.time() * 1000)
 
 
 def _safe_slug(key: str) -> str:
@@ -152,7 +295,6 @@ def _decode_and_validate(upload_bytes: bytes) -> tuple[Image.Image, dict]:
 
 def _encode_webp(source: Image.Image) -> tuple[bytes, int]:
     fitted = ImageOps.fit(source, TARGET_SIZE, method=Image.Resampling.LANCZOS, centering=(0.5, 0.5))
-
     for quality in (88, 84, 80, 76):
         buffer = io.BytesIO()
         fitted.save(buffer, format="WEBP", quality=quality, method=6)
@@ -161,30 +303,7 @@ def _encode_webp(source: Image.Image) -> tuple[bytes, int]:
             if len(payload) < 12 or payload[:4] != b"RIFF" or payload[8:12] != b"WEBP":
                 raise ValueError("WebP 编码结果校验失败")
             return payload, quality
-
     raise ValueError("转换后的 WebP 仍超过 2.5 MiB，请降低源图复杂度")
-
-
-def _write_atomic(path: Path, payload: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "wb") as handle:
-            handle.write(payload)
-            os.fchmod(handle.fileno(), 0o644)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp_name, path)
-    finally:
-        if os.path.exists(tmp_name):
-            os.unlink(tmp_name)
-
-
-def _write_manifest_atomic(manifest: dict) -> None:
-    if MANIFEST_PATH.exists():
-        shutil.copy2(MANIFEST_PATH, MANIFEST_PATH.with_suffix(".json.bak"))
-    payload = (json.dumps(manifest, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
-    _write_atomic(MANIFEST_PATH, payload)
 
 
 @app.get("/")
@@ -202,10 +321,76 @@ def healthz():
 @require_auth
 def state():
     try:
-        manifest = _load_manifest()
+        return jsonify(_load_manifest())
     except Exception as exc:
         return jsonify({"error": str(exc)}), 503
-    return jsonify(manifest)
+
+
+@app.get("/api/catalog/state")
+@require_auth
+def catalog_state():
+    try:
+        return jsonify(_load_catalog())
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 503
+
+
+@app.post("/api/catalog/save")
+@require_auth
+def catalog_save():
+    rejected = require_admin_post()
+    if rejected is not None:
+        return rejected
+    try:
+        payload = request.get_json(force=True, silent=False) or {}
+        catalog = _load_catalog()
+        vehicles = catalog["vehicles"]
+        catalog_id = str(payload.get("catalogId") or "").strip().lower()
+        existing = next((item for item in vehicles if item.get("catalogId") == catalog_id), None)
+        normalized = _normalize_catalog_item(payload, existing)
+        if existing is None:
+            vehicles.append(normalized)
+            action = "created"
+        else:
+            vehicles[vehicles.index(existing)] = normalized
+            action = "updated"
+        vehicles.sort(key=lambda item: (item.get("brand") or "", item.get("series") or "", -(item.get("modelYear") or 0), item.get("trimName") or ""))
+        _bump_catalog(catalog)
+        _write_catalog_atomic(catalog)
+        return jsonify({"ok": True, "action": action, "catalogVersion": catalog["catalogVersion"], "vehicle": normalized})
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        app.logger.exception("Vehicle catalog save failed")
+        return jsonify({"error": f"保存车型失败：{exc}"}), 500
+
+
+@app.post("/api/catalog/status")
+@require_auth
+def catalog_status():
+    rejected = require_admin_post()
+    if rejected is not None:
+        return rejected
+    try:
+        payload = request.get_json(force=True, silent=False) or {}
+        catalog_id = str(payload.get("catalogId") or "").strip().lower()
+        active = payload.get("isActive")
+        if not KEY_PATTERN.fullmatch(catalog_id) or not isinstance(active, bool):
+            raise ValueError("无效的车型状态请求")
+        catalog = _load_catalog()
+        item = next((entry for entry in catalog["vehicles"] if entry.get("catalogId") == catalog_id), None)
+        if item is None:
+            return jsonify({"error": "车型不存在"}), 404
+        item["isActive"] = active
+        item["sourceUpdatedAtEpochMillis"] = int(time.time() * 1000)
+        _bump_catalog(catalog)
+        _write_catalog_atomic(catalog)
+        return jsonify({"ok": True, "catalogVersion": catalog["catalogVersion"], "vehicle": item})
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:
+        app.logger.exception("Vehicle catalog status update failed")
+        return jsonify({"error": f"更新车型状态失败：{exc}"}), 500
 
 
 @app.post("/api/publish")
@@ -215,10 +400,9 @@ def publish():
     if rejected is not None:
         return rejected
 
-    key = (request.form.get("artworkKey") or "").strip()
+    key = (request.form.get("artworkKey") or "").strip().lower()
     if not KEY_PATTERN.fullmatch(key):
         return jsonify({"error": "无效的 artwork key"}), 400
-
     upload = request.files.get("file")
     if upload is None or not upload.filename:
         return jsonify({"error": "请选择 PNG 或 WebP 图片"}), 400
@@ -227,17 +411,13 @@ def publish():
         manifest = _load_manifest()
         artworks = manifest["artworks"]
         current = artworks.get(key)
-        if not isinstance(current, dict):
-            return jsonify({"error": "v1 管理页只允许更新已有车型；新增车型仍需先加入 Android 映射"}), 400
-
         raw = upload.read()
         if not raw:
             return jsonify({"error": "上传文件为空"}), 400
 
         source, metadata = _decode_and_validate(raw)
         webp_bytes, quality = _encode_webp(source)
-
-        current_version = int(current.get("version") or 0)
+        current_version = int(current.get("version") or 0) if isinstance(current, dict) else 0
         next_version = current_version + 1
         filename = f"{_safe_slug(key)}_v{next_version}.webp"
         destination = HERO_DIR / filename
@@ -245,25 +425,22 @@ def publish():
             return jsonify({"error": f"目标文件已存在：{filename}；请检查 manifest 版本"}), 409
 
         _write_atomic(destination, webp_bytes)
-
         public_url = f"{PUBLIC_ASSET_BASE}/{filename}"
         artworks[key] = {"version": next_version, "url": public_url}
         _write_manifest_atomic(manifest)
 
-        return jsonify(
-            {
-                "ok": True,
-                "artworkKey": key,
-                "version": next_version,
-                "url": public_url,
-                "filename": filename,
-                "outputBytes": len(webp_bytes),
-                "outputWidth": TARGET_SIZE[0],
-                "outputHeight": TARGET_SIZE[1],
-                "quality": quality,
-                **metadata,
-            }
-        )
+        return jsonify({
+            "ok": True,
+            "artworkKey": key,
+            "version": next_version,
+            "url": public_url,
+            "filename": filename,
+            "outputBytes": len(webp_bytes),
+            "outputWidth": TARGET_SIZE[0],
+            "outputHeight": TARGET_SIZE[1],
+            "quality": quality,
+            **metadata,
+        })
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     except Exception as exc:

--- a/hero-admin/templates/index.html
+++ b/hero-admin/templates/index.html
@@ -3,190 +3,129 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>EV Charge Book · Hero Admin</title>
+  <title>EV Charge Book · Admin</title>
   <style>
-    :root { color-scheme: dark; --bg:#050a08; --panel:#0b1512; --line:#1d2c27; --text:#f3f7f5; --muted:#94a39d; --green:#35ef84; }
-    * { box-sizing:border-box; }
-    body { margin:0; font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:radial-gradient(circle at 50% -20%,#123127 0,#07110d 36%,var(--bg) 72%); color:var(--text); min-height:100vh; }
-    main { width:min(920px,calc(100% - 32px)); margin:0 auto; padding:48px 0 72px; }
-    header { margin-bottom:24px; }
-    .eyebrow { color:var(--green); font-size:13px; letter-spacing:.16em; text-transform:uppercase; }
-    h1 { font-size:clamp(30px,5vw,48px); margin:8px 0 10px; font-weight:650; }
-    .intro { color:var(--muted); margin:0; line-height:1.65; }
-    .panel { background:rgba(10,22,18,.86); border:1px solid rgba(255,255,255,.09); border-radius:24px; padding:22px; box-shadow:0 20px 70px rgba(0,0,0,.32); backdrop-filter:blur(18px); }
-    .grid { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
-    label { display:block; color:#c5d0cc; font-size:14px; margin:0 0 8px; }
-    select,input,button { font:inherit; }
-    select { width:100%; padding:13px 14px; background:#07110d; color:var(--text); border:1px solid var(--line); border-radius:14px; outline:none; }
-    .drop { min-height:255px; border:1px dashed #365148; border-radius:18px; display:flex; align-items:center; justify-content:center; text-align:center; padding:18px; position:relative; overflow:hidden; cursor:pointer; background:rgba(255,255,255,.015); }
-    .drop.drag { border-color:var(--green); background:rgba(53,239,132,.05); }
-    .drop input { position:absolute; inset:0; opacity:0; cursor:pointer; }
-    .drop img { width:100%; height:100%; max-height:300px; object-fit:contain; border-radius:14px; display:none; }
-    .drop.has-preview img { display:block; }
-    .drop.has-preview .placeholder { display:none; }
-    .placeholder strong { display:block; font-size:17px; margin-bottom:6px; }
-    .placeholder span { color:var(--muted); font-size:13px; line-height:1.6; }
-    .status { margin-top:16px; padding:13px 14px; border-radius:14px; background:#07110d; border:1px solid var(--line); color:var(--muted); min-height:48px; line-height:1.55; }
-    .status.ok { color:#b8f8d0; border-color:rgba(53,239,132,.28); }
-    .status.error { color:#ffb5b5; border-color:rgba(255,90,90,.3); }
-    .actions { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top:18px; }
-    .hint { color:var(--muted); font-size:12px; line-height:1.55; }
-    button { border:0; border-radius:14px; padding:13px 22px; background:var(--green); color:#031108; font-weight:750; cursor:pointer; min-width:130px; }
-    button:disabled { opacity:.35; cursor:not-allowed; }
-    .current { margin-top:22px; display:grid; grid-template-columns:repeat(3,1fr); gap:10px; }
-    .current-card { padding:13px; background:#07110d; border:1px solid var(--line); border-radius:14px; min-width:0; }
-    .current-card b { display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-size:13px; }
-    .current-card span { color:var(--muted); font-size:12px; }
-    @media(max-width:720px){ .grid{grid-template-columns:1fr}.current{grid-template-columns:1fr 1fr} main{padding-top:28px}.actions{align-items:flex-end}.panel{padding:16px} }
+    :root{color-scheme:dark;--bg:#050a08;--panel:#0b1512;--panel2:#07110d;--line:#1d2c27;--text:#f3f7f5;--muted:#94a39d;--green:#35ef84;--danger:#ff8d8d}
+    *{box-sizing:border-box} body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 50% -20%,#123127 0,#07110d 36%,var(--bg) 72%);color:var(--text);min-height:100vh}
+    main{width:min(1060px,calc(100% - 32px));margin:0 auto;padding:42px 0 72px} header{margin-bottom:20px}.eyebrow{color:var(--green);font-size:13px;letter-spacing:.16em;text-transform:uppercase}h1{font-size:clamp(30px,5vw,46px);margin:8px 0 8px;font-weight:650}.intro{color:var(--muted);margin:0;line-height:1.65;max-width:820px}
+    .tabs{display:flex;gap:8px;margin:24px 0 14px}.tab{min-width:auto;background:transparent;color:var(--muted);border:1px solid var(--line);padding:10px 16px}.tab.active{background:rgba(53,239,132,.10);color:var(--green);border-color:rgba(53,239,132,.32)}
+    .panel{background:rgba(10,22,18,.86);border:1px solid rgba(255,255,255,.09);border-radius:24px;padding:20px;box-shadow:0 20px 70px rgba(0,0,0,.32);backdrop-filter:blur(18px)}.hidden{display:none!important}
+    button,input,select{font:inherit}button{border:0;border-radius:12px;padding:11px 17px;background:var(--green);color:#031108;font-weight:700;cursor:pointer}button.secondary{background:transparent;color:var(--text);border:1px solid var(--line)}button.danger{background:rgba(255,90,90,.08);color:var(--danger);border:1px solid rgba(255,90,90,.2)}button:disabled{opacity:.35;cursor:not-allowed}
+    input,select{width:100%;padding:11px 12px;background:var(--panel2);color:var(--text);border:1px solid var(--line);border-radius:12px;outline:none}label{display:block;color:#c5d0cc;font-size:13px;margin:0 0 7px}.toolbar{display:flex;gap:10px;align-items:center;margin-bottom:14px}.toolbar input{flex:1}.meta{color:var(--muted);font-size:12px;line-height:1.5}
+    .vehicle-list{display:grid;gap:8px}.vehicle-row{display:grid;grid-template-columns:minmax(230px,1.6fr) minmax(160px,1fr) minmax(150px,.8fr) auto;gap:12px;align-items:center;padding:13px 14px;background:var(--panel2);border:1px solid var(--line);border-radius:16px}.vehicle-row.retired{opacity:.55}.vehicle-title{font-weight:650}.vehicle-sub,.vehicle-facts{color:var(--muted);font-size:12px;margin-top:3px;line-height:1.45}.badge{display:inline-flex;border-radius:999px;padding:4px 8px;font-size:11px;background:rgba(53,239,132,.09);color:var(--green);margin-left:6px}.badge.off{background:rgba(255,255,255,.05);color:var(--muted)}.row-actions{display:flex;gap:6px}.row-actions button{padding:8px 10px;font-size:12px;min-width:auto}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}.current{margin-top:14px;display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.current-card{padding:12px;background:var(--panel2);border:1px solid var(--line);border-radius:12px;min-width:0}.current-card b{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:13px}.current-card span{color:var(--muted);font-size:11px}
+    .drop{min-height:250px;border:1px dashed #365148;border-radius:18px;display:flex;align-items:center;justify-content:center;text-align:center;padding:18px;position:relative;overflow:hidden;cursor:pointer;background:rgba(255,255,255,.015)}.drop.drag{border-color:var(--green);background:rgba(53,239,132,.05)}.drop input{position:absolute;inset:0;opacity:0;cursor:pointer}.drop img{width:100%;height:100%;max-height:300px;object-fit:contain;border-radius:14px;display:none}.drop.has-preview img{display:block}.drop.has-preview .placeholder{display:none}.placeholder strong{display:block;font-size:17px;margin-bottom:6px}.placeholder span{color:var(--muted);font-size:13px;line-height:1.6}.status{margin-top:14px;padding:12px 13px;border-radius:12px;background:var(--panel2);border:1px solid var(--line);color:var(--muted);min-height:44px;line-height:1.5}.status.ok{color:#b8f8d0;border-color:rgba(53,239,132,.28)}.status.error{color:#ffb5b5;border-color:rgba(255,90,90,.3)}.actions{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-top:16px}
+    dialog{width:min(680px,calc(100% - 28px));border:1px solid var(--line);border-radius:20px;background:#091310;color:var(--text);padding:0;box-shadow:0 30px 100px #000}dialog::backdrop{background:rgba(0,0,0,.68)}.dialog-body{padding:20px}.dialog-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}.dialog-head h2{margin:0;font-size:22px}.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:13px}.wide{grid-column:1/-1}.dialog-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:18px}
+    @media(max-width:760px){main{padding-top:26px}.grid,.form-grid{grid-template-columns:1fr}.vehicle-row{grid-template-columns:1fr}.row-actions{justify-content:flex-end}.toolbar{flex-wrap:wrap}.toolbar input{flex-basis:100%}.current{grid-template-columns:1fr 1fr}.actions{align-items:flex-end}.panel{padding:15px}}
   </style>
 </head>
 <body>
 <main>
   <header>
     <div class="eyebrow">EV Charge Book</div>
-    <h1>Hero 图片管理</h1>
-    <p class="intro">选择已有车型，拖入 PNG / WebP。服务器会校验比例、统一转换为 1600×1100 真 WebP、自动版本 +1，并原子更新 Hero manifest。</p>
+    <h1>车辆资源管理</h1>
+    <p class="intro">这里维护服务器车型目录和 Hero 图片。App 仍然以本地 Room 车型库运行；网络只用于刷新目录，断网不会影响记账、行程、车辆切换或已有车型使用。</p>
   </header>
 
-  <section class="panel">
+  <div class="tabs">
+    <button class="tab active" data-tab="catalog">车型库</button>
+    <button class="tab" data-tab="hero">Hero 图片</button>
+  </div>
+
+  <section class="panel" id="catalogPanel">
+    <div class="toolbar">
+      <input id="catalogSearch" placeholder="搜索品牌、车系、车型、catalogId" />
+      <span class="meta" id="catalogMeta">读取中…</span>
+      <button id="addVehicle">新增车型</button>
+    </div>
+    <div class="vehicle-list" id="vehicleList"></div>
+    <div class="status" id="catalogStatus">正在读取服务器车型目录…</div>
+  </section>
+
+  <section class="panel hidden" id="heroPanel">
     <div class="grid">
       <div>
-        <label for="vehicle">车型</label>
-        <select id="vehicle"></select>
-        <div class="current" id="current"></div>
+        <label for="artworkKey">Hero key</label>
+        <input id="artworkKey" list="heroKeys" placeholder="例如 leapmotor-c16-2026" autocomplete="off" />
+        <datalist id="heroKeys"></datalist>
+        <div class="current" id="heroCurrent"></div>
+        <p class="meta">可输入一个新 key。第一次发布自动生成 v1；已有 key 自动 v+1。车型库里的 <b>Hero key</b> 与这里保持一致即可。</p>
       </div>
-
       <div>
         <label>新 Hero 原图</label>
         <div class="drop" id="drop">
           <input id="file" type="file" accept="image/png,image/webp,.png,.webp" />
           <img id="preview" alt="Hero preview" />
-          <div class="placeholder">
-            <strong>拖图片到这里</strong>
-            <span>PNG / WebP · 推荐 1600×1100 · 比例约 1.45:1<br/>无需自己转换 WebP</span>
-          </div>
+          <div class="placeholder"><strong>拖图片到这里</strong><span>PNG / WebP · 推荐 1600×1100 · 比例约 1.45:1<br/>服务器自动转换成真 WebP</span></div>
         </div>
       </div>
     </div>
-
-    <div class="status" id="status">正在读取当前 Hero manifest…</div>
+    <div class="status" id="heroStatus">正在读取 Hero manifest…</div>
     <div class="actions">
-      <div class="hint">发布会生成新的 <code>_vN.webp</code>，不会覆盖旧文件。旧版本仍留在服务器，便于回退。</div>
-      <button id="publish" disabled>发布 Hero</button>
+      <div class="meta">发布生成新的 <code>_vN.webp</code>，不会覆盖旧文件。</div>
+      <button id="publishHero" disabled>发布 Hero</button>
     </div>
   </section>
 </main>
 
+<dialog id="vehicleDialog">
+  <form id="vehicleForm" class="dialog-body">
+    <div class="dialog-head"><h2 id="dialogTitle">新增车型</h2><button type="button" class="secondary" id="closeDialog">关闭</button></div>
+    <div class="form-grid">
+      <div class="wide"><label>catalogId（上线后不可改）</label><input name="catalogId" required placeholder="例如 byd-seal-2026-700" /></div>
+      <div><label>品牌</label><input name="brand" required /></div><div><label>车系</label><input name="series" required /></div>
+      <div><label>车型名称</label><input name="modelName" required /></div><div><label>配置</label><input name="trimName" /></div>
+      <div><label>年款</label><input name="modelYear" type="number" min="1990" max="2100" /></div>
+      <div><label>动力类型</label><select name="powertrainType"><option>BEV</option><option>PHEV</option><option>REEV</option></select></div>
+      <div><label>电池容量 kWh</label><input name="batteryCapacityKwh" type="number" min="0" step="0.1" /></div><div><label>标称续航 km</label><input name="rangeKm" type="number" min="0" step="1" /></div>
+      <div class="wide"><label>Hero key（可暂时留空）</label><input name="heroArtworkKey" placeholder="例如 byd-seal-2026" /></div>
+    </div>
+    <div class="status" id="formStatus">保存只更新服务器目录，不会改写用户已经添加的车辆快照。</div>
+    <div class="dialog-actions"><button type="button" class="secondary" id="cancelDialog">取消</button><button type="submit">保存车型</button></div>
+  </form>
+</dialog>
+
 <script>
-  const vehicle = document.getElementById('vehicle');
-  const fileInput = document.getElementById('file');
-  const drop = document.getElementById('drop');
-  const preview = document.getElementById('preview');
-  const publish = document.getElementById('publish');
-  const statusEl = document.getElementById('status');
-  const current = document.getElementById('current');
-  let manifest = null;
-  let chosenFile = null;
+  const adminHeaders={'X-Hero-Admin-Request':'1','Content-Type':'application/json'};
+  let catalog=null, manifest=null, chosenFile=null, editingId=null;
+  const $=id=>document.getElementById(id);
+  const esc=s=>String(s??'');
+  function setStatus(el,text,kind=''){el.className='status'+(kind?' '+kind:'');el.textContent=text}
+  function switchTab(name){document.querySelectorAll('.tab').forEach(x=>x.classList.toggle('active',x.dataset.tab===name));$('catalogPanel').classList.toggle('hidden',name!=='catalog');$('heroPanel').classList.toggle('hidden',name!=='hero')}
+  document.querySelectorAll('.tab').forEach(x=>x.onclick=()=>switchTab(x.dataset.tab));
 
-  function setStatus(text, kind='') {
-    statusEl.className = 'status' + (kind ? ' ' + kind : '');
-    statusEl.textContent = text;
+  async function loadCatalog(){
+    try{const r=await fetch('api/catalog/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取车型库失败');catalog=d;renderCatalog();setStatus($('catalogStatus'),`车型目录已加载 · v${d.catalogVersion} · App 将在有网络时后台同步，本地库始终可用。`,'ok')}catch(e){setStatus($('catalogStatus'),e.message,'error')}
   }
-
-  function renderCurrent() {
-    current.innerHTML = '';
-    if (!manifest) return;
-    const selected = manifest.artworks[vehicle.value];
-    if (!selected) return;
-    const values = [
-      ['当前版本', `v${selected.version}`],
-      ['目标版本', `v${selected.version + 1}`],
-      ['规格', '1600×1100'],
-    ];
-    for (const [name, value] of values) {
-      const card = document.createElement('div');
-      card.className = 'current-card';
-      card.innerHTML = `<b>${value}</b><span>${name}</span>`;
-      current.appendChild(card);
+  function renderCatalog(){
+    if(!catalog)return;const q=$('catalogSearch').value.trim().toLowerCase();const rows=catalog.vehicles.filter(v=>!q||`${v.catalogId} ${v.brand} ${v.series} ${v.modelName} ${v.trimName||''}`.toLowerCase().includes(q));
+    $('catalogMeta').textContent=`${catalog.vehicles.filter(v=>v.isActive!==false).length} 在用 / ${catalog.vehicles.length} 总计`;$('vehicleList').innerHTML='';
+    for(const v of rows){
+      const row=document.createElement('div');row.className='vehicle-row'+(v.isActive===false?' retired':'');
+      const a=document.createElement('div');const title=document.createElement('div');title.className='vehicle-title';title.textContent=`${v.brand} ${v.modelName}`;const badge=document.createElement('span');badge.className='badge'+(v.isActive===false?' off':'');badge.textContent=v.isActive===false?'已下架':'在用';title.appendChild(badge);const sub=document.createElement('div');sub.className='vehicle-sub';sub.textContent=`${v.trimName||v.series} · ${v.powertrainType} · ${v.catalogId}`;a.append(title,sub);
+      const b=document.createElement('div');b.className='vehicle-facts';b.textContent=`${v.batteryCapacityKwh??'--'} kWh · ${v.rangeKm??'--'} km`;
+      const c=document.createElement('div');c.className='vehicle-facts';c.textContent=`Hero: ${v.heroArtworkKey||'未配置'}`;
+      const acts=document.createElement('div');acts.className='row-actions';const edit=document.createElement('button');edit.className='secondary';edit.textContent='编辑';edit.onclick=()=>openVehicle(v);const status=document.createElement('button');status.className=v.isActive===false?'secondary':'danger';status.textContent=v.isActive===false?'恢复':'下架';status.onclick=()=>setVehicleStatus(v,v.isActive===false);acts.append(edit,status);row.append(a,b,c,acts);$('vehicleList').appendChild(row)
     }
   }
+  $('catalogSearch').oninput=renderCatalog;$('addVehicle').onclick=()=>openVehicle(null);
+  function openVehicle(v){editingId=v?.catalogId||null;$('dialogTitle').textContent=v?'编辑车型':'新增车型';const f=$('vehicleForm');f.reset();for(const name of ['catalogId','brand','series','modelName','trimName','modelYear','powertrainType','batteryCapacityKwh','rangeKm','heroArtworkKey']){if(v&&v[name]!=null)f.elements[name].value=v[name]}f.elements.catalogId.readOnly=!!v;setStatus($('formStatus'),'保存只更新服务器车型目录；用户已经添加的车辆参数快照不会被改写。');$('vehicleDialog').showModal()}
+  function closeVehicleDialog(){$('vehicleDialog').close();editingId=null}$('closeDialog').onclick=closeVehicleDialog;$('cancelDialog').onclick=closeVehicleDialog;
+  $('vehicleForm').onsubmit=async e=>{e.preventDefault();const f=e.currentTarget;const fd=new FormData(f);const body=Object.fromEntries(fd.entries());for(const k of ['modelYear','batteryCapacityKwh','rangeKm'])if(body[k]==='')body[k]=null;try{setStatus($('formStatus'),'正在保存…');const r=await fetch('api/catalog/save',{method:'POST',headers:adminHeaders,body:JSON.stringify(body)});const d=await r.json();if(!r.ok)throw new Error(d.error||'保存失败');await loadCatalog();closeVehicleDialog()}catch(err){setStatus($('formStatus'),err.message,'error')}};
+  async function setVehicleStatus(v,isActive){const verb=isActive?'恢复':'下架';if(!confirm(`${verb} ${v.brand} ${v.modelName}？\n\n已添加到用户本地的车辆和历史记录不会被删除。`))return;try{const r=await fetch('api/catalog/status',{method:'POST',headers:adminHeaders,body:JSON.stringify({catalogId:v.catalogId,isActive})});const d=await r.json();if(!r.ok)throw new Error(d.error||`${verb}失败`);await loadCatalog()}catch(e){setStatus($('catalogStatus'),e.message,'error')}}
 
-  async function loadState() {
-    try {
-      const res = await fetch('api/state');
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || '读取失败');
-      manifest = data;
-      vehicle.innerHTML = '';
-      for (const [key, item] of Object.entries(data.artworks)) {
-        const option = document.createElement('option');
-        option.value = key;
-        option.textContent = `${key} · v${item.version}`;
-        vehicle.appendChild(option);
-      }
-      renderCurrent();
-      setStatus('请选择图片。页面会先做本地预览，正式尺寸与格式由服务器再次校验。', 'ok');
-    } catch (err) {
-      setStatus(err.message, 'error');
-    }
+  async function loadHero(){
+    try{const r=await fetch('api/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取 Hero 失败');manifest=d;renderHeroKeys();setStatus($('heroStatus'),'请选择或输入 Hero key，再拖入图片。新 key 会从 v1 开始。','ok')}catch(e){setStatus($('heroStatus'),e.message,'error')}
   }
+  function renderHeroKeys(){const keys=new Set(Object.keys(manifest?.artworks||{}));for(const v of catalog?.vehicles||[])if(v.heroArtworkKey)keys.add(v.heroArtworkKey);$('heroKeys').innerHTML='';[...keys].sort().forEach(k=>{const o=document.createElement('option');o.value=k;$('heroKeys').appendChild(o)});renderHeroCurrent()}
+  function renderHeroCurrent(){$('heroCurrent').innerHTML='';const key=$('artworkKey').value.trim().toLowerCase();const cur=manifest?.artworks?.[key];const values=[['当前版本',cur?`v${cur.version}`:'尚未发布'],['目标版本',`v${(cur?.version||0)+1}`],['规格','1600×1100']];for(const [n,v] of values){const c=document.createElement('div');c.className='current-card';const b=document.createElement('b');b.textContent=v;const s=document.createElement('span');s.textContent=n;c.append(b,s);$('heroCurrent').appendChild(c)}updatePublishEnabled()}
+  $('artworkKey').oninput=renderHeroCurrent;
+  function updatePublishEnabled(){$('publishHero').disabled=!(chosenFile&&/^[a-z0-9][a-z0-9-]{1,100}$/.test($('artworkKey').value.trim().toLowerCase()))}
+  function selectFile(file){chosenFile=file||null;if(!chosenFile){$('drop').classList.remove('has-preview');$('preview').removeAttribute('src');updatePublishEnabled();return}if(!['image/png','image/webp'].includes(chosenFile.type)&&!/\.(png|webp)$/i.test(chosenFile.name)){chosenFile=null;setStatus($('heroStatus'),'只接受 PNG 或 WebP。','error');updatePublishEnabled();return}$('preview').src=URL.createObjectURL(chosenFile);$('drop').classList.add('has-preview');setStatus($('heroStatus'),`${chosenFile.name} · ${(chosenFile.size/1024).toFixed(0)} KB · 等待发布`,'ok');updatePublishEnabled()}
+  $('file').onchange=()=>selectFile($('file').files[0]);['dragenter','dragover'].forEach(t=>$('drop').addEventListener(t,e=>{e.preventDefault();$('drop').classList.add('drag')}));['dragleave','drop'].forEach(t=>$('drop').addEventListener(t,e=>{e.preventDefault();$('drop').classList.remove('drag')}));$('drop').addEventListener('drop',e=>selectFile(e.dataTransfer.files[0]));
+  $('publishHero').onclick=async()=>{const key=$('artworkKey').value.trim().toLowerCase();if(!chosenFile||!key)return;$('publishHero').disabled=true;setStatus($('heroStatus'),'正在校验、转换并发布…');const body=new FormData();body.append('artworkKey',key);body.append('file',chosenFile);try{const r=await fetch('api/publish',{method:'POST',headers:{'X-Hero-Admin-Request':'1'},body});const d=await r.json();if(!r.ok)throw new Error(d.error||'发布失败');manifest.artworks[d.artworkKey]={version:d.version,url:d.url};chosenFile=null;$('file').value='';$('drop').classList.remove('has-preview');$('preview').removeAttribute('src');renderHeroKeys();setStatus($('heroStatus'),`发布成功：${d.artworkKey} → v${d.version} · ${d.outputWidth}×${d.outputHeight} WebP · ${(d.outputBytes/1024).toFixed(0)} KB`,'ok')}catch(e){setStatus($('heroStatus'),e.message,'error')}finally{updatePublishEnabled()}};
 
-  function selectFile(file) {
-    chosenFile = file || null;
-    publish.disabled = !chosenFile || !manifest;
-    if (!chosenFile) {
-      drop.classList.remove('has-preview');
-      preview.removeAttribute('src');
-      return;
-    }
-    if (!['image/png','image/webp'].includes(chosenFile.type) && !/\.(png|webp)$/i.test(chosenFile.name)) {
-      chosenFile = null;
-      publish.disabled = true;
-      setStatus('只接受 PNG 或 WebP。', 'error');
-      return;
-    }
-    preview.src = URL.createObjectURL(chosenFile);
-    drop.classList.add('has-preview');
-    setStatus(`${chosenFile.name} · ${(chosenFile.size / 1024).toFixed(0)} KB · 等待发布`, 'ok');
-  }
-
-  fileInput.addEventListener('change', () => selectFile(fileInput.files[0]));
-  vehicle.addEventListener('change', renderCurrent);
-  ['dragenter','dragover'].forEach(type => drop.addEventListener(type, e => { e.preventDefault(); drop.classList.add('drag'); }));
-  ['dragleave','drop'].forEach(type => drop.addEventListener(type, e => { e.preventDefault(); drop.classList.remove('drag'); }));
-  drop.addEventListener('drop', e => selectFile(e.dataTransfer.files[0]));
-
-  publish.addEventListener('click', async () => {
-    if (!chosenFile || !vehicle.value) return;
-    publish.disabled = true;
-    setStatus('正在校验、转换并发布…');
-    const body = new FormData();
-    body.append('artworkKey', vehicle.value);
-    body.append('file', chosenFile);
-    try {
-      const res = await fetch('api/publish', {
-        method: 'POST',
-        headers: {'X-Hero-Admin-Request': '1'},
-        body,
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || '发布失败');
-
-      manifest.artworks[data.artworkKey] = {version: data.version, url: data.url};
-      renderCurrent();
-      chosenFile = null;
-      fileInput.value = '';
-      drop.classList.remove('has-preview');
-      preview.removeAttribute('src');
-      setStatus(`发布成功：${data.artworkKey} → v${data.version} · ${data.outputWidth}×${data.outputHeight} WebP · ${(data.outputBytes/1024).toFixed(0)} KB`, 'ok');
-    } catch (err) {
-      setStatus(err.message, 'error');
-    } finally {
-      publish.disabled = !chosenFile || !manifest;
-    }
-  });
-
-  loadState();
+  Promise.all([loadCatalog(),loadHero()]).then(renderHeroKeys);
 </script>
 </body>
 </html>

--- a/scripts/deploy-hero-admin.sh
+++ b/scripts/deploy-hero-admin.sh
@@ -13,6 +13,8 @@ CONTAINER="ev-charge-book-hero-admin"
 ENV_FILE="${ROOT}/hero-admin.env"
 MANIFEST="${ROOT}/release-meta/hero-assets-v1.json"
 SEED_MANIFEST="${STAGING_ROOT}/hero-assets/manifest-v1.json"
+CATALOG="${ROOT}/release-meta/vehicle-catalog-v1.json"
+SEED_CATALOG="${STAGING_ROOT}/vehicle-catalog/catalog-v1.json"
 
 log() {
   printf '[hero-admin-deploy] %s\n' "$*"
@@ -27,6 +29,7 @@ require_file() {
 
 require_file "${IMAGE_ARCHIVE}"
 require_file "${SEED_MANIFEST}"
+require_file "${SEED_CATALOG}"
 require_file "${NGINX_CONF}"
 
 docker network inspect "${NETWORK}" >/dev/null
@@ -51,6 +54,12 @@ if [ ! -f "${MANIFEST}" ]; then
   log "Seeding runtime Hero manifest"
   cp "${SEED_MANIFEST}" "${MANIFEST}"
   chmod 644 "${MANIFEST}"
+fi
+
+if [ ! -f "${CATALOG}" ]; then
+  log "Seeding runtime vehicle catalog"
+  cp "${SEED_CATALOG}" "${CATALOG}"
+  chmod 644 "${CATALOG}"
 fi
 
 log "Loading prebuilt Hero Admin image"
@@ -100,29 +109,20 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text(encoding="utf-8")
-
 if "# BEGIN EV CHARGE BOOK HERO ADMIN" in text:
     raise SystemExit(0)
-
 markers = [
     "        # =============================\n        # Frontend SPA",
     "        location / {",
 ]
-index = -1
-for marker in markers:
-    index = text.find(marker)
-    if index >= 0:
-        break
-
+index = next((text.find(marker) for marker in markers if text.find(marker) >= 0), -1)
 if index < 0:
     raise SystemExit("Could not locate Frontend SPA insertion point in nginx.conf")
-
 block = r'''        # BEGIN EV CHARGE BOOK HERO ADMIN
         # Mutable runtime Hero manifest. Never cache this pointer as immutable.
         location = /ev-charge-book/release-meta/hero-assets-v1.json {
             alias /opt/ev-charge-book/release-meta/hero-assets-v1.json;
             default_type application/json;
-
             add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
             add_header Pragma "no-cache" always;
             expires -1;
@@ -134,7 +134,6 @@ block = r'''        # BEGIN EV CHARGE BOOK HERO ADMIN
 
         location ^~ /ev-charge-book/hero-admin/ {
             client_max_body_size 12m;
-
             proxy_pass http://ev-charge-book-hero-admin:8080/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -142,17 +141,14 @@ block = r'''        # BEGIN EV CHARGE BOOK HERO ADMIN
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header Authorization $http_authorization;
-
             proxy_connect_timeout 10s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
-
             add_header Cache-Control "no-store" always;
         }
         # END EV CHARGE BOOK HERO ADMIN
 
 '''
-
 path.write_text(text[:index] + block + text[index:], encoding="utf-8")
 PY
 
@@ -162,25 +158,72 @@ PY
     docker exec "${NGINX_CONTAINER}" nginx -t || true
     exit 1
   fi
-
-  docker exec "${NGINX_CONTAINER}" nginx -s reload
 else
   log "Nginx Hero Admin routes already installed"
-  docker exec "${NGINX_CONTAINER}" nginx -t
-  docker exec "${NGINX_CONTAINER}" nginx -s reload
 fi
 
-log "Verifying local runtime manifest"
-python3 - "${MANIFEST}" <<'PY'
+CATALOG_MARKER="# BEGIN EV CHARGE BOOK VEHICLE CATALOG"
+if ! grep -Fq "${CATALOG_MARKER}" "${NGINX_CONF}"; then
+  log "Installing Nginx vehicle catalog route"
+  backup="${NGINX_CONF}.vehicle-catalog.$(date +%Y%m%d%H%M%S).bak"
+  cp "${NGINX_CONF}" "${backup}"
+  python3 - "${NGINX_CONF}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if "# BEGIN EV CHARGE BOOK VEHICLE CATALOG" in text:
+    raise SystemExit(0)
+marker = "        # BEGIN EV CHARGE BOOK HERO ADMIN"
+index = text.find(marker)
+if index < 0:
+    markers = ["        # =============================\n        # Frontend SPA", "        location / {"]
+    index = next((text.find(item) for item in markers if text.find(item) >= 0), -1)
+if index < 0:
+    raise SystemExit("Could not locate Nginx insertion point for vehicle catalog")
+block = r'''        # BEGIN EV CHARGE BOOK VEHICLE CATALOG
+        # Mutable remote catalog pointer. Android persists a local Room copy for offline use.
+        location = /ev-charge-book/release-meta/vehicle-catalog-v1.json {
+            alias /opt/ev-charge-book/release-meta/vehicle-catalog-v1.json;
+            default_type application/json;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+            add_header Pragma "no-cache" always;
+            expires -1;
+        }
+        # END EV CHARGE BOOK VEHICLE CATALOG
+
+'''
+path.write_text(text[:index] + block + text[index:], encoding="utf-8")
+PY
+
+  if ! docker exec "${NGINX_CONTAINER}" nginx -t; then
+    log "Nginx validation failed; restoring ${backup}"
+    cp "${backup}" "${NGINX_CONF}"
+    docker exec "${NGINX_CONTAINER}" nginx -t || true
+    exit 1
+  fi
+else
+  log "Nginx vehicle catalog route already installed"
+fi
+
+docker exec "${NGINX_CONTAINER}" nginx -t
+docker exec "${NGINX_CONTAINER}" nginx -s reload
+
+log "Verifying local runtime manifests"
+python3 - "${MANIFEST}" "${CATALOG}" <<'PY'
 import json
 from pathlib import Path
 import sys
 
 manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
 assert manifest.get("schemaVersion") == 1
-artworks = manifest.get("artworks")
-assert isinstance(artworks, dict) and artworks
+assert isinstance(manifest.get("artworks"), dict) and manifest["artworks"]
+
+catalog = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+assert catalog.get("schemaVersion") == 1
+assert isinstance(catalog.get("vehicles"), list) and catalog["vehicles"]
 PY
 
-log "Hero Admin deployment complete"
+log "EV Charge Book admin deployment complete"
 log "Credentials are stored only in ${ENV_FILE}"

--- a/vehicle-catalog/catalog-v1.json
+++ b/vehicle-catalog/catalog-v1.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "catalogVersion": 1,
+  "updatedAtEpochMillis": 0,
+  "vehicles": [
+    {
+      "catalogId": "leap-c16-2026-reev-67",
+      "source": "managed-v1",
+      "brand": "零跑",
+      "series": "C16",
+      "modelName": "C16 2026款",
+      "modelYear": 2026,
+      "trimName": "增程版",
+      "powertrainType": "REEV",
+      "batteryCapacityKwh": 67.7,
+      "rangeKm": 520,
+      "heroArtworkKey": "leapmotor-c16-2026",
+      "isActive": true,
+      "sourceUpdatedAtEpochMillis": 0
+    },
+    {
+      "catalogId": "xiaomi-su7-2024-max",
+      "source": "managed-v1",
+      "brand": "小米",
+      "series": "SU7",
+      "modelName": "SU7 2024款",
+      "modelYear": 2024,
+      "trimName": "Max",
+      "powertrainType": "BEV",
+      "batteryCapacityKwh": 101.0,
+      "rangeKm": 800,
+      "heroArtworkKey": "xiaomi-su7-2024",
+      "isActive": true,
+      "sourceUpdatedAtEpochMillis": 0
+    },
+    {
+      "catalogId": "tesla-model-y-2025-long-range",
+      "source": "managed-v1",
+      "brand": "特斯拉",
+      "series": "Model Y",
+      "modelName": "Model Y 2025款",
+      "modelYear": 2025,
+      "trimName": "长续航全轮驱动",
+      "powertrainType": "BEV",
+      "batteryCapacityKwh": 78.4,
+      "rangeKm": 719,
+      "heroArtworkKey": null,
+      "isActive": true,
+      "sourceUpdatedAtEpochMillis": 0
+    },
+    {
+      "catalogId": "byd-seal-2025-650",
+      "source": "managed-v1",
+      "brand": "比亚迪",
+      "series": "海豹",
+      "modelName": "海豹 2025款",
+      "modelYear": 2025,
+      "trimName": "650 长续航",
+      "powertrainType": "BEV",
+      "batteryCapacityKwh": 80.6,
+      "rangeKm": 650,
+      "heroArtworkKey": "byd-seal-2025",
+      "isActive": true,
+      "sourceUpdatedAtEpochMillis": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extend the existing protected EV resource admin so vehicle catalog maintenance lives beside Hero publishing.

## Admin UX

- add `车型库` and `Hero 图片` tabs to the same protected page
- add/edit catalog vehicles from the browser
- retire/restore catalog entries instead of destructive deletion
- keep `catalogId` immutable once created
- bind an optional `heroArtworkKey` to each catalog item
- allow publishing a brand-new Hero key from the same page (starts at v1)

## Runtime catalog

Add a small server-managed catalog document:

`https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json`

The seed includes the existing bundled catalog entries plus Hero-key relationships. The server increments `catalogVersion` on each mutation and writes the document atomically with a backup.

## Safety semantics

"删除车型" is implemented as `isActive=false` (下架), not physical removal. This prevents new selection while preserving stable catalog identity and any existing UserVehicle/history references. Retired items can be restored.

This PR only establishes the server/admin side. Android offline-first sync will be a follow-up after this endpoint is deployed and verified; the app remains on its existing local catalog in the meantime.

## CI / deployment

- E2E test covers create -> retire -> restore catalog lifecycle
- E2E test proves a new Hero key can be published at v1
- production deployment seeds the catalog only when absent
- Nginx exposes the catalog JSON as no-cache mutable metadata
- public deployment verification checks both Hero and vehicle catalog JSON
