### PR TITLE
fix(android): cache successful geocodes and preserve retry

### DIFF
--- a/android/app/src/main/java/com/evchargebook/location/AddressResolver.kt
+++ b/android/app/src/main/java/com/evchargebook/location/AddressResolver.kt
@@ -13,22 +13,31 @@ interface AddressResolver {
 class AndroidGeocoderAddressResolver(context: Context) : AddressResolver {
     private val geocoder = Geocoder(context.applicationContext, Locale.SIMPLIFIED_CHINESE)
 
-    override suspend fun reverse(latitude: Double, longitude: Double): String? = withContext(Dispatchers.IO) {
-        if (!Geocoder.isPresent()) return@withContext null
-        runCatching {
-            @Suppress("DEPRECATION")
-            geocoder.getFromLocation(latitude, longitude, 1)
-                ?.firstOrNull()
-                ?.let { address ->
-                    buildList {
-                        address.adminArea?.takeIf { it.isNotBlank() }?.let(::add)
-                        address.locality?.takeIf { it.isNotBlank() && it != address.adminArea }?.let(::add)
-                        address.subLocality?.takeIf { it.isNotBlank() }?.let(::add)
-                        address.thoroughfare?.takeIf { it.isNotBlank() }?.let(::add)
-                        address.subThoroughfare?.takeIf { it.isNotBlank() }?.let(::add)
-                        if (isEmpty()) address.getAddressLine(0)?.takeIf { it.isNotBlank() }?.let(::add)
-                    }.joinToString("").takeIf { it.isNotBlank() }
-                }
-        }.getOrNull()
+    override suspend fun reverse(latitude: Double, longitude: Double): String? {
+        sharedCache.get(latitude, longitude)?.let { return it }
+        return withContext(Dispatchers.IO) {
+            if (!Geocoder.isPresent()) return@withContext null
+            val resolved = runCatching {
+                @Suppress("DEPRECATION")
+                geocoder.getFromLocation(latitude, longitude, 1)
+                    ?.firstOrNull()
+                    ?.let { address ->
+                        buildList {
+                            address.adminArea?.takeIf { it.isNotBlank() }?.let(::add)
+                            address.locality?.takeIf { it.isNotBlank() && it != address.adminArea }?.let(::add)
+                            address.subLocality?.takeIf { it.isNotBlank() }?.let(::add)
+                            address.thoroughfare?.takeIf { it.isNotBlank() }?.let(::add)
+                            address.subThoroughfare?.takeIf { it.isNotBlank() }?.let(::add)
+                            if (isEmpty()) address.getAddressLine(0)?.takeIf { it.isNotBlank() }?.let(::add)
+                        }.joinToString("").takeIf { it.isNotBlank() }
+                    }
+            }.getOrNull()
+            sharedCache.put(latitude, longitude, resolved)
+            resolved
+        }
+    }
+
+    companion object {
+        private val sharedCache = GeocodeMemoryCache()
     }
 }

--- a/android/app/src/main/java/com/evchargebook/location/GeocodeMemoryCache.kt
+++ b/android/app/src/main/java/com/evchargebook/location/GeocodeMemoryCache.kt
@@ -1,0 +1,47 @@
+package com.evchargebook.location
+
+import kotlin.math.roundToLong
+
+/**
+ * Small process-local cache for derived address text.
+ *
+ * Coordinates remain the source of truth. Only successful, non-blank address text is cached;
+ * failures are intentionally not cached so a later user retry can call the geocoder again.
+ */
+class GeocodeMemoryCache(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES
+) {
+    init {
+        require(maxEntries > 0) { "maxEntries must be positive" }
+    }
+
+    private data class CoordinateKey(val latitudeBucket: Long, val longitudeBucket: Long)
+
+    private val entries = object : LinkedHashMap<CoordinateKey, String>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<CoordinateKey, String>?): Boolean =
+            size > maxEntries
+    }
+
+    @Synchronized
+    fun get(latitude: Double, longitude: Double): String? =
+        entries[key(latitude, longitude)]
+
+    @Synchronized
+    fun put(latitude: Double, longitude: Double, address: String?) {
+        val normalized = address?.trim()?.takeIf { it.isNotEmpty() } ?: return
+        entries[key(latitude, longitude)] = normalized
+    }
+
+    @Synchronized
+    internal fun size(): Int = entries.size
+
+    private fun key(latitude: Double, longitude: Double): CoordinateKey = CoordinateKey(
+        latitudeBucket = (latitude * COORDINATE_SCALE).roundToLong(),
+        longitudeBucket = (longitude * COORDINATE_SCALE).roundToLong()
+    )
+
+    companion object {
+        const val DEFAULT_MAX_ENTRIES = 128
+        private const val COORDINATE_SCALE = 10_000.0 // ~11 m latitude buckets; enough for address reuse.
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/location/GeocodeMemoryCacheTest.kt
+++ b/android/app/src/test/java/com/evchargebook/location/GeocodeMemoryCacheTest.kt
@@ -1,0 +1,38 @@
+package com.evchargebook.location
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GeocodeMemoryCacheTest {
+    @Test
+    fun `nearby coordinates reuse the same successful address`() {
+        val cache = GeocodeMemoryCache()
+        cache.put(31.23040, 121.47370, "上海市黄浦区")
+
+        assertEquals("上海市黄浦区", cache.get(31.23041, 121.47371))
+    }
+
+    @Test
+    fun `failed or blank geocode is not cached so later retry remains possible`() {
+        val cache = GeocodeMemoryCache()
+        cache.put(31.23040, 121.47370, null)
+        cache.put(31.23040, 121.47370, "   ")
+
+        assertNull(cache.get(31.23040, 121.47370))
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `cache stays bounded`() {
+        val cache = GeocodeMemoryCache(maxEntries = 2)
+        cache.put(31.0000, 121.0000, "A")
+        cache.put(31.1000, 121.1000, "B")
+        cache.put(31.2000, 121.2000, "C")
+
+        assertEquals(2, cache.size())
+        assertNull(cache.get(31.0000, 121.0000))
+        assertEquals("B", cache.get(31.1000, 121.1000))
+        assertEquals("C", cache.get(31.2000, 121.2000))
+    }
+}


### PR DESCRIPTION
## Summary

Close the remaining lightweight cache/retry gap in #66 without changing the coordinate-first Location architecture already on `main`.

Existing main already:
- separates `LocationProvider` from `AddressResolver`
- auto-requests current location when Add Charge opens with permission
- keeps raw coordinates independently from address text
- resolves address asynchronously
- preserves coordinates and allows manual location text when reverse geocoding fails
- exposes a `重新获取当前位置` retry action

This PR adds only:
- bounded process-local geocode cache (128 successful entries)
- ~11m coordinate buckets to avoid repeated reverse-geocoding of the same area
- successful non-blank address caching only
- failure/null/blank results are never cached, so later retries actually call Geocoder again
- JVM coverage for nearby-coordinate reuse, failure-not-cached behavior, and cache bounds

No database migration, map SDK, cloud lookup, polling, or new location service is introduced.

Refs #66