### PR TITLE
feat(admin): preview vehicle artwork and add PNG to WebP tool

### DIFF
--- a/.github/workflows/hero-admin.yml
+++ b/.github/workflows/hero-admin.yml
@@ -26,6 +26,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate admin browser script
+        shell: bash
+        run: |
+          set -eu
+          node <<'NODE'
+          const fs = require('fs');
+          const html = fs.readFileSync('hero-admin/templates/index.html', 'utf8');
+          const match = html.match(/<script>([\s\S]*?)<\/script>/);
+          if (!match) throw new Error('admin script block not found');
+          new Function(match[1]);
+          for (const marker of [
+            'data-tab="tools"',
+            'downloadRemoteArtwork',
+            'createImageBitmap',
+            "'image/webp'",
+            'Hero 1600×1100 居中裁切'
+          ]) {
+            if (!html.includes(marker)) throw new Error(`missing admin image-tool marker: ${marker}`);
+          }
+          NODE
+
       - name: Build admin container
         run: docker build -t ev-charge-book-hero-admin:test hero-admin
 

--- a/hero-admin/templates/index.html
+++ b/hero-admin/templates/index.html
@@ -6,17 +6,19 @@
   <title>EV Charge Book · Admin</title>
   <style>
     :root{color-scheme:dark;--bg:#050a08;--panel:#0b1512;--panel2:#07110d;--line:#1d2c27;--text:#f3f7f5;--muted:#94a39d;--green:#35ef84;--danger:#ff8d8d}
-    *{box-sizing:border-box} body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 50% -20%,#123127 0,#07110d 36%,var(--bg) 72%);color:var(--text);min-height:100vh}
-    main{width:min(1060px,calc(100% - 32px));margin:0 auto;padding:42px 0 72px} header{margin-bottom:20px}.eyebrow{color:var(--green);font-size:13px;letter-spacing:.16em;text-transform:uppercase}h1{font-size:clamp(30px,5vw,46px);margin:8px 0 8px;font-weight:650}.intro{color:var(--muted);margin:0;line-height:1.65;max-width:820px}
-    .tabs{display:flex;gap:8px;margin:24px 0 14px}.tab{min-width:auto;background:transparent;color:var(--muted);border:1px solid var(--line);padding:10px 16px}.tab.active{background:rgba(53,239,132,.10);color:var(--green);border-color:rgba(53,239,132,.32)}
+    *{box-sizing:border-box}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:radial-gradient(circle at 50% -20%,#123127 0,#07110d 36%,var(--bg) 72%);color:var(--text);min-height:100vh}
+    main{width:min(1120px,calc(100% - 32px));margin:0 auto;padding:42px 0 72px}header{margin-bottom:20px}.eyebrow{color:var(--green);font-size:13px;letter-spacing:.16em;text-transform:uppercase}h1{font-size:clamp(30px,5vw,46px);margin:8px 0 8px;font-weight:650}.intro{color:var(--muted);margin:0;line-height:1.65;max-width:860px}
+    .tabs{display:flex;gap:8px;margin:24px 0 14px;flex-wrap:wrap}.tab{min-width:auto;background:transparent;color:var(--muted);border:1px solid var(--line);padding:10px 16px}.tab.active{background:rgba(53,239,132,.10);color:var(--green);border-color:rgba(53,239,132,.32)}
     .panel{background:rgba(10,22,18,.86);border:1px solid rgba(255,255,255,.09);border-radius:24px;padding:20px;box-shadow:0 20px 70px rgba(0,0,0,.32);backdrop-filter:blur(18px)}.hidden{display:none!important}
-    button,input,select{font:inherit}button{border:0;border-radius:12px;padding:11px 17px;background:var(--green);color:#031108;font-weight:700;cursor:pointer}button.secondary{background:transparent;color:var(--text);border:1px solid var(--line)}button.danger{background:rgba(255,90,90,.08);color:var(--danger);border:1px solid rgba(255,90,90,.2)}button:disabled{opacity:.35;cursor:not-allowed}
-    input,select{width:100%;padding:11px 12px;background:var(--panel2);color:var(--text);border:1px solid var(--line);border-radius:12px;outline:none}label{display:block;color:#c5d0cc;font-size:13px;margin:0 0 7px}.toolbar{display:flex;gap:10px;align-items:center;margin-bottom:14px}.toolbar input{flex:1}.meta{color:var(--muted);font-size:12px;line-height:1.5}
-    .vehicle-list{display:grid;gap:8px}.vehicle-row{display:grid;grid-template-columns:minmax(230px,1.6fr) minmax(160px,1fr) minmax(150px,.8fr) auto;gap:12px;align-items:center;padding:13px 14px;background:var(--panel2);border:1px solid var(--line);border-radius:16px}.vehicle-row.retired{opacity:.55}.vehicle-title{font-weight:650}.vehicle-sub,.vehicle-facts{color:var(--muted);font-size:12px;margin-top:3px;line-height:1.45}.badge{display:inline-flex;border-radius:999px;padding:4px 8px;font-size:11px;background:rgba(53,239,132,.09);color:var(--green);margin-left:6px}.badge.off{background:rgba(255,255,255,.05);color:var(--muted)}.row-actions{display:flex;gap:6px}.row-actions button{padding:8px 10px;font-size:12px;min-width:auto}
+    button,input,select{font:inherit}button,.button-link{border:0;border-radius:12px;padding:11px 17px;background:var(--green);color:#031108;font-weight:700;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;justify-content:center}button.secondary,.button-link.secondary{background:transparent;color:var(--text);border:1px solid var(--line)}button.danger{background:rgba(255,90,90,.08);color:var(--danger);border:1px solid rgba(255,90,90,.2)}button:disabled{opacity:.35;cursor:not-allowed}
+    input,select{width:100%;padding:11px 12px;background:var(--panel2);color:var(--text);border:1px solid var(--line);border-radius:12px;outline:none}input[type="range"]{padding:0;border:0;background:transparent}label{display:block;color:#c5d0cc;font-size:13px;margin:0 0 7px}.toolbar{display:flex;gap:10px;align-items:center;margin-bottom:14px}.toolbar input{flex:1}.meta{color:var(--muted);font-size:12px;line-height:1.5}
+    .vehicle-list{display:grid;gap:8px}.vehicle-row{display:grid;grid-template-columns:minmax(230px,1.6fr) minmax(160px,1fr) minmax(150px,.8fr) auto;gap:12px;align-items:center;padding:13px 14px;background:var(--panel2);border:1px solid var(--line);border-radius:16px;cursor:pointer;transition:border-color .15s ease,background .15s ease}.vehicle-row:hover,.vehicle-row:focus-visible{border-color:rgba(53,239,132,.32);background:#0a1712;outline:none}.vehicle-row.retired{opacity:.58}.vehicle-title{font-weight:650}.vehicle-sub,.vehicle-facts{color:var(--muted);font-size:12px;margin-top:3px;line-height:1.45}.badge{display:inline-flex;border-radius:999px;padding:4px 8px;font-size:11px;background:rgba(53,239,132,.09);color:var(--green);margin-left:6px}.badge.off{background:rgba(255,255,255,.05);color:var(--muted)}.row-actions{display:flex;gap:6px}.row-actions button{padding:8px 10px;font-size:12px;min-width:auto}
     .grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}.current{margin-top:14px;display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.current-card{padding:12px;background:var(--panel2);border:1px solid var(--line);border-radius:12px;min-width:0}.current-card b{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:13px}.current-card span{color:var(--muted);font-size:11px}
-    .drop{min-height:250px;border:1px dashed #365148;border-radius:18px;display:flex;align-items:center;justify-content:center;text-align:center;padding:18px;position:relative;overflow:hidden;cursor:pointer;background:rgba(255,255,255,.015)}.drop.drag{border-color:var(--green);background:rgba(53,239,132,.05)}.drop input{position:absolute;inset:0;opacity:0;cursor:pointer}.drop img{width:100%;height:100%;max-height:300px;object-fit:contain;border-radius:14px;display:none}.drop.has-preview img{display:block}.drop.has-preview .placeholder{display:none}.placeholder strong{display:block;font-size:17px;margin-bottom:6px}.placeholder span{color:var(--muted);font-size:13px;line-height:1.6}.status{margin-top:14px;padding:12px 13px;border-radius:12px;background:var(--panel2);border:1px solid var(--line);color:var(--muted);min-height:44px;line-height:1.5}.status.ok{color:#b8f8d0;border-color:rgba(53,239,132,.28)}.status.error{color:#ffb5b5;border-color:rgba(255,90,90,.3)}.actions{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-top:16px}
-    dialog{width:min(680px,calc(100% - 28px));border:1px solid var(--line);border-radius:20px;background:#091310;color:var(--text);padding:0;box-shadow:0 30px 100px #000}dialog::backdrop{background:rgba(0,0,0,.68)}.dialog-body{padding:20px}.dialog-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:16px}.dialog-head h2{margin:0;font-size:22px}.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:13px}.wide{grid-column:1/-1}.dialog-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:18px}
-    @media(max-width:760px){main{padding-top:26px}.grid,.form-grid{grid-template-columns:1fr}.vehicle-row{grid-template-columns:1fr}.row-actions{justify-content:flex-end}.toolbar{flex-wrap:wrap}.toolbar input{flex-basis:100%}.current{grid-template-columns:1fr 1fr}.actions{align-items:flex-end}.panel{padding:15px}}
+    .drop{min-height:250px;border:1px dashed #365148;border-radius:18px;display:flex;align-items:center;justify-content:center;text-align:center;padding:18px;position:relative;overflow:hidden;cursor:pointer;background:rgba(255,255,255,.015)}.drop.drag{border-color:var(--green);background:rgba(53,239,132,.05)}.drop input[type="file"]{position:absolute;inset:0;opacity:0;cursor:pointer}.drop img{width:100%;height:100%;max-height:300px;object-fit:contain;border-radius:14px;display:none}.drop.has-preview img{display:block}.drop.has-preview .placeholder{display:none}.placeholder strong{display:block;font-size:17px;margin-bottom:6px}.placeholder span{color:var(--muted);font-size:13px;line-height:1.6}
+    .status{margin-top:14px;padding:12px 13px;border-radius:12px;background:var(--panel2);border:1px solid var(--line);color:var(--muted);min-height:44px;line-height:1.5}.status.ok{color:#b8f8d0;border-color:rgba(53,239,132,.28)}.status.error{color:#ffb5b5;border-color:rgba(255,90,90,.3)}.actions{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-top:16px}.action-group{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+    .tool-controls{display:grid;gap:16px}.tool-result{min-height:250px;border:1px solid var(--line);border-radius:18px;background:var(--panel2);display:flex;align-items:center;justify-content:center;overflow:hidden;padding:14px}.tool-result img{display:none;max-width:100%;max-height:300px;object-fit:contain;border-radius:12px}.tool-result.ready img{display:block}.tool-result.ready .empty-result{display:none}.empty-result{color:var(--muted);text-align:center;font-size:13px;line-height:1.6}.quality-row{display:flex;align-items:center;justify-content:space-between;gap:12px}.quality-row label{margin:0}.quality-value{color:var(--green);font-size:12px;font-weight:700}
+    dialog{width:min(680px,calc(100% - 28px));border:1px solid var(--line);border-radius:20px;background:#091310;color:var(--text);padding:0;box-shadow:0 30px 100px #000}dialog::backdrop{background:rgba(0,0,0,.68)}#artworkDialog{width:min(920px,calc(100% - 28px))}.dialog-body{padding:20px}.dialog-head{display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:16px}.dialog-head h2{margin:0;font-size:22px}.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:13px}.wide{grid-column:1/-1}.dialog-actions{display:flex;justify-content:flex-end;gap:8px;margin-top:18px;flex-wrap:wrap}.artwork-layout{display:grid;grid-template-columns:minmax(0,1.5fr) minmax(220px,.7fr);gap:16px}.artwork-frame{min-height:340px;border-radius:18px;background:#030806;border:1px solid var(--line);display:flex;align-items:center;justify-content:center;overflow:hidden}.artwork-frame img{width:100%;height:100%;max-height:560px;object-fit:contain}.artwork-side{display:flex;flex-direction:column;gap:12px}.artwork-info{padding:13px;background:var(--panel2);border:1px solid var(--line);border-radius:14px}.artwork-info b{display:block;font-size:14px;word-break:break-all}.artwork-info span{display:block;color:var(--muted);font-size:12px;margin-top:4px}
+    @media(max-width:760px){main{padding-top:26px}.grid,.form-grid,.artwork-layout{grid-template-columns:1fr}.vehicle-row{grid-template-columns:1fr}.row-actions{justify-content:flex-end}.toolbar{flex-wrap:wrap}.toolbar input{flex-basis:100%}.current{grid-template-columns:1fr 1fr}.actions{align-items:flex-end;flex-wrap:wrap}.panel{padding:15px}.artwork-frame{min-height:220px}}
   </style>
 </head>
 <body>
@@ -30,6 +32,7 @@
   <div class="tabs">
     <button class="tab active" data-tab="catalog">车型库</button>
     <button class="tab" data-tab="hero">Hero 图片</button>
+    <button class="tab" data-tab="tools">图片工具</button>
   </div>
 
   <section class="panel" id="catalogPanel">
@@ -66,6 +69,44 @@
       <button id="publishHero" disabled>发布 Hero</button>
     </div>
   </section>
+
+  <section class="panel hidden" id="toolsPanel">
+    <div class="grid">
+      <div>
+        <label>PNG 原图</label>
+        <div class="drop" id="convertDrop">
+          <input id="convertFile" type="file" accept="image/png,.png" />
+          <img id="convertInputPreview" alt="PNG preview" />
+          <div class="placeholder"><strong>拖 PNG 到这里</strong><span>转换完全在浏览器本地完成<br/>不会上传到服务器</span></div>
+        </div>
+      </div>
+      <div class="tool-controls">
+        <div>
+          <label for="convertMode">输出方式</label>
+          <select id="convertMode">
+            <option value="original">保持原尺寸</option>
+            <option value="hero">Hero 1600×1100 居中裁切</option>
+          </select>
+        </div>
+        <div>
+          <div class="quality-row"><label for="convertQuality">WebP 质量</label><span class="quality-value" id="qualityValue">90%</span></div>
+          <input id="convertQuality" type="range" min="0.70" max="1" step="0.01" value="0.90" />
+        </div>
+        <div class="tool-result" id="toolResult">
+          <img id="convertOutputPreview" alt="WebP preview" />
+          <div class="empty-result">转换完成后会在这里显示 WebP 预览、尺寸和文件大小。</div>
+        </div>
+      </div>
+    </div>
+    <div class="status" id="convertStatus">选择一个 PNG。这里仅做本地格式转换；正式 Hero 发布仍走「Hero 图片」页的服务器校验和版本化。</div>
+    <div class="actions">
+      <div class="meta">支持保持原尺寸，或直接准备符合 Hero 标准的 1600×1100 WebP。</div>
+      <div class="action-group">
+        <button id="downloadConverted" class="secondary" disabled>下载 WebP</button>
+        <button id="convertButton" disabled>转换为 WebP</button>
+      </div>
+    </div>
+  </section>
 </main>
 
 <dialog id="vehicleDialog">
@@ -85,27 +126,33 @@
   </form>
 </dialog>
 
+<dialog id="artworkDialog">
+  <div class="dialog-body">
+    <div class="dialog-head"><h2 id="artworkDialogTitle">车型图片</h2><button type="button" class="secondary" id="closeArtworkDialog">关闭</button></div>
+    <div id="artworkDialogContent"></div>
+  </div>
+</dialog>
+
 <script>
   const adminHeaders={'X-Hero-Admin-Request':'1','Content-Type':'application/json'};
-  let catalog=null, manifest=null, chosenFile=null, editingId=null;
+  let catalog=null,manifest=null,chosenFile=null,editingId=null,convertSourceFile=null,convertSourceUrl=null,convertedBlob=null,convertedUrl=null,convertedName=null;
   const $=id=>document.getElementById(id);
-  const esc=s=>String(s??'');
   function setStatus(el,text,kind=''){el.className='status'+(kind?' '+kind:'');el.textContent=text}
-  function switchTab(name){document.querySelectorAll('.tab').forEach(x=>x.classList.toggle('active',x.dataset.tab===name));$('catalogPanel').classList.toggle('hidden',name!=='catalog');$('heroPanel').classList.toggle('hidden',name!=='hero')}
+  function switchTab(name){const ids={catalog:'catalogPanel',hero:'heroPanel',tools:'toolsPanel'};document.querySelectorAll('.tab').forEach(x=>x.classList.toggle('active',x.dataset.tab===name));for(const [tab,id] of Object.entries(ids))$(id).classList.toggle('hidden',tab!==name)}
   document.querySelectorAll('.tab').forEach(x=>x.onclick=()=>switchTab(x.dataset.tab));
 
   async function loadCatalog(){
-    try{const r=await fetch('api/catalog/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取车型库失败');catalog=d;renderCatalog();setStatus($('catalogStatus'),`车型目录已加载 · v${d.catalogVersion} · App 将在有网络时后台同步，本地库始终可用。`,'ok')}catch(e){setStatus($('catalogStatus'),e.message,'error')}
+    try{const r=await fetch('api/catalog/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取车型库失败');catalog=d;renderCatalog();renderHeroKeys();setStatus($('catalogStatus'),`车型目录已加载 · v${d.catalogVersion} · App 将在有网络时后台同步，本地库始终可用。`,'ok')}catch(e){setStatus($('catalogStatus'),e.message,'error')}
   }
   function renderCatalog(){
     if(!catalog)return;const q=$('catalogSearch').value.trim().toLowerCase();const rows=catalog.vehicles.filter(v=>!q||`${v.catalogId} ${v.brand} ${v.series} ${v.modelName} ${v.trimName||''}`.toLowerCase().includes(q));
     $('catalogMeta').textContent=`${catalog.vehicles.filter(v=>v.isActive!==false).length} 在用 / ${catalog.vehicles.length} 总计`;$('vehicleList').innerHTML='';
     for(const v of rows){
-      const row=document.createElement('div');row.className='vehicle-row'+(v.isActive===false?' retired':'');
+      const row=document.createElement('div');row.className='vehicle-row'+(v.isActive===false?' retired':'');row.tabIndex=0;row.setAttribute('role','button');row.setAttribute('aria-label',`查看 ${v.brand} ${v.modelName} 图片`);row.onclick=e=>{if(!e.target.closest('button'))openArtwork(v)};row.onkeydown=e=>{if((e.key==='Enter'||e.key===' ')&&!e.target.closest('button')){e.preventDefault();openArtwork(v)}};
       const a=document.createElement('div');const title=document.createElement('div');title.className='vehicle-title';title.textContent=`${v.brand} ${v.modelName}`;const badge=document.createElement('span');badge.className='badge'+(v.isActive===false?' off':'');badge.textContent=v.isActive===false?'已下架':'在用';title.appendChild(badge);const sub=document.createElement('div');sub.className='vehicle-sub';sub.textContent=`${v.trimName||v.series} · ${v.powertrainType} · ${v.catalogId}`;a.append(title,sub);
       const b=document.createElement('div');b.className='vehicle-facts';b.textContent=`${v.batteryCapacityKwh??'--'} kWh · ${v.rangeKm??'--'} km`;
       const c=document.createElement('div');c.className='vehicle-facts';c.textContent=`Hero: ${v.heroArtworkKey||'未配置'}`;
-      const acts=document.createElement('div');acts.className='row-actions';const edit=document.createElement('button');edit.className='secondary';edit.textContent='编辑';edit.onclick=()=>openVehicle(v);const status=document.createElement('button');status.className=v.isActive===false?'secondary':'danger';status.textContent=v.isActive===false?'恢复':'下架';status.onclick=()=>setVehicleStatus(v,v.isActive===false);acts.append(edit,status);row.append(a,b,c,acts);$('vehicleList').appendChild(row)
+      const acts=document.createElement('div');acts.className='row-actions';const image=document.createElement('button');image.className='secondary';image.textContent='图片';image.onclick=e=>{e.stopPropagation();openArtwork(v)};const edit=document.createElement('button');edit.className='secondary';edit.textContent='编辑';edit.onclick=e=>{e.stopPropagation();openVehicle(v)};const status=document.createElement('button');status.className=v.isActive===false?'secondary':'danger';status.textContent=v.isActive===false?'恢复':'下架';status.onclick=e=>{e.stopPropagation();setVehicleStatus(v,v.isActive===false)};acts.append(image,edit,status);row.append(a,b,c,acts);$('vehicleList').appendChild(row)
     }
   }
   $('catalogSearch').oninput=renderCatalog;$('addVehicle').onclick=()=>openVehicle(null);
@@ -115,15 +162,31 @@
   async function setVehicleStatus(v,isActive){const verb=isActive?'恢复':'下架';if(!confirm(`${verb} ${v.brand} ${v.modelName}？\n\n已添加到用户本地的车辆和历史记录不会被删除。`))return;try{const r=await fetch('api/catalog/status',{method:'POST',headers:adminHeaders,body:JSON.stringify({catalogId:v.catalogId,isActive})});const d=await r.json();if(!r.ok)throw new Error(d.error||`${verb}失败`);await loadCatalog()}catch(e){setStatus($('catalogStatus'),e.message,'error')}}
 
   async function loadHero(){
-    try{const r=await fetch('api/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取 Hero 失败');manifest=d;renderHeroKeys();setStatus($('heroStatus'),'请选择或输入 Hero key，再拖入图片。新 key 会从 v1 开始。','ok')}catch(e){setStatus($('heroStatus'),e.message,'error')}
+    try{const r=await fetch('api/state');const d=await r.json();if(!r.ok)throw new Error(d.error||'读取 Hero 失败');manifest=d;renderHeroKeys();setStatus($('heroStatus'),'请选择或输入 Hero key，再拖入图片。新 key 会从 v1 开始。','ok');return true}catch(e){setStatus($('heroStatus'),e.message,'error');return false}
   }
   function renderHeroKeys(){const keys=new Set(Object.keys(manifest?.artworks||{}));for(const v of catalog?.vehicles||[])if(v.heroArtworkKey)keys.add(v.heroArtworkKey);$('heroKeys').innerHTML='';[...keys].sort().forEach(k=>{const o=document.createElement('option');o.value=k;$('heroKeys').appendChild(o)});renderHeroCurrent()}
   function renderHeroCurrent(){$('heroCurrent').innerHTML='';const key=$('artworkKey').value.trim().toLowerCase();const cur=manifest?.artworks?.[key];const values=[['当前版本',cur?`v${cur.version}`:'尚未发布'],['目标版本',`v${(cur?.version||0)+1}`],['规格','1600×1100']];for(const [n,v] of values){const c=document.createElement('div');c.className='current-card';const b=document.createElement('b');b.textContent=v;const s=document.createElement('span');s.textContent=n;c.append(b,s);$('heroCurrent').appendChild(c)}updatePublishEnabled()}
   $('artworkKey').oninput=renderHeroCurrent;
   function updatePublishEnabled(){$('publishHero').disabled=!(chosenFile&&/^[a-z0-9][a-z0-9-]{1,100}$/.test($('artworkKey').value.trim().toLowerCase()))}
   function selectFile(file){chosenFile=file||null;if(!chosenFile){$('drop').classList.remove('has-preview');$('preview').removeAttribute('src');updatePublishEnabled();return}if(!['image/png','image/webp'].includes(chosenFile.type)&&!/\.(png|webp)$/i.test(chosenFile.name)){chosenFile=null;setStatus($('heroStatus'),'只接受 PNG 或 WebP。','error');updatePublishEnabled();return}$('preview').src=URL.createObjectURL(chosenFile);$('drop').classList.add('has-preview');setStatus($('heroStatus'),`${chosenFile.name} · ${(chosenFile.size/1024).toFixed(0)} KB · 等待发布`,'ok');updatePublishEnabled()}
-  $('file').onchange=()=>selectFile($('file').files[0]);['dragenter','dragover'].forEach(t=>$('drop').addEventListener(t,e=>{e.preventDefault();$('drop').classList.add('drag')}));['dragleave','drop'].forEach(t=>$('drop').addEventListener(t,e=>{e.preventDefault();$('drop').classList.remove('drag')}));$('drop').addEventListener('drop',e=>selectFile(e.dataTransfer.files[0]));
+  $('file').onchange=()=>selectFile($('file').files[0]);wireDrop('drop',file=>selectFile(file));
   $('publishHero').onclick=async()=>{const key=$('artworkKey').value.trim().toLowerCase();if(!chosenFile||!key)return;$('publishHero').disabled=true;setStatus($('heroStatus'),'正在校验、转换并发布…');const body=new FormData();body.append('artworkKey',key);body.append('file',chosenFile);try{const r=await fetch('api/publish',{method:'POST',headers:{'X-Hero-Admin-Request':'1'},body});const d=await r.json();if(!r.ok)throw new Error(d.error||'发布失败');manifest.artworks[d.artworkKey]={version:d.version,url:d.url};chosenFile=null;$('file').value='';$('drop').classList.remove('has-preview');$('preview').removeAttribute('src');renderHeroKeys();setStatus($('heroStatus'),`发布成功：${d.artworkKey} → v${d.version} · ${d.outputWidth}×${d.outputHeight} WebP · ${(d.outputBytes/1024).toFixed(0)} KB`,'ok')}catch(e){setStatus($('heroStatus'),e.message,'error')}finally{updatePublishEnabled()}};
+
+  async function openArtwork(v){$('artworkDialogTitle').textContent=`${v.brand} ${v.modelName}`;$('artworkDialogContent').innerHTML='<div class="status">正在读取车型图片…</div>';$('artworkDialog').showModal();if(!manifest)await loadHero();renderArtworkDialog(v)}
+  function renderArtworkDialog(v){const root=$('artworkDialogContent');root.innerHTML='';const key=(v.heroArtworkKey||'').trim().toLowerCase();if(!key){const s=document.createElement('div');s.className='status';s.textContent='这款车型还没有绑定 Hero key。可以先编辑车型绑定 key，再上传图片。';const actions=document.createElement('div');actions.className='dialog-actions';const edit=document.createElement('button');edit.textContent='编辑车型';edit.onclick=()=>{$('artworkDialog').close();openVehicle(v)};actions.append(edit);root.append(s,actions);return}const art=manifest?.artworks?.[key];if(!art){const s=document.createElement('div');s.className='status';s.textContent=`已绑定 Hero key：${key}，但还没有发布图片。`;const actions=document.createElement('div');actions.className='dialog-actions';const upload=document.createElement('button');upload.textContent='去上传 Hero';upload.onclick=()=>goToHero(key);actions.append(upload);root.append(s,actions);return}const layout=document.createElement('div');layout.className='artwork-layout';const frame=document.createElement('div');frame.className='artwork-frame';const img=document.createElement('img');img.src=art.url;img.alt=`${v.brand} ${v.modelName} Hero`;img.loading='lazy';frame.append(img);const side=document.createElement('div');side.className='artwork-side';for(const [label,value] of [['Hero key',key],['当前版本',`v${art.version}`],['车型',`${v.brand} ${v.modelName}`]]){const info=document.createElement('div');info.className='artwork-info';const b=document.createElement('b');b.textContent=value;const span=document.createElement('span');span.textContent=label;info.append(b,span);side.append(info)}const open=document.createElement('a');open.className='button-link secondary';open.href=art.url;open.target='_blank';open.rel='noopener';open.textContent='查看原图';const download=document.createElement('button');download.textContent='下载 WebP';download.onclick=()=>downloadRemoteArtwork(art.url,key,art.version);const replace=document.createElement('button');replace.className='secondary';replace.textContent='更新 Hero';replace.onclick=()=>goToHero(key);side.append(open,download,replace);layout.append(frame,side);root.append(layout)}
+  function goToHero(key){$('artworkDialog').close();switchTab('hero');$('artworkKey').value=key;renderHeroCurrent();window.scrollTo({top:0,behavior:'smooth'})}
+  $('closeArtworkDialog').onclick=()=>$('artworkDialog').close();
+  async function downloadRemoteArtwork(url,key,version){try{const r=await fetch(url,{cache:'no-store'});if(!r.ok)throw new Error('下载失败');const blob=await r.blob();downloadBlob(blob,`${safeFileName(key)}_v${version}.webp`)}catch(e){window.open(url,'_blank','noopener')}}
+
+  function wireDrop(id,onFile){const el=$(id);['dragenter','dragover'].forEach(t=>el.addEventListener(t,e=>{e.preventDefault();el.classList.add('drag')}));['dragleave','drop'].forEach(t=>el.addEventListener(t,e=>{e.preventDefault();el.classList.remove('drag')}));el.addEventListener('drop',e=>onFile(e.dataTransfer.files[0]))}
+  function clearConverted(){if(convertedUrl)URL.revokeObjectURL(convertedUrl);convertedBlob=null;convertedUrl=null;convertedName=null;$('convertOutputPreview').removeAttribute('src');$('toolResult').classList.remove('ready');$('downloadConverted').disabled=true}
+  function selectConvertFile(file){clearConverted();if(convertSourceUrl)URL.revokeObjectURL(convertSourceUrl);convertSourceFile=file||null;convertSourceUrl=null;if(!convertSourceFile){$('convertDrop').classList.remove('has-preview');$('convertInputPreview').removeAttribute('src');$('convertButton').disabled=true;return}if(convertSourceFile.type!=='image/png'&&!/\.png$/i.test(convertSourceFile.name)){convertSourceFile=null;$('convertButton').disabled=true;setStatus($('convertStatus'),'这里只接受 PNG；正式 Hero 发布页仍可直接接受 PNG 或 WebP。','error');return}convertSourceUrl=URL.createObjectURL(convertSourceFile);$('convertInputPreview').src=convertSourceUrl;$('convertDrop').classList.add('has-preview');$('convertButton').disabled=false;setStatus($('convertStatus'),`${convertSourceFile.name} · ${(convertSourceFile.size/1024).toFixed(0)} KB · 等待本地转换`,'ok')}
+  $('convertFile').onchange=()=>selectConvertFile($('convertFile').files[0]);wireDrop('convertDrop',file=>selectConvertFile(file));
+  $('convertQuality').oninput=()=>{$('qualityValue').textContent=`${Math.round(Number($('convertQuality').value)*100)}%`;clearConverted()};$('convertMode').onchange=clearConverted;
+  $('convertButton').onclick=async()=>{if(!convertSourceFile)return;$('convertButton').disabled=true;clearConverted();setStatus($('convertStatus'),'正在浏览器本地转换…');try{const bitmap=await createImageBitmap(convertSourceFile);let targetW=bitmap.width,targetH=bitmap.height,sx=0,sy=0,sw=bitmap.width,sh=bitmap.height;if($('convertMode').value==='hero'){targetW=1600;targetH=1100;const targetRatio=targetW/targetH;const sourceRatio=bitmap.width/bitmap.height;if(sourceRatio>targetRatio){sh=bitmap.height;sw=sh*targetRatio;sx=(bitmap.width-sw)/2}else{sw=bitmap.width;sh=sw/targetRatio;sy=(bitmap.height-sh)/2}}const canvas=document.createElement('canvas');canvas.width=targetW;canvas.height=targetH;const ctx=canvas.getContext('2d');if(!ctx)throw new Error('浏览器 Canvas 不可用');ctx.drawImage(bitmap,sx,sy,sw,sh,0,0,targetW,targetH);bitmap.close?.();const quality=Number($('convertQuality').value);const blob=await new Promise((resolve,reject)=>canvas.toBlob(b=>b?resolve(b):reject(new Error('浏览器不支持 WebP 编码')),'image/webp',quality));if(blob.type!=='image/webp')throw new Error('浏览器没有生成有效 WebP');convertedBlob=blob;convertedUrl=URL.createObjectURL(blob);const stem=convertSourceFile.name.replace(/\.png$/i,'');convertedName=`${safeFileName(stem)}${$('convertMode').value==='hero'?'_1600x1100':''}.webp`;$('convertOutputPreview').src=convertedUrl;$('toolResult').classList.add('ready');$('downloadConverted').disabled=false;const ratio=convertSourceFile.size>0?(blob.size/convertSourceFile.size*100):0;setStatus($('convertStatus'),`转换完成 · ${targetW}×${targetH} · ${(blob.size/1024).toFixed(0)} KB · 原文件的 ${ratio.toFixed(0)}%`,'ok')}catch(e){setStatus($('convertStatus'),e.message||'转换失败','error')}finally{$('convertButton').disabled=!convertSourceFile}};
+  $('downloadConverted').onclick=()=>{if(convertedBlob&&convertedName)downloadBlob(convertedBlob,convertedName)};
+  function safeFileName(value){return String(value||'image').toLowerCase().replace(/[^a-z0-9._-]+/g,'_').replace(/^_+|_+$/g,'')||'image'}
+  function downloadBlob(blob,name){const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=name;document.body.appendChild(a);a.click();a.remove();setTimeout(()=>URL.revokeObjectURL(url),1500)}
 
   Promise.all([loadCatalog(),loadHero()]).then(renderHeroKeys);
 </script>


### PR DESCRIPTION
## Summary

Improve the existing protected EV resource admin with two small browser-side image workflows.

## Vehicle artwork preview

- vehicle rows are clickable and keyboard accessible
- clicking a catalog vehicle opens its currently bound Hero artwork
- show Hero key, current version and vehicle name
- provide `查看原图`, `下载 WebP` and `更新 Hero` actions
- if the vehicle has no Hero key, link back to vehicle editing
- if the key exists but has not been published, jump directly to Hero upload with the key prefilled

## PNG -> WebP tool

Add an `图片工具` tab that converts PNG locally in the browser using Canvas:

- source image never leaves the browser
- preserve original dimensions, or
- center-crop directly to the production Hero size `1600x1100`
- adjustable WebP quality (default 90%)
- preview output and report resulting dimensions / size ratio
- download the generated `.webp`

This utility is intentionally separate from publishing. Formal Hero publishing still uses the existing server-side validation, immutable version files and manifest update.

## CI

Add a lightweight Node syntax/marker check for the single-page admin browser script, while keeping the existing catalog and Hero publisher E2E checks unchanged.