### PR TITLE
fix(android): harden extreme Trip max speed trust

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -5,6 +5,7 @@ object TripSpeedTrustRules {
     private const val MIN_EXPECTED_DISTANCE_RATIO = 0.25
     private const val MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS = 25.0
     private const val MAX_TRUSTED_SPEED_ACCURACY_MPS = 3.0
+    private const val EXTREME_SPEED_REQUIRES_ACCURACY_MPS = 25.0
 
     fun eligibleForAggregate(
         reportedSpeedMps: Double?,
@@ -38,6 +39,7 @@ object TripSpeedTrustRules {
             return false
         }
 
+        if (reportedSpeedMps >= EXTREME_SPEED_REQUIRES_ACCURACY_MPS && speedAccuracyMps == null) return false
         if (speedAccuracyMps != null &&
             (!speedAccuracyMps.isFinite() || speedAccuracyMps < 0.0 || speedAccuracyMps > MAX_TRUSTED_SPEED_ACCURACY_MPS)
         ) {

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -84,6 +84,36 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
+    fun `extreme gps peak without speed accuracy cannot update max speed`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 34.005,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 140.0,
+                continuityAllowsSpeed = true,
+                provider = "gps",
+                horizontalAccuracyMeters = 8.0,
+                speedAccuracyMps = null
+            )
+        )
+    }
+
+    @Test
+    fun `moderate gps speed without speed accuracy remains usable`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 20.0,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 80.0,
+                continuityAllowsSpeed = true,
+                provider = "gps",
+                horizontalAccuracyMeters = 8.0,
+                speedAccuracyMps = null
+            )
+        )
+    }
+
+    @Test
     fun `coarse gps point cannot update max speed`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(


### PR DESCRIPTION
## Summary

Close the remaining code-side trust gap in #78 without changing raw TripPoint storage or provider fallback behavior.

- require explicit `speedAccuracy` evidence before an extreme GPS speed (`>= 25 m/s`, about 90 km/h) can update trusted measured/max-speed output
- keep moderate, horizontally accurate GPS speeds usable when older devices do not expose `speedAccuracy`
- preserve the existing network-provider and coarse-horizontal-accuracy rejection rules
- add regression coverage for both the extreme missing-accuracy rejection and moderate-speed compatibility case

## Why

PR #82 already rejects coarse/network speed spikes, including the observed ~122.4 km/h network fallback. #78 also requires missing `speedAccuracy` to reduce trust for extreme values; main still accepted that edge case for otherwise accurate GPS points.

## Acceptance scope

- code/test side only
- raw TripPoint data unchanged
- Local First Trip recording unchanged
- no new background/location architecture

Refs #78