### PR TITLE
feat(android): classify and explicitly clean invalid Trips

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/ChargingTripCoverage.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/ChargingTripCoverage.kt
@@ -2,7 +2,6 @@ package com.evchargebook.domain
 
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.TripSessionEntity
-import com.evchargebook.data.entity.TripStatus
 
 data class ChargingTripCoverageInterval(
     val previousRecordId: Long,
@@ -29,12 +28,7 @@ object ChargingTripCoverage {
         val orderedRecords = records
             .filter { it.odometerKm != null }
             .sortedBy { it.chargeTimeEpochMillis }
-        val completedTrips = trips.filter {
-            it.status == TripStatus.COMPLETED &&
-                it.endedAtEpochMillis != null &&
-                it.distanceMeters.isFinite() &&
-                it.distanceMeters >= 0.0
-        }
+        val completedTrips = trips.filter(TripValidityRules::isEligibleForAnalytics)
 
         val intervals = orderedRecords.zipWithNext().mapNotNull { (previous, current) ->
             val previousOdometer = previous.odometerKm ?: return@mapNotNull null

--- a/android/app/src/main/java/com/evchargebook/domain/TripValidityRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripValidityRules.kt
@@ -56,7 +56,11 @@ object TripValidityRules {
             if (trip.endedAtEpochMillis == null) add(TripValidityReason.MISSING_END_TIME)
             if (!trip.distanceMeters.isFinite() || trip.distanceMeters < 0.0) add(TripValidityReason.INVALID_DISTANCE)
             if (trip.elapsedSeconds <= 0L) add(TripValidityReason.INVALID_DURATION)
-            if (trip.distanceMeters.isFinite() && trip.distanceMeters in 0.0..<MIN_MEANINGFUL_DISTANCE_METERS) {
+            if (
+                trip.distanceMeters.isFinite() &&
+                trip.distanceMeters >= 0.0 &&
+                trip.distanceMeters < MIN_MEANINGFUL_DISTANCE_METERS
+            ) {
                 add(TripValidityReason.NO_MEANINGFUL_MOVEMENT)
             }
             if (acceptedPointCount != null && acceptedPointCount < MIN_TRACK_POINTS) {

--- a/android/app/src/main/java/com/evchargebook/domain/TripValidityRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripValidityRules.kt
@@ -1,0 +1,81 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.TripStatus
+
+enum class TripValidityStatus {
+    VALID,
+    REVIEW,
+    INVALID,
+    INCOMPLETE
+}
+
+enum class TripValidityReason {
+    NOT_COMPLETED,
+    MISSING_END_TIME,
+    INVALID_DISTANCE,
+    INVALID_DURATION,
+    NO_MEANINGFUL_MOVEMENT,
+    INSUFFICIENT_TRACK_POINTS,
+    VERY_SHORT_TRIP
+}
+
+data class TripValidityAssessment(
+    val status: TripValidityStatus,
+    val reasons: Set<TripValidityReason> = emptySet()
+) {
+    val eligibleForAnalytics: Boolean
+        get() = status == TripValidityStatus.VALID || status == TripValidityStatus.REVIEW
+}
+
+/**
+ * Conservative Trip validity rules.
+ *
+ * Only structurally impossible/empty completed Trips are excluded from analytics automatically.
+ * Very short Trips are review candidates rather than invalid, so legitimate parking-lot or
+ * repositioning drives are never silently discarded.
+ */
+object TripValidityRules {
+    const val MIN_MEANINGFUL_DISTANCE_METERS = 1.0
+    const val REVIEW_DISTANCE_METERS = 100.0
+    const val REVIEW_DURATION_SECONDS = 120L
+    const val MIN_TRACK_POINTS = 2
+
+    fun assess(
+        trip: TripSessionEntity,
+        acceptedPointCount: Int? = null
+    ): TripValidityAssessment {
+        if (trip.status != TripStatus.COMPLETED) {
+            return TripValidityAssessment(
+                status = TripValidityStatus.INCOMPLETE,
+                reasons = setOf(TripValidityReason.NOT_COMPLETED)
+            )
+        }
+
+        val invalidReasons = buildSet {
+            if (trip.endedAtEpochMillis == null) add(TripValidityReason.MISSING_END_TIME)
+            if (!trip.distanceMeters.isFinite() || trip.distanceMeters < 0.0) add(TripValidityReason.INVALID_DISTANCE)
+            if (trip.elapsedSeconds <= 0L) add(TripValidityReason.INVALID_DURATION)
+            if (trip.distanceMeters.isFinite() && trip.distanceMeters in 0.0..<MIN_MEANINGFUL_DISTANCE_METERS) {
+                add(TripValidityReason.NO_MEANINGFUL_MOVEMENT)
+            }
+            if (acceptedPointCount != null && acceptedPointCount < MIN_TRACK_POINTS) {
+                add(TripValidityReason.INSUFFICIENT_TRACK_POINTS)
+            }
+        }
+        if (invalidReasons.isNotEmpty()) {
+            return TripValidityAssessment(TripValidityStatus.INVALID, invalidReasons)
+        }
+
+        if (trip.distanceMeters < REVIEW_DISTANCE_METERS && trip.elapsedSeconds < REVIEW_DURATION_SECONDS) {
+            return TripValidityAssessment(
+                status = TripValidityStatus.REVIEW,
+                reasons = setOf(TripValidityReason.VERY_SHORT_TRIP)
+            )
+        }
+
+        return TripValidityAssessment(TripValidityStatus.VALID)
+    }
+
+    fun isEligibleForAnalytics(trip: TripSessionEntity): Boolean = assess(trip).eligibleForAnalytics
+}

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyAnalytics.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripEnergyAnalytics.kt
@@ -1,7 +1,7 @@
 package com.evchargebook.domain.trip
 
 import com.evchargebook.data.entity.TripSessionEntity
-import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.TripValidityRules
 
 data class TripEnergySummary(
     val completedTripCount: Int,
@@ -19,7 +19,7 @@ object TripEnergyAnalytics {
         endExclusiveEpochMillis: Long? = null
     ): TripEnergySummary {
         val completed = trips.filter { trip ->
-            if (trip.status != TripStatus.COMPLETED) return@filter false
+            if (!TripValidityRules.isEligibleForAnalytics(trip)) return@filter false
             val occurredAt = trip.endedAtEpochMillis ?: trip.startedAtEpochMillis
             (startInclusiveEpochMillis == null || occurredAt >= startInclusiveEpochMillis) &&
                 (endExclusiveEpochMillis == null || occurredAt < endExclusiveEpochMillis)

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
-import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.TripValidityRules
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.viewmodel.MainUiState
@@ -52,7 +52,7 @@ fun DashboardScreen(
     val selectedVehicleId = state.vehicle?.id
     val latestCompletedTrip = state.trips
         .asSequence()
-        .filter { it.vehicleId == selectedVehicleId && it.status == TripStatus.COMPLETED }
+        .filter { it.vehicleId == selectedVehicleId && TripValidityRules.isEligibleForAnalytics(it) }
         .maxByOrNull { it.endedAtEpochMillis ?: it.startedAtEpochMillis }
 
     LazyColumn(
@@ -156,83 +156,33 @@ private fun RecentChargingHeader(
 
 @Composable
 private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onAddClick)
-            .padding(vertical = MaterialTheme.spacing.sm),
-        verticalAlignment = Alignment.Top
-    ) {
+    Row(Modifier.fillMaxWidth().clickable(onClick = onAddClick).padding(vertical = MaterialTheme.spacing.sm), verticalAlignment = Alignment.Top) {
         TimelineRail(isLast = true)
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                "等待第一笔充电",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
+            Text("等待第一笔充电", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
-            Text(
-                "记录后会在这里形成连续的充电时间轴。",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Text("记录后会在这里形成连续的充电时间轴。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
-            Text(
-                "记录第一次充电  →",
-                style = MaterialTheme.typography.bodyMedium,
-                color = EVDesignTokens.Energy.green
-            )
+            Text("记录第一次充电  →", style = MaterialTheme.typography.bodyMedium, color = EVDesignTokens.Energy.green)
         }
     }
 }
 
 @Composable
-private fun ChargingTimelineRow(
-    record: ChargingRecordEntity,
-    onEdit: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onEdit)
-            .padding(vertical = MaterialTheme.spacing.sm),
-        verticalAlignment = Alignment.Top
-    ) {
+private fun ChargingTimelineRow(record: ChargingRecordEntity, onEdit: () -> Unit) {
+    Row(Modifier.fillMaxWidth().clickable(onClick = onEdit).padding(vertical = MaterialTheme.spacing.sm), verticalAlignment = Alignment.Top) {
         TimelineRail(isLast = false)
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    record.location ?: "未命名充电地点",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Text(
-                    "¥ ${two(record.cost)}",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text(record.location ?: "未命名充电地点", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("¥ ${two(record.cost)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             }
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    "${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    "+ ${one(record.energyKwh)} kWh",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = EVDesignTokens.Energy.green
-                )
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("+ ${one(record.energyKwh)} kWh", style = MaterialTheme.typography.bodyMedium, color = EVDesignTokens.Energy.green)
             }
         }
     }
@@ -241,26 +191,10 @@ private fun ChargingTimelineRow(
 @Composable
 private fun TimelineRail(isLast: Boolean) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            modifier = Modifier
-                .size(36.dp)
-                .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Default.Bolt,
-                contentDescription = null,
-                tint = EVDesignTokens.Energy.green,
-                modifier = Modifier.size(18.dp)
-            )
+        Box(Modifier.size(36.dp).background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape), contentAlignment = Alignment.Center) {
+            Icon(Icons.Default.Bolt, contentDescription = null, tint = EVDesignTokens.Energy.green, modifier = Modifier.size(18.dp))
         }
-        if (!isLast) {
-            Box(
-                modifier = Modifier
-                    .size(width = 1.dp, height = 36.dp)
-                    .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f))
-            )
-        }
+        if (!isLast) Box(Modifier.size(width = 1.dp, height = 36.dp).background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f)))
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -156,33 +156,83 @@ private fun RecentChargingHeader(
 
 @Composable
 private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
-    Row(Modifier.fillMaxWidth().clickable(onClick = onAddClick).padding(vertical = MaterialTheme.spacing.sm), verticalAlignment = Alignment.Top) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onAddClick)
+            .padding(vertical = MaterialTheme.spacing.sm),
+        verticalAlignment = Alignment.Top
+    ) {
         TimelineRail(isLast = true)
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
-            Text("等待第一笔充电", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                "等待第一笔充电",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
-            Text("记录后会在这里形成连续的充电时间轴。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(
+                "记录后会在这里形成连续的充电时间轴。",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
-            Text("记录第一次充电  →", style = MaterialTheme.typography.bodyMedium, color = EVDesignTokens.Energy.green)
+            Text(
+                "记录第一次充电  →",
+                style = MaterialTheme.typography.bodyMedium,
+                color = EVDesignTokens.Energy.green
+            )
         }
     }
 }
 
 @Composable
-private fun ChargingTimelineRow(record: ChargingRecordEntity, onEdit: () -> Unit) {
-    Row(Modifier.fillMaxWidth().clickable(onClick = onEdit).padding(vertical = MaterialTheme.spacing.sm), verticalAlignment = Alignment.Top) {
+private fun ChargingTimelineRow(
+    record: ChargingRecordEntity,
+    onEdit: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onEdit)
+            .padding(vertical = MaterialTheme.spacing.sm),
+        verticalAlignment = Alignment.Top
+    ) {
         TimelineRail(isLast = false)
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Text(record.location ?: "未命名充电地点", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                Text("¥ ${two(record.cost)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    record.location ?: "未命名充电地点",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    "¥ ${two(record.cost)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
             }
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text("${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text("+ ${one(record.energyKwh)} kWh", style = MaterialTheme.typography.bodyMedium, color = EVDesignTokens.Energy.green)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    "${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "+ ${one(record.energyKwh)} kWh",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = EVDesignTokens.Energy.green
+                )
             }
         }
     }
@@ -191,10 +241,26 @@ private fun ChargingTimelineRow(record: ChargingRecordEntity, onEdit: () -> Unit
 @Composable
 private fun TimelineRail(isLast: Boolean) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(Modifier.size(36.dp).background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape), contentAlignment = Alignment.Center) {
-            Icon(Icons.Default.Bolt, contentDescription = null, tint = EVDesignTokens.Energy.green, modifier = Modifier.size(18.dp))
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                Icons.Default.Bolt,
+                contentDescription = null,
+                tint = EVDesignTokens.Energy.green,
+                modifier = Modifier.size(18.dp)
+            )
         }
-        if (!isLast) Box(Modifier.size(width = 1.dp, height = 36.dp).background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f)))
+        if (!isLast) {
+            Box(
+                modifier = Modifier
+                    .size(width = 1.dp, height = 36.dp)
+                    .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f))
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.domain.TripValidityRules
+import com.evchargebook.domain.TripValidityStatus
 import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import java.text.SimpleDateFormat
@@ -115,7 +117,7 @@ fun TripReadyScreen(
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text("全部行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                    Text("TRIP HISTORY", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("短途只提示检查；明确空行程不会进入汇总统计", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
             if (orderedTrips.isEmpty()) {
@@ -217,6 +219,7 @@ private fun ReadyRecentTripRow(
     onClick: () -> Unit,
     onDelete: () -> Unit
 ) {
+    val validity = remember(trip) { TripValidityRules.assess(trip) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -231,16 +234,28 @@ private fun ReadyRecentTripRow(
         }
         Spacer(Modifier.width(MaterialTheme.spacing.md))
         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text(
-                SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(trip.startedAtEpochMillis)),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold
-            )
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                Text(
+                    SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(trip.startedAtEpochMillis)),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                when (validity.status) {
+                    TripValidityStatus.INVALID -> TripValidityBadge("无效", true)
+                    TripValidityStatus.REVIEW -> TripValidityBadge("建议检查", false)
+                    else -> Unit
+                }
+            }
             Text(
                 "${String.format(Locale.US, "%.1f", trip.distanceMeters / 1000.0)} km · ${formatReadyDuration(trip.elapsedSeconds)}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            if (validity.status == TripValidityStatus.INVALID) {
+                Text("明确空/异常行程已从 Dashboard 与汇总统计排除，可确认后删除。", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.error)
+            } else if (validity.status == TripValidityStatus.REVIEW) {
+                Text("距离和时长都很短，仅提示检查，不自动排除或删除。", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
         }
         Column(horizontalAlignment = Alignment.End) {
             trip.averageConsumptionKwhPer100Km?.let {
@@ -256,6 +271,19 @@ private fun ReadyRecentTripRow(
                 modifier = Modifier.size(19.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun TripValidityBadge(text: String, invalid: Boolean) {
+    val color = if (invalid) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary
+    Surface(shape = CircleShape, color = color.copy(alpha = .12f)) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = color
+        )
     }
 }
 

--- a/android/app/src/test/java/com/evchargebook/domain/ChargingTripCoverageTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/ChargingTripCoverageTest.kt
@@ -57,12 +57,30 @@ class ChargingTripCoverageTest {
             startedAtEpochMillis = 2_000,
             endedAtEpochMillis = 4_000,
             distanceMeters = 80_000.0,
+            elapsedSeconds = 2,
             status = TripStatus.INTERRUPTED
         )
 
         val summary = ChargingTripCoverage.summarize(records, listOf(trip))
 
         assertEquals(0, summary.intervals.size)
+    }
+
+    @Test
+    fun `clearly empty completed trip does not inflate coverage count`() {
+        val records = listOf(
+            charge(1, 1_000, 10_000.0),
+            charge(2, 10_000, 10_100.0)
+        )
+        val trips = listOf(
+            trip(1, 2_000, 4_000, 40_000.0),
+            trip(2, 5_000, 8_000, 0.0)
+        )
+
+        val summary = ChargingTripCoverage.summarize(records, trips)
+
+        assertEquals(1, summary.intervals.single().completedTripCount)
+        assertEquals(40.0, summary.completedTripDistanceKm, 0.0001)
     }
 
     private fun charge(id: Long, time: Long, odometer: Double) = ChargingRecordEntity(
@@ -82,6 +100,7 @@ class ChargingTripCoverageTest {
         startedAtEpochMillis = start,
         endedAtEpochMillis = end,
         distanceMeters = distanceMeters,
+        elapsedSeconds = ((end - start) / 1_000).coerceAtLeast(1),
         status = TripStatus.COMPLETED
     )
 }

--- a/android/app/src/test/java/com/evchargebook/domain/TripValidityRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripValidityRulesTest.kt
@@ -1,0 +1,87 @@
+package com.evchargebook.domain
+
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.TripStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripValidityRulesTest {
+    @Test
+    fun `normal completed trip is valid for analytics`() {
+        val assessment = TripValidityRules.assess(trip(distanceMeters = 2_500.0, elapsedSeconds = 600))
+
+        assertEquals(TripValidityStatus.VALID, assessment.status)
+        assertTrue(assessment.eligibleForAnalytics)
+    }
+
+    @Test
+    fun `zero movement completed trip is invalid and excluded from analytics`() {
+        val assessment = TripValidityRules.assess(trip(distanceMeters = 0.0, elapsedSeconds = 180))
+
+        assertEquals(TripValidityStatus.INVALID, assessment.status)
+        assertTrue(TripValidityReason.NO_MEANINGFUL_MOVEMENT in assessment.reasons)
+        assertFalse(assessment.eligibleForAnalytics)
+    }
+
+    @Test
+    fun `zero duration completed trip is invalid`() {
+        val assessment = TripValidityRules.assess(trip(distanceMeters = 300.0, elapsedSeconds = 0))
+
+        assertEquals(TripValidityStatus.INVALID, assessment.status)
+        assertTrue(TripValidityReason.INVALID_DURATION in assessment.reasons)
+    }
+
+    @Test
+    fun `completed trip without enough track points is invalid when detail evidence is available`() {
+        val assessment = TripValidityRules.assess(
+            trip = trip(distanceMeters = 200.0, elapsedSeconds = 120),
+            acceptedPointCount = 1
+        )
+
+        assertEquals(TripValidityStatus.INVALID, assessment.status)
+        assertTrue(TripValidityReason.INSUFFICIENT_TRACK_POINTS in assessment.reasons)
+    }
+
+    @Test
+    fun `very short trip is review only and stays in analytics until user decides`() {
+        val assessment = TripValidityRules.assess(trip(distanceMeters = 60.0, elapsedSeconds = 70))
+
+        assertEquals(TripValidityStatus.REVIEW, assessment.status)
+        assertTrue(assessment.eligibleForAnalytics)
+    }
+
+    @Test
+    fun `short distance with meaningful duration remains valid`() {
+        val assessment = TripValidityRules.assess(trip(distanceMeters = 60.0, elapsedSeconds = 180))
+
+        assertEquals(TripValidityStatus.VALID, assessment.status)
+        assertTrue(assessment.eligibleForAnalytics)
+    }
+
+    @Test
+    fun `interrupted trip is incomplete rather than automatically invalid`() {
+        val assessment = TripValidityRules.assess(
+            trip(distanceMeters = 0.0, elapsedSeconds = 30, status = TripStatus.INTERRUPTED, endedAt = null)
+        )
+
+        assertEquals(TripValidityStatus.INCOMPLETE, assessment.status)
+        assertFalse(assessment.eligibleForAnalytics)
+    }
+
+    private fun trip(
+        distanceMeters: Double,
+        elapsedSeconds: Long,
+        status: String = TripStatus.COMPLETED,
+        endedAt: Long? = 20_000L
+    ) = TripSessionEntity(
+        id = 1,
+        vehicleId = 1,
+        startedAtEpochMillis = 10_000L,
+        endedAtEpochMillis = endedAt,
+        distanceMeters = distanceMeters,
+        elapsedSeconds = elapsedSeconds,
+        status = status
+    )
+}

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyAnalyticsTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripEnergyAnalyticsTest.kt
@@ -23,7 +23,7 @@ class TripEnergyAnalyticsTest {
     }
 
     @Test
-    fun `excludes completed trips without trustworthy energy and ignores active trips`() {
+    fun `excludes empty invalid and energy-incomplete trips and ignores active trips`() {
         val trips = listOf(
             completedTrip(id = 1, distanceMeters = 20_000.0, energyKwh = null),
             completedTrip(id = 2, distanceMeters = 0.0, energyKwh = 2.0),
@@ -32,6 +32,7 @@ class TripEnergyAnalyticsTest {
                 vehicleId = 1,
                 startedAtEpochMillis = 3000,
                 distanceMeters = 30_000.0,
+                elapsedSeconds = 60,
                 consumedEnergyKwh = 3.0,
                 status = TripStatus.RECORDING
             )
@@ -39,9 +40,9 @@ class TripEnergyAnalyticsTest {
 
         val summary = TripEnergyAnalytics.summarize(trips)
 
-        assertEquals(2, summary.completedTripCount)
+        assertEquals(1, summary.completedTripCount)
         assertEquals(0, summary.eligibleTripCount)
-        assertEquals(2, summary.excludedTripCount)
+        assertEquals(1, summary.excludedTripCount)
         assertEquals(0.0, summary.estimatedEnergyKwh, 0.001)
         assertNull(summary.weightedAverageKwhPer100Km)
     }
@@ -76,6 +77,7 @@ class TripEnergyAnalyticsTest {
         startedAtEpochMillis = 1000,
         endedAtEpochMillis = endedAt,
         distanceMeters = distanceMeters,
+        elapsedSeconds = ((endedAt - 1000) / 1_000).coerceAtLeast(1),
         consumedEnergyKwh = energyKwh,
         status = TripStatus.COMPLETED
     )


### PR DESCRIPTION
## Summary

Implement the conservative v0.5 Trip validity/cleanup scope from #68 without adding schema or destructive automation.

### Classification
- add pure Kotlin `TripValidityRules`
- classify non-completed Trips as `INCOMPLETE`
- classify structurally empty/impossible completed Trips as `INVALID`
  - missing end time
  - non-finite/negative distance
  - zero/non-positive elapsed duration
  - <1m meaningful movement
  - insufficient track points when detail evidence is supplied
- classify only very short (<100m and <120s) completed Trips as `REVIEW`, not invalid

### Data behavior
- explicitly invalid Trips are excluded from Dashboard latest-Trip selection
- explicitly invalid Trips are excluded from Trip energy analytics and charging-to-Trip coverage analytics
- `REVIEW` Trips stay in analytics so legitimate parking-lot/repositioning drives are not silently discarded

### Cleanup UX
- completed Trip history remains the review surface
- invalid rows are labeled `无效`
- short rows are labeled `建议检查`
- existing explicit delete confirmation remains the only destructive action
- no automatic cleanup, migration, tombstone, or background job

### Tests
- validity status boundaries
- zero movement / zero duration exclusion
- short Trip remains review-only
- interrupted Trip remains incomplete
- invalid Trip does not inflate energy or coverage summaries

Refs #68