### PR TITLE
feat(android): request Trip notifications without blocking tracking

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -32,6 +32,7 @@ import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.export.ChargingCsvExporter
 import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.domain.TripNotificationPermissionPolicy
 import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.ui.dashboard.DashboardScreen
 import com.evchargebook.ui.records.AddRecordScreen
@@ -51,6 +52,9 @@ import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+
+private const val TRIP_PERMISSION_PREFS = "trip_permission_prompts"
+private const val KEY_TRIP_NOTIFICATION_PERMISSION_REQUESTED = "notification_requested"
 
 class MainActivity : ComponentActivity() {
     private val vm: MainViewModel by viewModels {
@@ -104,6 +108,9 @@ fun MainApp(
     val lifecycleOwner = LocalLifecycleOwner.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val tripPermissionPrefs = remember(context) {
+        context.getSharedPreferences(TRIP_PERMISSION_PREFS, android.content.Context.MODE_PRIVATE)
+    }
     var tab by remember { mutableIntStateOf(0) }
     var editVehicle by remember { mutableStateOf(false) }
     var addVehicle by remember { mutableStateOf(false) }
@@ -191,6 +198,30 @@ fun MainApp(
             bluetoothPrompt = true
         }
     }
+    val tripNotificationPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (!granted) {
+            scope.launch {
+                snackbarHostState.showSnackbar("行程会继续记录；通知权限未开启，锁屏可能看不到持续状态。可稍后在系统设置中开启。")
+            }
+        }
+    }
+
+    fun maybeRequestTripNotificationPermission() {
+        val permissionGranted = Build.VERSION.SDK_INT < TripNotificationPermissionPolicy.NOTIFICATION_RUNTIME_PERMISSION_API ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        val alreadyRequested = tripPermissionPrefs.getBoolean(KEY_TRIP_NOTIFICATION_PERMISSION_REQUESTED, false)
+        if (
+            TripNotificationPermissionPolicy.shouldRequest(
+                apiLevel = Build.VERSION.SDK_INT,
+                permissionGranted = permissionGranted,
+                alreadyRequestedForTrip = alreadyRequested
+            )
+        ) {
+            tripPermissionPrefs.edit().putBoolean(KEY_TRIP_NOTIFICATION_PERMISSION_REQUESTED, true).apply()
+            tripNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
     val bluetoothPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
         if (granted) {
             if (Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
@@ -208,6 +239,7 @@ fun MainApp(
             val resumeId = pendingResumeTripId
             pendingResumeTripId = null
             if (resumeId != null) viewModel.resumeTrip(resumeId) else viewModel.startTrip()
+            maybeRequestTripNotificationPermission()
         } else {
             pendingResumeTripId = null
             scope.launch { snackbarHostState.showSnackbar("需要定位权限才能记录真实行程轨迹") }
@@ -227,13 +259,19 @@ fun MainApp(
 
     fun startTripWithPermission() {
         pendingResumeTripId = null
-        if (hasLocationPermission()) viewModel.startTrip()
-        else tripLocationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+        if (hasLocationPermission()) {
+            viewModel.startTrip()
+            maybeRequestTripNotificationPermission()
+        } else {
+            tripLocationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+        }
     }
 
     fun resumeTripWithPermission(tripId: Long) {
-        if (hasLocationPermission()) viewModel.resumeTrip(tripId)
-        else {
+        if (hasLocationPermission()) {
+            viewModel.resumeTrip(tripId)
+            maybeRequestTripNotificationPermission()
+        } else {
             pendingResumeTripId = tripId
             tripLocationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
         }

--- a/android/app/src/main/java/com/evchargebook/domain/TripNotificationPermissionPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripNotificationPermissionPolicy.kt
@@ -1,0 +1,14 @@
+package com.evchargebook.domain
+
+object TripNotificationPermissionPolicy {
+    const val NOTIFICATION_RUNTIME_PERMISSION_API = 33
+
+    fun shouldRequest(
+        apiLevel: Int,
+        permissionGranted: Boolean,
+        alreadyRequestedForTrip: Boolean
+    ): Boolean =
+        apiLevel >= NOTIFICATION_RUNTIME_PERMISSION_API &&
+            !permissionGranted &&
+            !alreadyRequestedForTrip
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripNotificationPermissionPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripNotificationPermissionPolicyTest.kt
@@ -1,0 +1,51 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripNotificationPermissionPolicyTest {
+    @Test
+    fun `requests once on android 13 plus when missing`() {
+        assertTrue(
+            TripNotificationPermissionPolicy.shouldRequest(
+                apiLevel = 33,
+                permissionGranted = false,
+                alreadyRequestedForTrip = false
+            )
+        )
+    }
+
+    @Test
+    fun `does not request on older android`() {
+        assertFalse(
+            TripNotificationPermissionPolicy.shouldRequest(
+                apiLevel = 32,
+                permissionGranted = false,
+                alreadyRequestedForTrip = false
+            )
+        )
+    }
+
+    @Test
+    fun `does not request when already granted`() {
+        assertFalse(
+            TripNotificationPermissionPolicy.shouldRequest(
+                apiLevel = 35,
+                permissionGranted = true,
+                alreadyRequestedForTrip = false
+            )
+        )
+    }
+
+    @Test
+    fun `does not nag again after Trip prompt was already shown`() {
+        assertFalse(
+            TripNotificationPermissionPolicy.shouldRequest(
+                apiLevel = 35,
+                permissionGranted = false,
+                alreadyRequestedForTrip = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Complete the Android 13+ notification-permission slice from #26 without making notifications a prerequisite for Trip recording.

- on Android 13+ request `POST_NOTIFICATIONS` once when the user starts or resumes a Trip and permission is still missing
- start/resume the Trip **before** launching the notification permission dialog so GPS tracking is never blocked or delayed by the prompt
- if location permission had to be requested first, start/resume after location grant and only then request notification permission
- denial keeps the Trip running and shows a truthful Snackbar: lock-screen ongoing status may be unavailable, but recording continues
- persist a small Trip-specific one-time prompt flag so later Trips do not nag repeatedly
- Android 12 and below do not run the runtime notification prompt
- keep the existing Bluetooth notification-permission flow unchanged
- add pure Kotlin prompt policy + JVM coverage

## Boundary

No foreground-service changes, database migration, background worker, notification polling, or Trip business-rule change. This only controls whether the existing #130/#131 notification UX is visible on Android 13+.

## Remaining #26 after this PR

- physical-device verification of lock-screen progress, active-Trip deep link, repair notifications, settings round-trip, and allow/deny behavior
- optional trusted current/recent speed only if device use proves valuable
- battery-optimization guidance only if physical evidence shows it is necessary

Refs #26