### PR TITLE
feat(android): enrich active Trip lock-screen status

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -58,17 +58,21 @@ class MainActivity : ComponentActivity() {
         MainViewModel.Factory(ChargingRepository(db, applicationContext))
     }
     private var openTripConfirmation by mutableStateOf(false)
+    private var openActiveTrip by mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         openTripConfirmation = intent.getBooleanExtra(EXTRA_OPEN_TRIP_CONFIRMATION, false)
+        openActiveTrip = intent.getBooleanExtra(EXTRA_OPEN_ACTIVE_TRIP, false)
         enableEdgeToEdge()
         setContent {
             EvChargeTheme {
                 MainApp(
                     viewModel = vm,
                     openTripConfirmation = openTripConfirmation,
-                    onTripConfirmationConsumed = { openTripConfirmation = false }
+                    onTripConfirmationConsumed = { openTripConfirmation = false },
+                    openActiveTrip = openActiveTrip,
+                    onActiveTripConsumed = { openActiveTrip = false }
                 )
             }
         }
@@ -78,10 +82,12 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         if (intent.getBooleanExtra(EXTRA_OPEN_TRIP_CONFIRMATION, false)) openTripConfirmation = true
+        if (intent.getBooleanExtra(EXTRA_OPEN_ACTIVE_TRIP, false)) openActiveTrip = true
     }
 
     companion object {
         const val EXTRA_OPEN_TRIP_CONFIRMATION = "open_trip_confirmation"
+        const val EXTRA_OPEN_ACTIVE_TRIP = "open_active_trip"
     }
 }
 
