### PR TITLE
feat(android): sync vehicle catalog with offline-first local fallback

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,8 @@ val updateManifestUrl = System.getenv("APP_UPDATE_MANIFEST_URL")
     ?: "https://groupim.cn/ev-charge-book/release-meta/latest.json"
 val heroArtworkManifestUrl = System.getenv("HERO_ARTWORK_MANIFEST_URL")
     ?: "https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
+val vehicleCatalogUrl = System.getenv("VEHICLE_CATALOG_URL")
+    ?: "https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json"
 
 android {
     namespace = "com.evchargebook"
@@ -31,6 +33,7 @@ android {
         versionName = System.getenv("APP_VERSION_NAME") ?: "0.1.0-dev"
         buildConfigField("String", "UPDATE_MANIFEST_URL", "\"$updateManifestUrl\"")
         buildConfigField("String", "HERO_ARTWORK_MANIFEST_URL", "\"$heroArtworkManifestUrl\"")
+        buildConfigField("String", "VEHICLE_CATALOG_URL", "\"$vehicleCatalogUrl\"")
     }
 
     signingConfigs {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -93,4 +93,5 @@ dependencies {
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20240303")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <application
+        android:name=".EvChargeBookApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="EV Charge Book"

--- a/android/app/src/main/assets/vehicle_catalog.json
+++ b/android/app/src/main/assets/vehicle_catalog.json
@@ -1,6 +1,6 @@
 [
-  {"catalogId":"leap-c16-2026-reev-67","source":"bundled-v1","brand":"零跑","series":"C16","modelName":"C16 2026款","modelYear":2026,"trimName":"增程版","powertrainType":"REEV","batteryCapacityKwh":67.7,"rangeKm":520},
-  {"catalogId":"xiaomi-su7-2024-max","source":"bundled-v1","brand":"小米","series":"SU7","modelName":"SU7 2024款","modelYear":2024,"trimName":"Max","powertrainType":"BEV","batteryCapacityKwh":101.0,"rangeKm":800},
-  {"catalogId":"tesla-model-y-2025-long-range","source":"bundled-v1","brand":"特斯拉","series":"Model Y","modelName":"Model Y 2025款","modelYear":2025,"trimName":"长续航全轮驱动","powertrainType":"BEV","batteryCapacityKwh":78.4,"rangeKm":719},
-  {"catalogId":"byd-seal-2025-650","source":"bundled-v1","brand":"比亚迪","series":"海豹","modelName":"海豹 2025款","modelYear":2025,"trimName":"650 长续航","powertrainType":"BEV","batteryCapacityKwh":80.6,"rangeKm":650}
+  {"catalogId":"leap-c16-2026-reev-67","source":"bundled-v1","brand":"零跑","series":"C16","modelName":"C16 2026款","modelYear":2026,"trimName":"增程版","powertrainType":"REEV","batteryCapacityKwh":67.7,"rangeKm":520,"heroArtworkKey":"leapmotor-c16-2026","isActive":true},
+  {"catalogId":"xiaomi-su7-2024-max","source":"bundled-v1","brand":"小米","series":"SU7","modelName":"SU7 2024款","modelYear":2024,"trimName":"Max","powertrainType":"BEV","batteryCapacityKwh":101.0,"rangeKm":800,"heroArtworkKey":"xiaomi-su7-2024","isActive":true},
+  {"catalogId":"tesla-model-y-2025-long-range","source":"bundled-v1","brand":"特斯拉","series":"Model Y","modelName":"Model Y 2025款","modelYear":2025,"trimName":"长续航全轮驱动","powertrainType":"BEV","batteryCapacityKwh":78.4,"rangeKm":719,"heroArtworkKey":null,"isActive":true},
+  {"catalogId":"byd-seal-2025-650","source":"bundled-v1","brand":"比亚迪","series":"海豹","modelName":"海豹 2025款","modelYear":2025,"trimName":"650 长续航","powertrainType":"BEV","batteryCapacityKwh":80.6,"rangeKm":650,"heroArtworkKey":"byd-seal-2025","isActive":true}
 ]

--- a/android/app/src/main/java/com/evchargebook/EvChargeBookApplication.kt
+++ b/android/app/src/main/java/com/evchargebook/EvChargeBookApplication.kt
@@ -1,0 +1,25 @@
+package com.evchargebook
+
+import android.app.Application
+import com.evchargebook.data.database.AppDatabase
+import com.evchargebook.data.repository.VehicleCatalogSync
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class EvChargeBookApplication : Application() {
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        applicationScope.launch {
+            // Catalog networking is best-effort metadata refresh only. A timeout, malformed response,
+            // DNS failure or server outage must never block or fail normal local app startup.
+            runCatching {
+                VehicleCatalogSync(AppDatabase.getInstance(this@EvChargeBookApplication))
+                    .refresh(BuildConfig.VEHICLE_CATALOG_URL)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
@@ -12,6 +12,9 @@ interface VehicleCatalogDao {
     @Query("SELECT * FROM vehicle_catalog ORDER BY brand, series, modelYear DESC, trimName")
     fun observeAll(): Flow<List<VehicleCatalogEntity>>
 
+    @Query("SELECT heroArtworkKey FROM vehicle_catalog WHERE catalogId = :catalogId LIMIT 1")
+    fun observeHeroArtworkKey(catalogId: String): Flow<String?>
+
     @Query("SELECT COUNT(*) FROM vehicle_catalog")
     suspend fun count(): Int
 

--- a/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
@@ -18,6 +18,10 @@ interface VehicleCatalogDao {
     @Query("UPDATE vehicle_catalog SET isActive = 0 WHERE source = 'managed-v1'")
     suspend fun deactivateManagedEntries()
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    // The APK seed is a fallback only. It must never overwrite a row refreshed from the server.
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertAll(items: List<VehicleCatalogEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertManaged(items: List<VehicleCatalogEntity>)
 }

--- a/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/VehicleCatalogDao.kt
@@ -12,6 +12,12 @@ interface VehicleCatalogDao {
     @Query("SELECT * FROM vehicle_catalog ORDER BY brand, series, modelYear DESC, trimName")
     fun observeAll(): Flow<List<VehicleCatalogEntity>>
 
+    @Query("SELECT COUNT(*) FROM vehicle_catalog")
+    suspend fun count(): Int
+
+    @Query("UPDATE vehicle_catalog SET isActive = 0 WHERE source = 'managed-v1'")
+    suspend fun deactivateManagedEntries()
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(items: List<VehicleCatalogEntity>)
 }

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -29,7 +29,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
         TripDiagnosticEventEntity::class,
         VehicleStateEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -151,6 +151,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE vehicle_catalog ADD COLUMN heroArtworkKey TEXT")
+                db.execSQL("ALTER TABLE vehicle_catalog ADD COLUMN isActive INTEGER NOT NULL DEFAULT 1")
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -170,7 +177,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_6_7,
                         MIGRATION_7_8,
                         MIGRATION_8_9,
-                        MIGRATION_9_10
+                        MIGRATION_9_10,
+                        MIGRATION_10_11
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/entity/VehicleCatalogEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/VehicleCatalogEntity.kt
@@ -15,5 +15,7 @@ data class VehicleCatalogEntity(
     val powertrainType: String,
     val batteryCapacityKwh: Double? = null,
     val rangeKm: Int? = null,
+    val heroArtworkKey: String? = null,
+    val isActive: Boolean = true,
     val sourceUpdatedAtEpochMillis: Long = 0L
 )

--- a/android/app/src/main/java/com/evchargebook/data/repository/VehicleCatalogSync.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/VehicleCatalogSync.kt
@@ -1,0 +1,111 @@
+package com.evchargebook.data.repository
+
+import androidx.room.withTransaction
+import com.evchargebook.data.database.AppDatabase
+import com.evchargebook.data.entity.VehicleCatalogEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+internal object VehicleCatalogRemoteParser {
+    private val powertrainTypes = setOf("BEV", "PHEV", "REEV")
+
+    fun parse(json: String): List<VehicleCatalogEntity> {
+        val root = JSONObject(json)
+        require(root.optInt("schemaVersion", -1) == 1) { "unsupported vehicle catalog schema" }
+        val array = root.optJSONArray("vehicles") ?: error("vehicle catalog has no vehicles")
+        require(array.length() > 0) { "vehicle catalog must not be empty" }
+
+        val seen = mutableSetOf<String>()
+        return List(array.length()) { index ->
+            val item = array.getJSONObject(index)
+            val catalogId = item.getString("catalogId").trim().lowercase()
+            require(catalogId.matches(Regex("^[a-z0-9][a-z0-9-]{1,100}$"))) { "invalid catalogId" }
+            require(seen.add(catalogId)) { "duplicate catalogId" }
+
+            val brand = item.getString("brand").trim()
+            val series = item.getString("series").trim()
+            val modelName = item.getString("modelName").trim()
+            val powertrainType = item.getString("powertrainType").trim().uppercase()
+            require(brand.isNotEmpty() && series.isNotEmpty() && modelName.isNotEmpty()) { "blank catalog text" }
+            require(powertrainType in powertrainTypes) { "invalid powertrain type" }
+
+            val modelYear = optionalPositiveInt(item, "modelYear")
+            if (modelYear != null) require(modelYear in 1990..2100) { "invalid model year" }
+            val battery = optionalPositiveDouble(item, "batteryCapacityKwh")
+            val range = optionalPositiveInt(item, "rangeKm")
+            val heroKey = item.optString("heroArtworkKey")
+                .trim()
+                .lowercase()
+                .takeIf { it.isNotEmpty() }
+            if (heroKey != null) {
+                require(heroKey.matches(Regex("^[a-z0-9][a-z0-9-]{1,100}$"))) { "invalid Hero key" }
+            }
+
+            VehicleCatalogEntity(
+                catalogId = catalogId,
+                source = "managed-v1",
+                brand = brand,
+                series = series,
+                modelName = modelName,
+                modelYear = modelYear,
+                trimName = item.optString("trimName").trim().takeIf { it.isNotEmpty() },
+                powertrainType = powertrainType,
+                batteryCapacityKwh = battery,
+                rangeKm = range,
+                heroArtworkKey = heroKey,
+                isActive = if (item.has("isActive")) item.getBoolean("isActive") else true,
+                sourceUpdatedAtEpochMillis = item.optLong("sourceUpdatedAtEpochMillis", 0L)
+            )
+        }
+    }
+
+    private fun optionalPositiveInt(item: JSONObject, key: String): Int? {
+        if (!item.has(key) || item.isNull(key)) return null
+        return item.getInt(key).also { require(it > 0) { "$key must be positive" } }
+    }
+
+    private fun optionalPositiveDouble(item: JSONObject, key: String): Double? {
+        if (!item.has(key) || item.isNull(key)) return null
+        return item.getDouble(key).also { require(it.isFinite() && it > 0.0) { "$key must be positive" } }
+    }
+}
+
+class VehicleCatalogSync(private val database: AppDatabase) {
+    private val dao = database.vehicleCatalogDao()
+
+    suspend fun refresh(url: String): Boolean {
+        val json = fetch(url) ?: return false
+        val items = runCatching { VehicleCatalogRemoteParser.parse(json) }.getOrNull() ?: return false
+        if (items.isEmpty()) return false
+
+        database.withTransaction {
+            // A successful, fully parsed document is authoritative only for previously managed rows.
+            // Bundled/local fallback rows are never removed by a failed or partial network response.
+            dao.deactivateManagedEntries()
+            dao.insertAll(items)
+        }
+        return true
+    }
+
+    private suspend fun fetch(url: String): String? = withContext(Dispatchers.IO) {
+        if (!url.startsWith("https://")) return@withContext null
+        runCatching {
+            val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = 3_000
+                readTimeout = 4_000
+                setRequestProperty("Accept", "application/json")
+                useCaches = false
+            }
+            try {
+                if (connection.responseCode !in 200..299) return@runCatching null
+                connection.inputStream.bufferedReader().use { it.readText() }
+            } finally {
+                connection.disconnect()
+            }
+        }.getOrNull()
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/data/repository/VehicleCatalogSync.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/VehicleCatalogSync.kt
@@ -82,10 +82,10 @@ class VehicleCatalogSync(private val database: AppDatabase) {
         if (items.isEmpty()) return false
 
         database.withTransaction {
-            // A successful, fully parsed document is authoritative only for previously managed rows.
-            // Bundled/local fallback rows are never removed by a failed or partial network response.
+            // Only a complete, valid remote document may change the local catalog.
+            // Previously managed rows missing from the new document become inactive, never deleted.
             dao.deactivateManagedEntries()
-            dao.insertAll(items)
+            dao.upsertManaged(items)
         }
         return true
     }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,12 +48,14 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.LocalCockpitColors
 import com.evchargebook.ui.vehicle.HeroArtworkManifestRepository
 import com.evchargebook.ui.vehicle.OfficialVehicleImageCatalog
+import kotlinx.coroutines.flow.flowOf
 import java.util.Locale
 
 private const val VEHICLE_ARTWORK_TAG = "VehicleArtwork"
@@ -69,6 +72,17 @@ fun HeroVehicleCard(
     artworkKey: String? = null
 ) {
     val cockpit = LocalCockpitColors.current
+    val context = LocalContext.current
+    val catalogId = vehicle?.catalogVehicleId?.trim()?.takeIf { it.isNotEmpty() }
+    val localArtworkKey by remember(catalogId, context.applicationContext) {
+        catalogId?.let {
+            AppDatabase.getInstance(context.applicationContext)
+                .vehicleCatalogDao()
+                .observeHeroArtworkKey(it)
+        } ?: flowOf(null)
+    }.collectAsState(initial = null)
+    val effectiveArtworkKey = artworkKey?.trim()?.takeIf { it.isNotEmpty() } ?: localArtworkKey
+
     val selectableVehicles = if (vehicles.isNotEmpty()) vehicles else listOfNotNull(vehicle)
     val canSwitchVehicle = vehicleSwitchEnabled && selectableVehicles.size > 1
     var vehicleMenuExpanded by remember { mutableStateOf(false) }
@@ -84,7 +98,7 @@ fun HeroVehicleCard(
                     .fillMaxWidth()
                     .aspectRatio(1.46f)
             ) {
-                VehicleStage(vehicle, artworkKey, Modifier.fillMaxSize())
+                VehicleStage(vehicle, effectiveArtworkKey, Modifier.fillMaxSize())
                 Box(
                     Modifier
                         .fillMaxSize()

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -65,7 +65,8 @@ fun HeroVehicleCard(
     latestTrip: TripSessionEntity? = null,
     vehicles: List<VehicleEntity> = emptyList(),
     vehicleSwitchEnabled: Boolean = true,
-    onSelectVehicle: (Long) -> Unit = {}
+    onSelectVehicle: (Long) -> Unit = {},
+    artworkKey: String? = null
 ) {
     val cockpit = LocalCockpitColors.current
     val selectableVehicles = if (vehicles.isNotEmpty()) vehicles else listOfNotNull(vehicle)
@@ -83,7 +84,7 @@ fun HeroVehicleCard(
                     .fillMaxWidth()
                     .aspectRatio(1.46f)
             ) {
-                VehicleStage(vehicle, Modifier.fillMaxSize())
+                VehicleStage(vehicle, artworkKey, Modifier.fillMaxSize())
                 Box(
                     Modifier
                         .fillMaxSize()
@@ -194,9 +195,13 @@ fun HeroVehicleCard(
 }
 
 @Composable
-private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier) {
+private fun VehicleStage(
+    vehicle: VehicleEntity?,
+    artworkKey: String? = null,
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
-    val artwork = OfficialVehicleImageCatalog.resolve(vehicle)
+    val artwork = OfficialVehicleImageCatalog.resolve(vehicle, artworkKey)
     var remoteArtwork by remember(artwork?.key) {
         mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null)
     }
@@ -208,7 +213,7 @@ private fun VehicleStage(vehicle: VehicleEntity?, modifier: Modifier = Modifier)
     val imageUrl = remoteArtwork?.url ?: artwork?.remoteFallbackUrl
     val cacheVersion = remoteArtwork?.version ?: 0
 
-    remember(vehicle?.catalogVehicleId, vehicle?.brand, vehicle?.model, artwork?.key, imageUrl) {
+    remember(vehicle?.catalogVehicleId, vehicle?.brand, vehicle?.model, artworkKey, artwork?.key, imageUrl) {
         Log.d(
             VEHICLE_ARTWORK_TAG,
             "vehicle=${vehicle?.brand}/${vehicle?.model} catalog=${vehicle?.catalogVehicleId} artwork=${artwork?.key} remote=${imageUrl != null}"

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/OfficialVehicleImageCatalog.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/OfficialVehicleImageCatalog.kt
@@ -4,7 +4,7 @@ import com.evchargebook.data.entity.VehicleEntity
 
 data class OfficialVehicleImage(
     val key: String,
-    val remoteFallbackUrl: String,
+    val remoteFallbackUrl: String?,
     val sourceLabel: String
 )
 
@@ -18,38 +18,25 @@ object OfficialVehicleImageCatalog {
         sourceLabel = label
     )
 
-    private val bydSeal = remote(
-        key = "byd-seal-2025",
-        fileName = "byd_seal_2025.webp",
-        label = "BYD Seal remote hero artwork"
-    )
-    private val leapmotorC16 = remote(
-        key = "leapmotor-c16-2026",
-        fileName = "leapmotor_c16_2026.webp",
-        label = "Leapmotor C16 remote hero artwork"
-    )
-    private val xiaomiSu7 = remote(
-        key = "xiaomi-su7-2024",
-        fileName = "xiaomi_su7_2024.webp",
-        label = "Xiaomi SU7 remote hero artwork"
-    )
-    private val xiaomiSu7Ultra = remote(
-        key = "xiaomi-su7-ultra-2024",
-        fileName = "xiaomi_su7_ultra_2024.webp",
-        label = "Xiaomi SU7 Ultra remote hero artwork"
-    )
-    private val xiaomiYu7 = remote(
-        key = "xiaomi-yu7-2025",
-        fileName = "xiaomi_yu7_2025.webp",
-        label = "Xiaomi YU7 remote hero artwork"
-    )
-    private val teslaModel3 = remote(
-        key = "tesla-model-3",
-        fileName = "tesla_model_3.webp",
-        label = "Tesla Model 3 remote hero artwork"
-    )
+    private val bydSeal = remote("byd-seal-2025", "byd_seal_2025.webp", "BYD Seal remote hero artwork")
+    private val leapmotorC16 = remote("leapmotor-c16-2026", "leapmotor_c16_2026.webp", "Leapmotor C16 remote hero artwork")
+    private val xiaomiSu7 = remote("xiaomi-su7-2024", "xiaomi_su7_2024.webp", "Xiaomi SU7 remote hero artwork")
+    private val xiaomiSu7Ultra = remote("xiaomi-su7-ultra-2024", "xiaomi_su7_ultra_2024.webp", "Xiaomi SU7 Ultra remote hero artwork")
+    private val xiaomiYu7 = remote("xiaomi-yu7-2025", "xiaomi_yu7_2025.webp", "Xiaomi YU7 remote hero artwork")
+    private val teslaModel3 = remote("tesla-model-3", "tesla_model_3.webp", "Tesla Model 3 remote hero artwork")
 
-    fun resolve(vehicle: VehicleEntity?): OfficialVehicleImage? {
+    private val knownByKey = listOf(bydSeal, leapmotorC16, xiaomiSu7, xiaomiSu7Ultra, xiaomiYu7, teslaModel3)
+        .associateBy { it.key }
+
+    fun resolve(vehicle: VehicleEntity?, preferredArtworkKey: String? = null): OfficialVehicleImage? {
+        preferredArtworkKey?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }?.let { key ->
+            return knownByKey[key] ?: OfficialVehicleImage(
+                key = key,
+                remoteFallbackUrl = null,
+                sourceLabel = "Managed vehicle catalog Hero artwork"
+            )
+        }
+
         vehicle ?: return null
         when (vehicle.catalogVehicleId?.trim()?.lowercase()) {
             "byd-seal-2025-650" -> return bydSeal

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
@@ -34,9 +34,10 @@ fun VehicleCatalogScreen(
     onBack: () -> Unit
 ) {
     var query by remember { mutableStateOf("") }
-    val filtered = remember(items, query) {
+    val activeItems = remember(items) { items.filter { it.isActive } }
+    val filtered = remember(activeItems, query) {
         val keyword = query.trim()
-        if (keyword.isBlank()) items else items.filter {
+        if (keyword.isBlank()) activeItems else activeItems.filter {
             "${it.brand} ${it.series} ${it.modelName} ${it.trimName.orEmpty()}".contains(keyword, ignoreCase = true)
         }
     }
@@ -81,7 +82,7 @@ fun VehicleCatalogScreen(
                             Text("VEHICLE / FIND", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
                         }
                         Text("找到你的车型", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                        Text("优先选择车型库，电池容量和标称续航会自动带入。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("车型库保存在本机；有网络时会后台刷新，没有网络也可以正常使用。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         OutlinedTextField(
                             value = query,
                             onValueChange = { query = it },
@@ -91,7 +92,7 @@ fun VehicleCatalogScreen(
                             singleLine = true
                         )
                         Text(
-                            if (query.isBlank()) "车型库 ${items.size} 条" else "找到 ${filtered.size} 条结果",
+                            if (query.isBlank()) "车型库 ${activeItems.size} 条" else "找到 ${filtered.size} 条结果",
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -108,9 +109,7 @@ fun VehicleCatalogScreen(
                 }
             }
 
-            items(filtered, key = { it.catalogId }) { item ->
-                CatalogVehicleRow(item, onSelect)
-            }
+            items(filtered, key = { it.catalogId }) { item -> CatalogVehicleRow(item, onSelect) }
             item { Spacer(Modifier.height(16.dp)) }
         }
     }

--- a/android/app/src/test/java/com/evchargebook/data/repository/VehicleCatalogSyncTest.kt
+++ b/android/app/src/test/java/com/evchargebook/data/repository/VehicleCatalogSyncTest.kt
@@ -1,0 +1,92 @@
+package com.evchargebook.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class VehicleCatalogSyncTest {
+    @Test
+    fun `valid managed catalog parses local offline fields`() {
+        val json = """
+            {
+              "schemaVersion": 1,
+              "catalogVersion": 8,
+              "vehicles": [
+                {
+                  "catalogId": "example-ev-2026-long-range",
+                  "brand": "Example",
+                  "series": "EV",
+                  "modelName": "EV 2026",
+                  "modelYear": 2026,
+                  "trimName": "Long Range",
+                  "powertrainType": "BEV",
+                  "batteryCapacityKwh": 88.8,
+                  "rangeKm": 688,
+                  "heroArtworkKey": "example-ev-2026",
+                  "isActive": false,
+                  "sourceUpdatedAtEpochMillis": 123456
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val item = VehicleCatalogRemoteParser.parse(json).single()
+
+        assertEquals("example-ev-2026-long-range", item.catalogId)
+        assertEquals("managed-v1", item.source)
+        assertEquals("example-ev-2026", item.heroArtworkKey)
+        assertFalse(item.isActive)
+        assertEquals(88.8, item.batteryCapacityKwh!!, 0.001)
+        assertEquals(688, item.rangeKm)
+        assertEquals(123456L, item.sourceUpdatedAtEpochMillis)
+    }
+
+    @Test
+    fun `missing optional Hero key stays null`() {
+        val json = """
+            {
+              "schemaVersion": 1,
+              "vehicles": [
+                {
+                  "catalogId": "example-ev-2026",
+                  "brand": "Example",
+                  "series": "EV",
+                  "modelName": "EV 2026",
+                  "powertrainType": "BEV",
+                  "isActive": true
+                }
+              ]
+            }
+        """.trimIndent()
+
+        assertNull(VehicleCatalogRemoteParser.parse(json).single().heroArtworkKey)
+    }
+
+    @Test
+    fun `duplicate ids reject the whole remote document`() {
+        val json = """
+            {
+              "schemaVersion": 1,
+              "vehicles": [
+                {"catalogId":"same-id","brand":"A","series":"A","modelName":"A","powertrainType":"BEV"},
+                {"catalogId":"same-id","brand":"B","series":"B","modelName":"B","powertrainType":"BEV"}
+              ]
+            }
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            VehicleCatalogRemoteParser.parse(json)
+        }
+    }
+
+    @Test
+    fun `empty remote catalog is rejected so local Room data is not replaced`() {
+        val json = """{"schemaVersion":1,"vehicles":[]}"""
+
+        assertThrows(IllegalArgumentException::class.java) {
+            VehicleCatalogRemoteParser.parse(json)
+        }
+    }
+}

--- a/docs/VEHICLE_CATALOG_OFFLINE_SYNC.md
+++ b/docs/VEHICLE_CATALOG_OFFLINE_SYNC.md
@@ -1,0 +1,51 @@
+# Vehicle Catalog Remote Maintenance and Offline-First Runtime
+
+## Purpose
+
+EV Charge Book uses the network to **refresh reference vehicle metadata only**. The network is not an availability dependency for normal application use.
+
+Production catalog endpoint:
+
+`https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json`
+
+Protected management page:
+
+`https://groupim.cn/ev-charge-book/hero-admin/`
+
+## Authority model
+
+1. The APK ships a small `assets/vehicle_catalog.json` fallback so a first launch with no network still has usable catalog entries.
+2. Room `vehicle_catalog` is the runtime source shown by the app.
+3. On process start, a separate application-scope IO coroutine may attempt to refresh the managed catalog.
+4. The complete remote document is parsed and validated **before** any Room mutation.
+5. A timeout, DNS failure, HTTP failure, unsupported schema, malformed item, duplicate ID, or empty catalog leaves the existing Room data unchanged.
+6. A successful refresh upserts managed entries. Managed entries omitted from a later authoritative document are retired locally rather than deleted.
+7. The bundled seed uses conflict-ignore semantics and therefore cannot overwrite a row already refreshed from the server.
+
+## Offline guarantee
+
+Without a network connection, users must still be able to:
+
+- open the app and switch among existing local vehicles;
+- select catalog vehicles that were already stored locally;
+- use custom vehicle entry;
+- record, edit and view charging records;
+- start, resume and finish trips;
+- view statistics and vehicle state;
+- use the last successfully cached Hero artwork when Coil has it available.
+
+Catalog refresh never blocks `MainActivity`, `MainViewModel`, Room reads, or any business workflow.
+
+## Catalog lifecycle
+
+`catalogId` is a stable identity and must not be renamed after publication.
+
+The admin action labelled **下架** sets `isActive=false`; it does not physically delete the catalog row. Retired entries disappear from new-vehicle selection but may remain locally so an existing `UserVehicle.catalogVehicleId` continues to resolve metadata. The admin can restore an entry later.
+
+Most importantly, catalog updates never rewrite `VehicleEntity` values already copied into a user's vehicle. Battery capacity, range, brand/model edits and historical records remain user-owned snapshots unless the user explicitly edits their vehicle.
+
+## Hero relationship
+
+A catalog item may contain `heroArtworkKey`. The Hero UI observes this value from local Room by `catalogId`, then resolves the actual image URL through the independently versioned Hero manifest. This lets a newly managed vehicle receive a Hero without adding another hard-coded Android mapping.
+
+If a catalog item has no Hero key or the image cannot be downloaded, the app falls back to its existing generic/legacy vehicle presentation rather than failing the vehicle workflow.


### PR DESCRIPTION
## Summary

Connect Android to the managed vehicle catalog that is now live behind the protected EV resource admin, while preserving local-first operation.

## Offline-first behavior

- APK still ships a small `assets/vehicle_catalog.json` fallback
- Room `vehicle_catalog` is always the runtime source
- remote refresh runs independently in `Application` IO scope and never gates `MainActivity` / `MainViewModel`
- HTTPS fetch uses short connect/read timeouts
- the entire remote document must parse and validate before Room changes
- DNS/HTTP/timeout/schema/malformed/duplicate/empty failures leave local Room data untouched
- bundled seed now uses conflict-ignore semantics, so it cannot overwrite a previously synced row
- successful refresh upserts managed rows; previously managed rows omitted later are retired, not deleted
- catalog retirement only hides a model from new selection; existing user vehicles and history remain intact

## Managed Hero mapping

- persist `heroArtworkKey` and `isActive` in Room (schema 10 -> 11)
- Hero UI observes the current vehicle's Hero key from local Room
- arbitrary managed Hero keys resolve through the first-party Hero manifest
- legacy hard-coded mappings remain only as compatibility fallback

This means a vehicle added in the web admin can later appear in Android and use its Hero without adding a new hard-coded model mapping to the APK.

## Endpoint

`https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json`

The endpoint has already been deployed and production-verified by #120.

## Tests / docs

- add parser tests for valid managed fields, optional Hero key, duplicate IDs and empty documents
- document the authority model and explicit offline guarantees in `docs/VEHICLE_CATALOG_OFFLINE_SYNC.md`
