### PR TITLE
ui(android): align background updater with dashboard visual language

### DIFF
--- a/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
@@ -4,12 +4,14 @@ import android.app.Activity
 import android.net.Uri
 import android.util.Log
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -19,7 +21,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.ErrorOutline
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -37,10 +38,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import com.evchargebook.BuildConfig
+import com.evchargebook.ui.theme.EVDesignTokens
 
 @Composable
 fun AppUpdatePrompt() {
@@ -58,7 +61,6 @@ fun AppUpdatePrompt() {
     LaunchedEffect(Unit) {
         runCatching { manager.checkForUpdate() }
             .onSuccess { update = it }
-            // Update discovery must never block Local First app usage, but keep an adb-visible diagnostic.
             .onFailure { error ->
                 Log.w(TAG, "Update discovery failed for ${BuildConfig.UPDATE_MANIFEST_URL}", error)
             }
@@ -88,7 +90,7 @@ fun AppUpdatePrompt() {
     ) {
         Box(
             modifier = Modifier
-                .padding(horizontal = 20.dp, vertical = 96.dp)
+                .padding(horizontal = 8.dp, vertical = 88.dp)
                 .widthIn(min = 320.dp, max = 520.dp)
         ) {
             BackgroundUpdateCard(
@@ -126,107 +128,121 @@ private fun BackgroundUpdateCard(
     onRetry: () -> Unit,
     onLater: () -> Unit
 ) {
-    val primary = MaterialTheme.colorScheme.primary
-    val (icon, title, subtitle, accent) = when (phase) {
+    val copy = when (phase) {
         UpdatePhase.IDLE,
         UpdatePhase.DOWNLOADING -> UpdateCardCopy(
             icon = Icons.Rounded.Download,
             title = "正在后台更新 $versionName",
             subtitle = "可以继续使用应用，下载并校验完成后再安装",
-            accent = primary
+            accent = EVDesignTokens.Energy.green,
+            action = null
         )
         UpdatePhase.READY -> UpdateCardCopy(
             icon = Icons.Rounded.CheckCircle,
             title = "$versionName 已准备好",
-            subtitle = "更新包已下载并完成校验",
-            accent = primary
+            subtitle = "更新包已下载并完成校验，可随时安装",
+            accent = EVDesignTokens.Energy.success,
+            action = "安装"
         )
         UpdatePhase.PERMISSION_REQUIRED -> UpdateCardCopy(
             icon = Icons.Rounded.CheckCircle,
             title = "允许安装后即可更新",
-            subtitle = "返回应用后点击“继续安装”",
-            accent = primary
+            subtitle = "授权后返回应用，再继续安装",
+            accent = EVDesignTokens.Energy.warning,
+            action = "继续安装"
         )
         UpdatePhase.FAILED -> UpdateCardCopy(
             icon = Icons.Rounded.ErrorOutline,
             title = "后台更新失败",
             subtitle = errorMessage ?: "网络恢复后可以重试",
-            accent = MaterialTheme.colorScheme.error
+            accent = EVDesignTokens.Energy.danger,
+            action = "重试"
         )
     }
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.97f),
-        contentColor = MaterialTheme.colorScheme.onSurface,
-        tonalElevation = 8.dp,
-        shadowElevation = 10.dp,
-        border = BorderStroke(
-            width = 1.dp,
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f)
-        )
+        shape = RoundedCornerShape(EVDesignTokens.Radius.large.dp),
+        color = EVDesignTokens.Dark.surfaceElevated.copy(alpha = 0.98f),
+        contentColor = EVDesignTokens.Dark.primaryText,
+        tonalElevation = 0.dp,
+        shadowElevation = 0.dp,
+        border = BorderStroke(1.dp, EVDesignTokens.Dark.outline)
     ) {
         Column {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, top = 14.dp, end = 12.dp, bottom = 12.dp),
+                    .padding(start = 16.dp, top = 14.dp, end = 10.dp, bottom = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 Surface(
-                    modifier = Modifier.size(42.dp),
+                    modifier = Modifier.size(40.dp),
                     shape = CircleShape,
-                    color = accent.copy(alpha = 0.12f),
-                    contentColor = accent
+                    color = copy.accent.copy(alpha = 0.12f),
+                    contentColor = copy.accent,
+                    tonalElevation = 0.dp,
+                    shadowElevation = 0.dp
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Icon(
-                            imageVector = icon,
+                            imageVector = copy.icon,
                             contentDescription = null,
-                            modifier = Modifier.size(21.dp)
+                            modifier = Modifier.size(20.dp)
                         )
                     }
                 }
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleSmall
+                        text = copy.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = EVDesignTokens.Dark.primaryText
                     )
-                    Spacer(modifier = Modifier.size(3.dp))
+                    Spacer(modifier = Modifier.height(3.dp))
                     Text(
-                        text = subtitle,
+                        text = copy.subtitle,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = EVDesignTokens.Dark.secondaryText
                     )
                 }
 
-                when (phase) {
-                    UpdatePhase.READY -> {
-                        FilledTonalButton(onClick = onInstall) { Text("安装") }
+                copy.action?.let { label ->
+                    TextButton(
+                        onClick = if (phase == UpdatePhase.FAILED) onRetry else onInstall
+                    ) {
+                        Text(
+                            text = label,
+                            color = copy.accent,
+                            fontWeight = FontWeight.SemiBold
+                        )
                     }
-                    UpdatePhase.PERMISSION_REQUIRED -> {
-                        FilledTonalButton(onClick = onInstall) { Text("继续") }
-                    }
-                    UpdatePhase.FAILED -> {
-                        TextButton(onClick = onRetry) { Text("重试") }
-                    }
-                    else -> Unit
                 }
 
                 if (!mandatory && phase != UpdatePhase.DOWNLOADING && phase != UpdatePhase.IDLE) {
-                    TextButton(onClick = onLater) { Text("稍后") }
+                    TextButton(onClick = onLater) {
+                        Text("稍后", color = EVDesignTokens.Dark.secondaryText)
+                    }
                 }
             }
 
             if (phase == UpdatePhase.DOWNLOADING || phase == UpdatePhase.IDLE) {
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = primary,
-                    trackColor = Color.Transparent
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(3.dp)
+                        .background(EVDesignTokens.Dark.outline)
+                ) {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(3.dp),
+                        color = EVDesignTokens.Energy.green,
+                        trackColor = Color.Transparent
+                    )
+                }
             }
         }
     }
@@ -236,7 +252,8 @@ private data class UpdateCardCopy(
     val icon: androidx.compose.ui.graphics.vector.ImageVector,
     val title: String,
     val subtitle: String,
-    val accent: Color
+    val accent: Color,
+    val action: String?
 )
 
 private enum class UpdatePhase {

--- a/docs/EVChargeBook_UI_Design_Language_v0.5.md
+++ b/docs/EVChargeBook_UI_Design_Language_v0.5.md
@@ -129,6 +129,32 @@ Displays:
 - Cost analysis
 - Energy distribution
 
+### Background Update Card
+
+The release-only APK updater is part of the same Dashboard visual system, not a generic Material dialog.
+
+Visual rules:
+
+- float above the bottom navigation without a scrim;
+- use the Dashboard horizontal gutter (8dp starting point);
+- use `EVDesignTokens.Dark.surfaceElevated` with a subtle `EVDesignTokens.Dark.outline` hairline;
+- use the large radius family (about 24dp) and no visible Material elevation;
+- keep the icon in a compact circular tinted container;
+- use energy green for normal/update-ready actions, warning only for permission state, and danger only for failures;
+- keep primary copy near-white and supporting copy muted gray-green;
+- prefer compact text/pill actions over large tonal buttons;
+- downloading uses a thin green progress line at the card bottom;
+- the card must remain non-modal and must never interrupt Local First usage.
+
+State copy hierarchy:
+
+1. `正在后台更新 <version>` — application remains usable while download and verification run.
+2. `<version> 已准备好` — compact install action becomes available.
+3. `允许安装后即可更新` — guide the Android unknown-source permission flow without changing card geometry.
+4. `后台更新失败` — error accent plus retry, while keeping the same dark card surface.
+
+The visual alignment issue is tracked in #125. Functional old-release -> new-release device acceptance remains tracked separately by #102.
+
 ## Navigation
 
 Bottom navigation:


### PR DESCRIPTION
## Summary

Align the existing release-only background update card with the approved EV Charge Book Dashboard visual language from #125.

## Changes

- replace generic elevated Material updater styling with the app's dark teal/black surface tokens
- use the existing energy/success/warning/danger accent tokens per state
- reduce the updater to the same 8dp Dashboard side gutter and keep it floating above bottom navigation
- remove visible tonal/shadow elevation and use the app's subtle outline language
- keep compact circular state icons and compact text actions
- use a thin green bottom progress line while download/verification is running
- document the updater as a first-class shared UI component in the v0.5 design language

## Behavior intentionally unchanged

- release-only startup check
- automatic background APK download
- SHA-256 verification
- Android unknown-source permission flow
- Android system installer confirmation
- non-blocking update-service failures
- no polling, service, or silent installation

## Acceptance

- [ ] Android CI passes
- [ ] visually matches the current dark Dashboard language on a release build
- [ ] downloading / ready / permission / failed states remain readable and non-modal
- [ ] optional update can still be deferred

Closes #125 after visual/CI acceptance.
Functional physical old-release -> new-release acceptance remains tracked by #102.