@@ -89,7 +95,9 @@ class MainActivity : ComponentActivity() {
 fun MainApp(
     viewModel: MainViewModel,
     openTripConfirmation: Boolean = false,
-    onTripConfirmationConsumed: () -> Unit = {}
+    onTripConfirmationConsumed: () -> Unit = {},
+    openActiveTrip: Boolean = false,
+    onActiveTripConsumed: () -> Unit = {}
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
@@ -152,6 +160,14 @@ fun MainApp(
         if (openTripConfirmation) {
             showBluetoothTripPrompt("已检测到车辆蓝牙连接，请确认是否开始本次行程")
             onTripConfirmationConsumed()
+        }
+    }
+
+    LaunchedEffect(openActiveTrip) {
+        if (openActiveTrip) {
+            viewModel.closeTripDetail()
+            tab = 3
+            onActiveTripConsumed()
         }
     }
 

--- a/android/app/src/main/java/com/evchargebook/domain/TripNotificationProgress.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripNotificationProgress.kt
@@ -1,0 +1,30 @@
+package com.evchargebook.domain
+
+import java.util.Locale
+
+/** Compact, truthful Trip progress for foreground/lock-screen notification surfaces. */
+object TripNotificationProgress {
+    fun format(elapsedSeconds: Long, distanceMeters: Double): String {
+        val safeSeconds = elapsedSeconds.coerceAtLeast(0L)
+        val safeDistance = distanceMeters.takeIf { it.isFinite() && it >= 0.0 } ?: 0.0
+        return "${formatDuration(safeSeconds)} · ${formatDistance(safeDistance)}"
+    }
+
+    private fun formatDuration(seconds: Long): String {
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        val remainingSeconds = seconds % 60
+        return if (hours > 0) {
+            "${hours}小时${minutes}分"
+        } else {
+            "${minutes}分${remainingSeconds}秒"
+        }
+    }
+
+    private fun formatDistance(meters: Double): String =
+        if (meters >= 1000.0) {
+            String.format(Locale.US, "%.2f km", meters / 1000.0)
+        } else {
+            String.format(Locale.US, "%.0f m", meters)
+        }
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -30,6 +30,7 @@ import com.evchargebook.domain.TripDiagnosticSamplingRules
 import com.evchargebook.domain.TripGpsHealth
 import com.evchargebook.domain.TripGpsHealthSnapshot
 import com.evchargebook.domain.TripGpsHealthStatus
+import com.evchargebook.domain.TripNotificationProgress
 import com.evchargebook.domain.TripRules
 import com.evchargebook.domain.TripSamplingRules
 import com.evchargebook.domain.TripServiceLifecycleRules
@@ -57,6 +58,8 @@ class TripTrackingService : Service() {
     private var healthMonitorJob: Job? = null
 
     @Volatile private var trackingStartedAtEpochMillis: Long = 0L
+    @Volatile private var tripStartedAtEpochMillis: Long = 0L
+    @Volatile private var currentDistanceMeters: Double = 0.0
     @Volatile private var lastCallbackAtEpochMillis: Long? = null
     @Volatile private var lastAcceptedPointAtEpochMillis: Long? = null
     @Volatile private var lastAcceptedProvider: String? = null
@@ -117,6 +120,8 @@ class TripTrackingService : Service() {
         if (currentTripId == tripId) return
         currentTripId = tripId
         trackingStartedAtEpochMillis = System.currentTimeMillis()
+        tripStartedAtEpochMillis = 0L
+        currentDistanceMeters = 0.0
         lastCallbackAtEpochMillis = null
         lastAcceptedPointAtEpochMillis = null
         lastAcceptedProvider = null
@@ -146,6 +151,8 @@ class TripTrackingService : Service() {
                 stopTrackingAndSelf()
                 return@launch
             }
+            tripStartedAtEpochMillis = session.startedAtEpochMillis
+            currentDistanceMeters = session.distanceMeters
             recordEvent(
                 tripId,
                 if (redelivered) TripDiagnosticEventType.SERVICE_REDELIVERED else TripDiagnosticEventType.SERVICE_START,
@@ -156,6 +163,7 @@ class TripTrackingService : Service() {
                 lastAcceptedPointAtEpochMillis = it.capturedAtEpochMillis
                 lastAcceptedProvider = it.provider
             }
+            updateNotification()
             requestLocationUpdatesOrInterrupt(tripId)
             startHealthMonitor()
         }
@@ -335,6 +343,7 @@ class TripTrackingService : Service() {
                 maxAltitudeMeters = mergeMax(session.maxAltitudeMeters, altitude)
             )
         )
+        currentDistanceMeters = newDistance
         updateNotification()
     }
 
@@ -395,6 +404,8 @@ class TripTrackingService : Service() {
         healthMonitorJob = null
         runCatching { locationManager.removeUpdates(locationListener) }
         currentTripId = null
+        tripStartedAtEpochMillis = 0L
+        currentDistanceMeters = 0.0
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         stopSelf()
     }
@@ -430,18 +441,22 @@ class TripTrackingService : Service() {
         .setContentText(notificationText(snapshot))
         .setOngoing(true)
         .setOnlyAlertOnce(true)
-        .setContentIntent(PendingIntent.getActivity(this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE))
+        .setContentIntent(openActiveTripPendingIntent(0))
         .addAction(
             android.R.drawable.ic_menu_view,
             "打开行程",
-            PendingIntent.getActivity(
-                this,
-                1,
-                Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
+            openActiveTripPendingIntent(1)
         )
         .build()
+
+    private fun openActiveTripPendingIntent(requestCode: Int): PendingIntent = PendingIntent.getActivity(
+        this,
+        requestCode,
+        Intent(this, MainActivity::class.java)
+            .putExtra(MainActivity.EXTRA_OPEN_ACTIVE_TRIP, true)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP),
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
 
     private fun notificationTitle(status: TripGpsHealthStatus): String = when (status) {
         TripGpsHealthStatus.WAITING, TripGpsHealthStatus.GOOD -> "EV Charge Book 正在记录行程"
@@ -451,6 +466,10 @@ class TripTrackingService : Service() {
     }
 
     private fun notificationText(snapshot: TripGpsHealthSnapshot): String {
+        val progressText = tripStartedAtEpochMillis.takeIf { it > 0L }?.let { startedAt ->
+            val elapsedSeconds = ((System.currentTimeMillis() - startedAt) / 1000).coerceAtLeast(0L)
+            TripNotificationProgress.format(elapsedSeconds, currentDistanceMeters)
+        }
         val ageText = snapshot.secondsSinceLastAcceptedPoint?.let { "最近有效定位 ${formatAge(it)}前" } ?: snapshot.message
         val providerText = when (lastAcceptedProvider) {
             LocationManager.GPS_PROVIDER -> "GPS"
@@ -458,7 +477,12 @@ class TripTrackingService : Service() {
             null -> null
             else -> lastAcceptedProvider
         }
-        return listOfNotNull(ageText, providerText, rejectedPointCount.takeIf { it > 0 }?.let { "已过滤 $it 点" }).joinToString(" · ")
+        return listOfNotNull(
+            progressText,
+            ageText,
+            providerText,
+            rejectedPointCount.takeIf { it > 0 }?.let { "已过滤 $it 点" }
+        ).joinToString(" · ")
     }
 
     private fun formatAge(seconds: Long): String = if (seconds < 60) "${seconds}秒" else "${seconds / 60}分${seconds % 60}秒"

--- a/android/app/src/test/java/com/evchargebook/domain/TripNotificationProgressTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripNotificationProgressTest.kt
@@ -1,0 +1,21 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripNotificationProgressTest {
+    @Test
+    fun `formats sub-hour trip progress compactly`() {
+        assertEquals("12分34秒 · 5.42 km", TripNotificationProgress.format(754, 5_420.0))
+    }
+
+    @Test
+    fun `formats long trip without seconds noise`() {
+        assertEquals("1小时23分 · 860 m", TripNotificationProgress.format(5_020, 860.0))
+    }
+
+    @Test
+    fun `sanitizes invalid values`() {
+        assertEquals("0分0秒 · 0 m", TripNotificationProgress.format(-3, Double.NaN))
+    }
+}


### PR DESCRIPTION
## Summary

Implement the first compact lock-screen / ongoing-notification slice from #26 on current `main`.

- show actual Trip elapsed time in the ongoing foreground notification
- show the already-trusted persisted Trip distance; do not recalculate or invent movement in the notification layer
- refresh progress with the existing 10s health-monitor cadence so elapsed time remains useful while stationary
- make both notification tap and `打开行程` route directly to the Trip tab through a dedicated active-Trip intent extra
- keep GPS health / last accepted provider / rejected-point diagnostics in the same notification
- keep precise coordinates and addresses out of lock-screen notification text
- preserve the end-SOC completion boundary: notification does **not** directly complete a Trip or bypass the in-app end-SOC flow
- add pure Kotlin formatter + JVM coverage

## Architecture boundary

No WorkManager, second tracking service, new database state, background polling, or notification framework is introduced. This reuses the existing foreground service and `MainActivity` navigation state.

## Remaining #26 after this PR

- optional trusted current/recent speed display
- explicit repair UX for interrupted/service-restart/provider-disabled states
- permission-revoked / system Location repair deep links
- one-time battery-optimization/background restriction guidance

Refs #26