### PR TITLE
feat(android): add trusted Trip elevation analysis

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripElevationAnalytics.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripElevationAnalytics.kt
@@ -1,0 +1,99 @@
+package com.evchargebook.domain.trip
+
+import com.evchargebook.data.entity.TripPointEntity
+import com.evchargebook.domain.TripContinuityRules
+import kotlin.math.abs
+
+/**
+ * Presentation analytics derived from already-persisted TripPoint altitude facts.
+ *
+ * This deliberately does not change Trip/GPS acceptance rules. It only avoids turning
+ * obviously weak vertical fixes, tiny altitude jitter, or long GPS gaps into cumulative
+ * climb/descent claims.
+ */
+data class TripElevationSummary(
+    val startAltitudeMeters: Double,
+    val endAltitudeMeters: Double,
+    val minAltitudeMeters: Double,
+    val maxAltitudeMeters: Double,
+    val elevationGainMeters: Double,
+    val elevationLossMeters: Double,
+    val trustedSampleCount: Int,
+    val skippedLongGapCount: Int
+) {
+    val hasCumulativeEstimate: Boolean get() = trustedSampleCount >= 2
+}
+
+object TripElevationAnalytics {
+    const val MAX_VERTICAL_ACCURACY_METERS = 30.0
+    const val MIN_SIGNIFICANT_ALTITUDE_CHANGE_METERS = 3.0
+
+    fun summarize(points: List<TripPointEntity>): TripElevationSummary? {
+        val samples = points
+            .asSequence()
+            .sortedBy { it.capturedAtEpochMillis }
+            .mapNotNull { point ->
+                val altitude = point.altitudeMeters?.takeIf { it.isFinite() } ?: return@mapNotNull null
+                val verticalAccuracy = point.verticalAccuracyMeters
+                if (verticalAccuracy != null &&
+                    (!verticalAccuracy.isFinite() || verticalAccuracy < 0.0 || verticalAccuracy > MAX_VERTICAL_ACCURACY_METERS)
+                ) {
+                    return@mapNotNull null
+                }
+                ElevationSample(
+                    capturedAtEpochMillis = point.capturedAtEpochMillis,
+                    altitudeMeters = altitude,
+                    verticalAccuracyMeters = verticalAccuracy
+                )
+            }
+            .toList()
+
+        if (samples.isEmpty()) return null
+
+        var gainMeters = 0.0
+        var lossMeters = 0.0
+        var skippedLongGapCount = 0
+        var previous = samples.first()
+        var altitudeAnchor = samples.first()
+
+        samples.drop(1).forEach { current ->
+            val deltaSeconds = ((current.capturedAtEpochMillis - previous.capturedAtEpochMillis) / 1000)
+                .coerceAtLeast(0L)
+            if (deltaSeconds >= TripContinuityRules.LONG_GAP_SECONDS) {
+                skippedLongGapCount += 1
+                altitudeAnchor = current
+                previous = current
+                return@forEach
+            }
+
+            val altitudeDelta = current.altitudeMeters - altitudeAnchor.altitudeMeters
+            val significanceThreshold = maxOf(
+                MIN_SIGNIFICANT_ALTITUDE_CHANGE_METERS,
+                altitudeAnchor.verticalAccuracyMeters ?: 0.0,
+                current.verticalAccuracyMeters ?: 0.0
+            )
+            if (abs(altitudeDelta) >= significanceThreshold) {
+                if (altitudeDelta > 0.0) gainMeters += altitudeDelta else lossMeters += -altitudeDelta
+                altitudeAnchor = current
+            }
+            previous = current
+        }
+
+        return TripElevationSummary(
+            startAltitudeMeters = samples.first().altitudeMeters,
+            endAltitudeMeters = samples.last().altitudeMeters,
+            minAltitudeMeters = samples.minOf { it.altitudeMeters },
+            maxAltitudeMeters = samples.maxOf { it.altitudeMeters },
+            elevationGainMeters = gainMeters,
+            elevationLossMeters = lossMeters,
+            trustedSampleCount = samples.size,
+            skippedLongGapCount = skippedLongGapCount
+        )
+    }
+
+    private data class ElevationSample(
+        val capturedAtEpochMillis: Long,
+        val altitudeMeters: Double,
+        val verticalAccuracyMeters: Double?
+    )
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -35,6 +35,7 @@ import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.domain.TripSpeedTrustRules
+import com.evchargebook.domain.trip.TripElevationAnalytics
 import com.evchargebook.domain.trip.TripGeoPoint
 import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.location.AndroidGeocoderAddressResolver
@@ -394,7 +395,8 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
     var startAddress by remember(trip.id) { mutableStateOf<String?>(null) }
     var endAddress by remember(trip.id) { mutableStateOf<String?>(null) }
     var resolvingAddresses by remember(trip.id) { mutableStateOf(false) }
-    val hasAltitude = listOf(
+    val elevationSummary = remember(points) { TripElevationAnalytics.summarize(points) }
+    val hasAltitude = elevationSummary != null || listOf(
         trip.startAltitudeMeters,
         trip.endAltitudeMeters,
         trip.minAltitudeMeters,
@@ -499,16 +501,39 @@ private fun TripDetailScreen(trip: TripSessionEntity, vehicles: List<VehicleEnti
 
             if (hasAltitude) {
                 item {
-                    SectionHeading("海拔", "来自设备定位海拔；暂不根据原始噪声推算累计爬升")
+                    SectionHeading(
+                        "海拔",
+                        if ((elevationSummary?.skippedLongGapCount ?: 0) > 0) {
+                            "来自可信定位海拔；GPS 长缺口两侧不会被拼成累计爬升/下降"
+                        } else {
+                            "来自可信定位海拔；累计爬升/下降会抑制小幅 GPS 垂直抖动"
+                        }
+                    )
                     Spacer(Modifier.height(MaterialTheme.spacing.sm))
                     ResponsiveCockpitMetrics(
                         listOf(
-                            CockpitMetricData("起点海拔", formatAltitude(trip.startAltitudeMeters)),
-                            CockpitMetricData("终点海拔", formatAltitude(trip.endAltitudeMeters)),
-                            CockpitMetricData("最低海拔", formatAltitude(trip.minAltitudeMeters)),
-                            CockpitMetricData("最高海拔", formatAltitude(trip.maxAltitudeMeters))
+                            CockpitMetricData("起点海拔", formatAltitude(elevationSummary?.startAltitudeMeters ?: trip.startAltitudeMeters)),
+                            CockpitMetricData("终点海拔", formatAltitude(elevationSummary?.endAltitudeMeters ?: trip.endAltitudeMeters)),
+                            CockpitMetricData("最低海拔", formatAltitude(elevationSummary?.minAltitudeMeters ?: trip.minAltitudeMeters)),
+                            CockpitMetricData("最高海拔", formatAltitude(elevationSummary?.maxAltitudeMeters ?: trip.maxAltitudeMeters)),
+                            CockpitMetricData(
+                                "累计爬升",
+                                if (elevationSummary?.hasCumulativeEstimate == true) formatAltitude(elevationSummary.elevationGainMeters) else "--"
+                            ),
+                            CockpitMetricData(
+                                "累计下降",
+                                if (elevationSummary?.hasCumulativeEstimate == true) formatAltitude(elevationSummary.elevationLossMeters) else "--"
+                            )
                         )
                     )
+                    elevationSummary?.takeIf { it.skippedLongGapCount > 0 }?.let {
+                        Spacer(Modifier.height(MaterialTheme.spacing.sm))
+                        Text(
+                            "${it.skippedLongGapCount} 个 GPS 长缺口已从累计海拔变化中断开；不会用缺失区间的高度差制造地形变化。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
 

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripElevationAnalyticsTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripElevationAnalyticsTest.kt
@@ -1,0 +1,121 @@
+package com.evchargebook.domain.trip
+
+import com.evchargebook.data.entity.TripPointEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripElevationAnalyticsTest {
+    @Test
+    fun `summarizes climb descent min and max from trusted altitude points`() {
+        val summary = TripElevationAnalytics.summarize(
+            listOf(
+                point(seconds = 0, altitude = 10.0, verticalAccuracy = 2.0),
+                point(seconds = 10, altitude = 12.0, verticalAccuracy = 2.0), // jitter below 3m deadband
+                point(seconds = 20, altitude = 16.0, verticalAccuracy = 2.0), // +6m from anchor
+                point(seconds = 30, altitude = 11.0, verticalAccuracy = 2.0)  // -5m
+            )
+        )!!
+
+        assertEquals(10.0, summary.startAltitudeMeters, 0.001)
+        assertEquals(11.0, summary.endAltitudeMeters, 0.001)
+        assertEquals(10.0, summary.minAltitudeMeters, 0.001)
+        assertEquals(16.0, summary.maxAltitudeMeters, 0.001)
+        assertEquals(6.0, summary.elevationGainMeters, 0.001)
+        assertEquals(5.0, summary.elevationLossMeters, 0.001)
+        assertTrue(summary.hasCumulativeEstimate)
+    }
+
+    @Test
+    fun `does not bridge cumulative elevation across long gps gap`() {
+        val summary = TripElevationAnalytics.summarize(
+            listOf(
+                point(seconds = 0, altitude = 20.0),
+                point(seconds = 20, altitude = 30.0),
+                point(seconds = 160, altitude = 80.0),
+                point(seconds = 180, altitude = 70.0)
+            )
+        )!!
+
+        assertEquals(10.0, summary.elevationGainMeters, 0.001)
+        assertEquals(10.0, summary.elevationLossMeters, 0.001)
+        assertEquals(1, summary.skippedLongGapCount)
+    }
+
+    @Test
+    fun `continuous small altitude samples do not become a false long gap`() {
+        val summary = TripElevationAnalytics.summarize(
+            listOf(
+                point(seconds = 0, altitude = 100.0, verticalAccuracy = 4.0),
+                point(seconds = 30, altitude = 101.0, verticalAccuracy = 4.0),
+                point(seconds = 60, altitude = 102.0, verticalAccuracy = 4.0),
+                point(seconds = 90, altitude = 103.0, verticalAccuracy = 4.0),
+                point(seconds = 120, altitude = 104.0, verticalAccuracy = 4.0),
+                point(seconds = 150, altitude = 105.0, verticalAccuracy = 4.0)
+            )
+        )!!
+
+        assertEquals(0, summary.skippedLongGapCount)
+        assertEquals(4.0, summary.elevationGainMeters, 0.001)
+    }
+
+    @Test
+    fun `rejects weak vertical accuracy from elevation analytics`() {
+        val summary = TripElevationAnalytics.summarize(
+            listOf(
+                point(seconds = 0, altitude = 100.0, verticalAccuracy = 4.0),
+                point(seconds = 10, altitude = 180.0, verticalAccuracy = 80.0),
+                point(seconds = 20, altitude = 108.0, verticalAccuracy = 4.0)
+            )
+        )!!
+
+        assertEquals(100.0, summary.minAltitudeMeters, 0.001)
+        assertEquals(108.0, summary.maxAltitudeMeters, 0.001)
+        assertEquals(8.0, summary.elevationGainMeters, 0.001)
+        assertEquals(2, summary.trustedSampleCount)
+    }
+
+    @Test
+    fun `uses reported vertical accuracy as the jitter threshold`() {
+        val summary = TripElevationAnalytics.summarize(
+            listOf(
+                point(seconds = 0, altitude = 100.0, verticalAccuracy = 8.0),
+                point(seconds = 10, altitude = 106.0, verticalAccuracy = 8.0),
+                point(seconds = 20, altitude = 109.0, verticalAccuracy = 8.0)
+            )
+        )!!
+
+        assertEquals(9.0, summary.elevationGainMeters, 0.001)
+    }
+
+    @Test
+    fun `returns null when no altitude facts exist`() {
+        assertNull(
+            TripElevationAnalytics.summarize(
+                listOf(
+                    TripPointEntity(
+                        tripId = 1,
+                        capturedAtEpochMillis = 1_000,
+                        latitude = 31.0,
+                        longitude = 121.0
+                    )
+                )
+            )
+        )
+    }
+
+    private fun point(
+        seconds: Long,
+        altitude: Double,
+        verticalAccuracy: Double? = null
+    ) = TripPointEntity(
+        tripId = 1,
+        capturedAtEpochMillis = seconds * 1_000,
+        latitude = 31.0,
+        longitude = 121.0,
+        altitudeMeters = altitude,
+        verticalAccuracyMeters = verticalAccuracy,
+        provider = "gps"
+    )
+}


### PR DESCRIPTION
## Summary

Implement the code-side scope for #69 using altitude facts that are already persisted on `TripPoint` / `TripSession`.

- add pure Kotlin `TripElevationAnalytics`
- calculate trusted start/end/min/max altitude plus cumulative climb and descent
- suppress tiny vertical jitter using a small deadband that expands to the reported vertical-accuracy uncertainty
- ignore altitude samples with clearly weak vertical accuracy (>30m)
- do not bridge cumulative elevation across existing >=120s GPS long gaps
- surface climb/descent together with start/end/min/max altitude on Trip detail
- keep raw TripPoint storage and existing GPS acceptance rules unchanged
- add JVM coverage for climb/descent, long-gap handling, weak vertical accuracy, jitter threshold and missing-altitude behavior

## Data boundary

This remains device-GPS elevation analysis. It does not claim map/terrain-corrected elevation and does not fabricate values when altitude facts are unavailable.

No database migration, map SDK, background service, or new architecture is introduced.

Refs #69