### PR TITLE
docs: reconcile roadmap and project master with current main

### DIFF
--- a/docs/PROJECT_MASTER.md
+++ b/docs/PROJECT_MASTER.md
@@ -1,7 +1,7 @@
 # EV Charge Book 项目总纲（PROJECT MASTER）
 
-版本: v2.2.0
-更新时间: 2026-08-27
+版本: v2.3.0
+更新时间: 2026-08-28
 状态: Authority Document / Single Source of Truth
 
 ## 1. 项目定位
@@ -44,6 +44,8 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 
 实现与文档冲突时，先以当前代码、CI 与真机事实为准，再修正文档。
 
+阶段状态必须区分：代码已实现、CI Green、真机功能验收、真机视觉验收和 Production Release 验收。不得用其中一个替代另一个。
+
 ---
 
 ## 3. 产品原则
@@ -62,19 +64,21 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - 无网络和云端故障不能阻塞本地记账 / Trip
 - GPS 缺失不得通过假路线或假距离静默补齐
 - 速度必须保留来源语义，不把 GNSS / 派生值 / future OBD 混成无来源真值
+- 地址是坐标的派生展示，不能反过来成为 Location 事实的前置条件
+- notification 是后台状态可见性，不得成为 Trip 是否能记录的业务前置条件
 - 正式 APK 版本只在真正执行 Production Release 时生成；普通业务提交不得为了代码变化而升级正式版本
 
 ---
 
 ## 4. v0.1 状态: Released / Accepted
 
-已完成充电记录 CRUD、车辆编辑、Dashboard/Records/Stats、核心规则测试、Android CI、真机 CRUD、signed production APK 与原子发布。
+已完成充电记录 CRUD、车辆编辑、Dashboard / Records / Stats、核心规则测试、Android CI、真机 CRUD、signed production APK 与原子发布。
 
 ---
 
-## 5. v0.2 状态: Core Accepted / Reliability Hardening
+## 5. v0.2 状态: Core Implemented / Physical Reliability Revalidation
 
-已完成并经过当前真机功能验证：
+基础能力已经实现：
 
 - odometer + migration
 - Local Backup / Restore
@@ -84,102 +88,214 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - AddressResolver + Android Geocoder
 - TripSession / TripPoint
 - foreground tracking / notification
-- Trip start / stop / interrupted resume / detail
+- Trip start / completion / interrupted resume / detail
 - distance / elapsed / moving / stopped
 - speed / bearing / GPS altitude / accuracy
 - GPS bad-point / jump filtering
-- stationary throttling
+- app-level stationary write throttling
 - TripRouteGeometry + 无底图真实轨迹预览
 
-Trip #15 与 Bluetooth #21 已按此前真机功能反馈关闭，但真实长行程数据暴露出新的 reliability follow-up，不重新打开旧基础功能验收结论。
+### 5.1 post-RC Trip reliability 当前事实
 
-### 真实 Trip #7 新结论
+真实 Trip #7 和后续 2026-08-27 设备数据证明：`COMPLETED` 只表示业务收口，不代表 GPS 全程连续；foreground service 存在也不等于 Location callback 必然持续。
 
-2026-08-27 导出的真实 Trip #7 出现约 12 分 29 秒和 15 分 17 秒的 GPS gap。
-
-因此：
-
-- `COMPLETED` 只表示行程最终正常收口，不表示 GPS 全程连续。
-- foreground service 存在不等于 Location callback 一定持续。
-- MapLibre 不是当前优先级；必须先让 GPS continuity 可观察、可诊断、可解释。
-
-PR #35 已将该方向写入正式设计；PR #36 第一阶段代码已实现并通过 Android Build Run #184。
-
-已实现第一阶段：
+当前代码已经继续补齐：
 
 - runtime `TripGpsHealth`
-- 15s / 30s / 120s health thresholds
-- ongoing notification 周期刷新 GPS health / last accepted age / provider / rejected count
-- 长 gap route geometry 拆段，禁止假实线
-- 全程均速 / 行驶均速 / 最高速度 / moving time 语义拆分
+- callback heartbeat 与 accepted-point heartbeat 分离
+- WAITING / GOOD / DEGRADED / LOST / LONG_GAP
+- long-gap route segmentation，不画假实线
+- long-gap 两端不计可信连续距离
+- foreground Location callback 使用 time-based liveness，不再依赖 8m displacement gate
+- stationary write throttling 继续留在 `TripSamplingRules`
+- provider / permission / service lifecycle / re-delivery diagnostics
+- coarse/network max-speed peak rejection
+- extreme GPS speed 缺失 speedAccuracy 时降低信任
+- trusted speed-colored route presentation
+- 起点/终点形状 + 文本语义
 
-仍需 P0：
+Issue #77 保留为 post-RC 真机可靠性验收：另一 App 前台、2–3 分钟 stationary hold、真实 callback/provider loss 和 stationary write volume 必须通过真实设备验证。不得因为当前 CI Green 就关闭。
 
-1. 长 gap 两端不参与可信距离累计
-2. GPS / Network point 去重与择优
-3. longest gap / provider counters / rejected reason 持久摘要
-4. service restart / re-delivery evidence
-5. 锁屏长行程真机复验
+### 5.2 海拔与 Trip validity
 
-MapLibre 继续作为可选展示层，不是业务阶段门槛。
+当前 `main` 已实现：
+
+- Trip start/end/min/max altitude
+- trusted cumulative elevation gain / loss
+- vertical accuracy filtering + jitter deadband
+- cumulative elevation 不跨 LONG_GAP
+- conservative Trip validity classification
+- 明确空/异常完成 Trip 从 Dashboard 与汇总 analytics 排除
+- 极短真实 Trip 只进入 REVIEW，不自动删除、不自动排除
+- 删除始终由用户显式确认
+
+对应代码工作 #69/#68 已完成关闭。
+
+MapLibre 继续作为可选展示层，不是当前业务阶段门槛。
 
 ---
 
 ## 6. 速度与距离事实模型
 
-### 6.1 当前距离
+### 6.1 距离
 
-当前 Trip distance 由连续 accepted location point 的地理距离累计得到。
+Trip distance 来自连续可信 accepted location point 的地理距离累计。
 
 它不是道路里程，也不是车辆轮速里程，因此弯路、采样稀疏、provider switch、GPS gap 都可能影响结果。
 
-原则：长 gap 两端不能继续被视为可信连续距离。
+当前规则：LONG_GAP 两端不能继续作为可信连续距离；原始 TripPoint 证据保留，派生统计只决定“什么可以进入汇总”。
 
-### 6.2 当前瞬时 / 最高速度
+### 6.2 瞬时 / 最高速度
 
-当前 TripPoint `speedMps` 和最高已记录速度主要来自 Android `Location.speed`，不是简单的两点直线距离 / 时间。
+TripPoint `speedMps` 主要来自 Android `Location.speed`，不是简单的两点直线距离 / 时间。
 
-因此产品必须区分：
+产品继续区分：
 
 - `Location.speed`：定位系统报告的时刻速度
-- derived segment speed：连续可信点的距离 / 时间及窗口统计
-- whole-trip / moving average：依赖累计 recorded distance 的派生统计
+- derived segment evidence：连续可信点的距离 / 时间及窗口证据
+- whole-trip / moving average：依赖累计 trusted distance 的派生统计
 
-短时峰值可能因为采样窗口没有命中而漏采。例如峰值只持续约 4 秒，而采样目标为 2-5 秒时，不能保证一定保存到该峰值。
+最高速度只允许可信 GPS evidence 更新；coarse/network provider 和缺失关键 accuracy evidence 的 extreme peak 不应成为 max-speed 真值。
 
 UI 应称“最高已记录速度”，不得宣称未采样到的真实车辆峰值。
 
-### 6.3 P1 速度可视化
+### 6.3 速度轨迹
 
-后续 `TripSpeedSegment`：
+当前 route 已能按可信 GPS speed 进行颜色表达，同时保留：
 
-- 基于连续可信 GPS segment
-- 结合 `Location.speed` / speed accuracy / point-to-point evidence
-- 不跨 LONG_GAP
-- 连续红 -> 黄 -> 绿 -> 蓝表示本车速度分布
-- 无道路类型 / 限速 / 交通数据前，不使用真实“拥堵/畅通”交通标签
+- unknown speed 灰色语义
+- LONG_GAP 断开
+- legend / 区间说明
+- “颜色表示本车速度，不代表真实道路交通状态”说明
+
+不为了速度轨迹提前引入 MapLibre 或道路限速/拥堵语义。
 
 ---
 
-## 7. v0.3 状态: Feature Complete Candidate / Reliability Follow-up
+## 7. v0.3 状态: Feature Complete / Incremental Follow-up Only
 
-已实现充电区间、费用/100km、电量/100km、Trip 覆盖、SOC 可信度、月趋势、月环比、charger type、ChargingPlace、常用地点复用、CSV 与异常提示。
+已实现：
 
-v0.3 当前不扩重型 chart、独立 ChargingPlace 表或无真实需求的期间筛选。Reliability follow-up 优先于继续堆统计 UI。
+- charging interval odometer distance
+- cost / 100km estimate
+- charged kWh / 100km estimate
+- Trip + odometer coverage evidence
+- SOC confidence hints
+- month trend / month-over-month
+- charger type mix
+- ChargingPlace aggregation / common-place reuse
+- charging CSV analysis export
+- non-blocking anomaly hints
+- Local JSON Backup / Restore
+- Trip validity-aware analytics
+- Charge 桩端事实与 Trip SOC energy estimate 分层展示
+
+Issue #19 已完成关闭。
+
+不为了“数据治理框架完整”新增独立 ChargingPlace Room 表、统一 confidence 分数或不必要的 source metadata。Privacy Zone 等能力在真实 route export/share 出现前再推进。
 
 ---
 
 ## 8. v0.4 Local First Sync Foundation
 
-Vehicle + ChargingRecord 已具备 stable `syncId`、`updatedAtEpochMillis`、ChargingRecord tombstone、Room v6 -> v7 migration、旧数据补 identity、Backup schema v6 与 sync identity tests。
+Phase A 已完成：
 
-`SYNC_PROTOCOL.md` 已固定第一版 payload / idempotency / tombstone / conflict / cursor 边界。
+- Vehicle `syncId` + `updatedAtEpochMillis`
+- ChargingRecord `syncId` + `updatedAtEpochMillis`
+- ChargingRecord tombstone
+- explicit Room migration / old identity generation
+- Backup / Restore 保留 sync metadata
+- active UI / analytics 排除 tombstone
+- pure JVM identity tests
 
-当前策略：不删除、不回退现有 sync foundation，但暂停继续扩 Spring Boot / PostgreSQL / Trip cloud sync，直到 Trip P0 reliability 具备可观察性并完成一次锁屏长行程复验。
+Issue #28 已完成关闭；父 Issue #27 继续承担 Phase B / Phase C。
+
+`SYNC_PROTOCOL.md` 保留第一版 payload / idempotency / tombstone / conflict / cursor 边界。
+
+下一步仍坚持最小方案：Vehicle + ChargingRecord 的 envelope、push/pull cursor、幂等 upsert、tombstone propagation、简单 conflict policy，然后才是 HTTPS + Spring Boot monolith + PostgreSQL。
+
+当前不做：TripSession / TripPoint cloud sync、CRDT、微服务、Kafka/MQ、云端成为唯一备份。
 
 ---
 
-## 9. P3 Optional Vehicle Data / OBD-II
+## 9. v0.5 Local Experience / VehicleState 状态: Code Baseline Implemented / Physical Closeout
+
+### 9.1 UI
+
+已合并 Dark First 基线与核心页面重构（#71），并继续补齐：
+
+- Dashboard dynamic Vehicle Hero（#96）
+- Dashboard recent Trip card（#100）
+- current SOC / current mileage VehicleState presentation
+- release updater Dashboard dark/green visual alignment（#126）
+
+#70/#94/#95/#42/#22 仍保留真机视觉 / accessibility / large-font / small-screen closeout，不从 CI 推导视觉验收。
+
+### 9.2 Trip SOC / mileage / energy -> VehicleState
+
+PR #87 等当前基线已经实现：
+
+- Trip start snapshot 当前 VehicleState SOC / mileage
+- completion 要求 explicit end SOC
+- end mileage 默认按 start mileage + GPS distance 预填并允许修正
+- TripSession 保存 start/end SOC + mileage
+- 只有正向可信 SOC drop 才估算 consumed energy
+- required inputs 足够时才估算 kWh / 100km
+- Trip completion 后 end SOC / mileage 回写 VehicleState
+- 删除完成 Trip 后重新构建 VehicleState
+- 后发生的 Charge / manual VehicleState 保持 authority，不被更老 Trip 回滚
+
+Issue #124 专门负责真机数据闭环验收，不再创建重复实现 PR。
+
+### 9.3 Location / address optionality
+
+当前原则已经落地：coordinates 是事实，address 是派生展示。
+
+- Add Charge 有权限时自动请求当前位置
+- Geocoder failure 不阻塞坐标事实
+- 可继续手填地点
+- `LocationProvider` / `AddressResolver` 分离
+- successful geocode 使用 bounded process-local cache
+- failed / blank result 不缓存，下次用户 retry 会重新调用 Geocoder
+
+Issue #66 已完成；真实权限 / Geocoder / backup-restore 继续由 #14 真机验收。
+
+### 9.4 Lock-screen / background Trip UX
+
+PR #130/#131/#132 已形成当前必要代码基线：
+
+- ongoing notification 显示 Trip elapsed time + trusted persisted distance
+- notification tap / `打开行程` 直接进入 active Trip
+- 锁屏文本不泄露精确坐标 / 地址
+- runtime Location permission loss -> `INTERRUPTED` + one-shot repair notification
+- no usable location provider -> `INTERRUPTED` + system Location repair action
+- repair 后不会自动恢复 tracking；用户回 Trip 明确 resume
+- stale repair warning 在 resume/start 后清除
+- Android 13+ Trip notification permission 在 tracking 已开始/恢复后请求
+- notification denial 不阻塞、不回滚 Trip
+- Trip 场景只做一次 notification permission prompt，避免重复打扰
+- 通知不能直接 complete Trip，结束仍进入 App 输入 end SOC
+
+Issue #26 现在只保留真机 acceptance，以及 trusted current speed / battery optimization guidance 两项 evidence-driven optional。
+
+### 9.5 Production APK updater
+
+当前已实现：
+
+- release manifest `latest.json`
+- higher version discovery
+- DownloadManager
+- SHA-256 verification
+- unknown-source permission flow
+- Android system installer handoff
+- root app composition wiring（#103）
+- Dashboard-style non-modal updater UI（#126）
+
+Issue #102 保留 old-production APK -> newer-production APK 的真实覆盖升级验收。不能只凭 Debug CI 关闭。
+
+---
+
+## 10. P3 Optional Vehicle Data / OBD-II
 
 OBD-II 是未来可选数据源，不是当前产品依赖。
 
@@ -192,30 +308,30 @@ VehicleSpeedSource
 
 第一个 PoC 只验证：
 
-- 外接 Bluetooth/BLE/Wi-Fi OBD-II adapter
+- 外接 Bluetooth / BLE / Wi-Fi OBD-II adapter
 - 查询标准 Vehicle Speed 支持
-- 读取 OBD Vehicle Speed
+- 读取标准 OBD Vehicle Speed
 - 与 GNSS speed 对照
 
 当前明确不做：厂商私有 CAN ID 逆向、私有 BMS PID 逆向、单车型复杂协议维护、让 OBD 成为 Trip 必需依赖。
 
-如果 Vehicle Speed PoC 稳定且有产品价值，再评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
+只有 Vehicle Speed PoC 稳定且有产品价值后，才评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
 
 ---
 
-## 10. 恢复与隐私
+## 11. 恢复与隐私
 
 - Local JSON Backup 长期保留
 - Cloud Sync 不是唯一恢复路径
 - restore 失败不得破坏当前数据
-- 持续定位必须可见
+- 持续定位必须可见；通知权限被拒绝也不得阻止 Trip 本身记录
 - ongoing notification 不显示精确经纬度 / HOME / WORK 地址
-- 路线公开分享/导出之前实现 Privacy Zone
+- 路线公开分享 / 导出之前实现 Privacy Zone
 - 云同步轨迹需要明确产品同意与隐私说明
 
 ---
 
-## 11. 发布 / CI / APK 自动升级基线
+## 12. 发布 / CI / APK 自动升级基线
 
 - JDK 17
 - Android SDK 36
@@ -232,17 +348,21 @@ VehicleSpeedSource
 - 下载后 SHA-256 校验
 - 最终由 Android 系统安装器完成覆盖安装
 
-详细规则见 `CI_CD.md` 与 `APK_AUTO_UPDATE.md`。
+近期 current-head evidence：
 
-近期关键验收：
+- #123 Android Build #408 Green：extreme Trip max-speed trust
+- #127 Android Build #414 Green：Trip elevation analytics
+- #128 Android Build #417 Green：Trip validity / cleanup
+- #129 Android Build #419 Green：geocode cache / retry
+- #130 Android Build #422 Green：lock-screen Trip progress / active-Trip deep link
+- #131 Android Build #424 Green：provider / permission repair notifications
+- #132 Android Build #426 Green：Android 13+ non-blocking Trip notification permission
 
-- Build Run #169：ChargingPlace + CSV 基线 Green
-- Build Run #184：PR #36 Trip GPS health / route gap / speed semantics，Build/Test + Debug APK Green
-- APK auto-update Android CI：当前等待最新 updater cumulative build 完成
+这些 CI 只证明自动化 build/test；#77/#124/#26/#14/#70/#94/#95/#42/#22/#102 的真机 acceptance 仍独立存在。
 
 ---
 
-## 12. 架构约束
+## 13. 架构约束
 
 Android 保持：
 
@@ -250,7 +370,7 @@ Android 保持：
 Compose -> MainViewModel -> ChargingRepository -> Room DAO -> Room
 ```
 
-v0.4 云端第一版保持：
+未来 v0.4 云端第一版保持：
 
 ```text
 Android Room
@@ -259,31 +379,35 @@ Spring Boot Monolith
    -> PostgreSQL
 ```
 
-不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ 或其他当前没有收益的基础设施。
+不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ、第二套 Trip tracking service、为了通知增加 WorkManager 或其他当前没有收益的基础设施。
 
 OBD 未来也必须是 optional adapter，不允许反向污染核心 Trip 架构。
 
 ---
 
-## 13. 当前执行顺序
+## 14. 当前执行顺序
 
 ```text
-Trip P0 reliability
-  -> long-gap distance correction
-  -> GPS / Network dedupe + quality policy
-  -> Trip completeness / persistent diagnostics
-  -> lock-screen long-drive physical verification
-  -> Trip P1 segmented speed + continuous color route
-  -> v0.3 reliability closeout
-  -> resume v0.4 sync expansion
+v0.5 physical acceptance bundle
+  -> #77 background / stationary Trip reliability
+  -> #124 Trip SOC -> VehicleState data closure
+  -> #26 lock-screen / repair notification round-trip
+  -> #14 Location / Geocoder device behavior
+  -> #70 / #94 / #95 / #42 / #22 UI-device checks
+  -> #102 old-production -> new-production updater flow
+  -> only fix concrete device regressions
+  -> resume #27 minimal sync protocol/runtime
+  -> advance #20 catalog pipeline when data-source/coverage work is justified
   -> P3 OBD-II Vehicle Speed PoC only when justified
 ```
 
-APK 自动升级属于发布基础设施，不改变当前业务优先级；它随 Production Release 验收独立推进。
+APK 自动升级属于发布基础设施；它随 Production Release 验收独立推进。
+
+MapLibre 继续保持低优先级；已有真实 WGS84 route preview，不为了路线“看起来完整”提前引入地图 SDK。
 
 ---
 
-## 14. 开发验收规则
+## 15. 开发验收规则
 
 每轮业务代码必须：
 
@@ -295,26 +419,57 @@ APK 自动升级属于发布基础设施，不改变当前业务优先级；它�
 - 不把“代码已写”标成“CI Accepted”
 - 不把 CI 通过标成“真机已验收”
 - GPS `COMPLETED` 不等同于 continuity accepted
+- notification available 不等同于 tracking data accepted
+- Open Issue 不等同于“代码还没写”；先检查 owning PR / current `main`
 
 正式 APK 版本规则：
 
 - 不发布 APK -> 不触发 Android Release -> 不升级正式版本
-- 需要下发 APK -> Android CI Green -> 手动 Android Release -> 自动生成正式版本
+- 需要下发 APK -> current-head Android CI Green -> 手动 Android Release -> 自动生成正式版本
 
 ---
 
-## 15. 当前 Issues
+## 16. 当前 Issues
 
-- #19 Data Reliability：只保留增量可靠性尾项
-- #22 UI polish：主要视觉工作已合并，真机视觉复核非阻塞
-- #26 Background activity / lock-screen Trip status / notification center
-- #27 v0.4 Sync 主线：foundation 保留，扩展暂缓
-- #28 Sync Phase A 实现与验收
-- #20 Catalog Coverage：后续可持续车型目录管道
+### 代码主体已完成、等待真机/视觉验收
+
+- #14 Location / Geocoder
+- #22 top spacing / density
+- #26 background / lock-screen / repair notification
+- #42 accessibility / large font / small screen / state safety
+- #67 trajectory presentation device check
+- #70 v0.5 core UI physical closeout
+- #77 background callback / stationary hold
+- #94 Dashboard dynamic Hero
+- #95 recent Trip card
+- #102 Production APK auto-update
+- #124 Trip SOC -> VehicleState
+
+### 后续真正业务扩展
+
+- #27 Local First Sync Phase B / smallest cloud slice
+- #20 scalable Vehicle Catalog pipeline
+
+### Repository / maintenance
+
+- #6 authoritative docs ongoing maintenance
+- #75 main branch protection / required CI，需要 repository administration 权限；不通过代码 PR 伪实现
 
 ---
 
-## 16. 决策记录
+## 17. 决策记录
+
+### v2.3.0
+
+- reconciled PROJECT_MASTER with current `main` after reliability/data-quality work through #123/#127/#128/#129
+- recorded Trip SOC/mileage/energy -> VehicleState authority and #124 physical acceptance boundary
+- recorded dynamic Dashboard Hero / recent Trip baseline (#96/#100)
+- recorded updater wiring/UI baseline (#103/#126) while retaining #102 Production APK acceptance
+- recorded lock-screen Trip progress and direct active-Trip navigation (#130)
+- recorded explicit provider/permission interruption repair flow (#131)
+- recorded Android 13+ non-blocking Trip notification permission semantics (#132)
+- changed current execution from “implement Trip P0 slices” to “physical acceptance bundle, then resume minimal Local First sync”
+- retained simple architecture boundaries; no WorkManager/second tracking service/MapLibre requirement introduced
 
 ### v2.2.0
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,19 +1,29 @@
 # EV Charge Book Roadmap
 
-版本: v2.6.0
-更新时间: 2026-08-27
+版本: v2.7.0
+更新时间: 2026-08-28
 
 ## 0. 路线原则
 
-以 PROJECT_MASTER / PRODUCT / FEATURE_MATRIX 为准。
+以 `PROJECT_MASTER.md` / `PRODUCT.md` / `FEATURE_MATRIX.md` 为准。
 
 继续坚持：简单可维护、Local First、真实数据、先验收后扩功能；原始事实、派生值与估算值必须区分。
+
+阶段状态必须区分：
+
+- 代码已实现
+- Android CI 已通过
+- 真机功能验收
+- 真机视觉验收
+- Production Release 验收
+
+不得用 CI Green 代替真机结论，也不得因为 Issue 仍然 Open 就重复实现已经进入 `main` 的代码。
 
 ---
 
 ## v0.1 - Local Charging Book
 
-状态: Released / Accepted
+状态: **Released / Accepted**
 
 - [x] Room / DAO / Repository / ViewModel
 - [x] 车辆创建 / 编辑持久化
@@ -27,46 +37,65 @@
 
 ## v0.2 - Vehicle, Location & Trip Foundation
 
-状态: **Core Accepted / Reliability Hardening**
+状态: **Core Implemented / Physical Reliability Revalidation**
 
-### Trip / Location reliability
+### Trip / Location 基础
 
-- [x] TripSession / TripPoint + migration
-- [x] manual start/stop
+- [x] TripSession / TripPoint + Room migration
+- [x] manual start / completion / interrupted resume
 - [x] foreground location service + persistent notification
 - [x] WGS84 / accuracy / speed / bearing / altitude
 - [x] distance / elapsed / moving / stopped / average / max speed
-- [x] interrupted resume same TripSession
-- [x] GPS quality / jump filtering + stationary throttling
-- [x] GPS/Network provider fallback
-- [x] runtime GPS health / accepted-point heartbeat
-- [x] GPS LOST / LONG_GAP ongoing notification
-- [x] long GPS gap 在 route preview 中断开，不画假实线
-- [x] 全程均速 / 行驶均速 / 最高速度口径明确区分
-- [ ] 长 gap 两端不参与可信距离累计
-- [ ] GPS / Network 去重与择优
-- [ ] longest gap / provider counters / rejected reason 持久摘要
-- [ ] service lifecycle / restart / re-delivery evidence
-- [ ] 锁屏长行程真机复验
-- [ ] TripSpeedSegment 派生模型
-- [ ] 连续速度颜色映射
-- [ ] 短时峰值与 segment speed 分开展示
+- [x] runtime GPS health / callback heartbeat / accepted-point heartbeat
+- [x] `lastLocationCallbackAt` 与 `lastAcceptedPointAt` 分离诊断
+- [x] GPS / Network provider fallback
+- [x] provider / permission / service lifecycle diagnostics
+- [x] `START_REDELIVER_INTENT` evidence
 
-PR #36 第一阶段代码已通过 Android Build Run #184：Build/Test + Debug APK Green。
+### GPS continuity / data trust
 
-详细设计：`docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` 与 `docs/LOCATION_TRIP.md`。
+- [x] callback registration 改为 time-based liveness，不再依赖 8m system displacement gate
+- [x] stationary TripPoint 继续由 app-level 15s throttling 控制
+- [x] LONG_GAP 两端不作为可信连续距离
+- [x] long gap 在 route preview 中保持断开，不画假实线
+- [x] GPS health 区分 WAITING / GOOD / DEGRADED / LOST / LONG_GAP
+- [x] coarse/network provider 不直接制造 Trip max-speed peak
+- [x] extreme GPS peak 缺失 `speedAccuracy` 时不进入可信 max speed
+- [x] raw TripPoint 保留，不通过派生统计“清洗掉”原始证据
+- [x] 轨迹按可信本车速度着色，并保留 gap / unknown speed 语义
+- [x] 起点 / 终点不只依赖颜色区分
+
+### Trip analytics / data quality
+
+- [x] 起终点 / 最低 / 最高海拔
+- [x] 累计爬升 / 下降，过滤明显弱 vertical accuracy 和小幅 GPS 垂直抖动
+- [x] 累计海拔变化不跨 LONG_GAP 拼接
+- [x] Trip validity：明确空/异常完成行程从 Dashboard 与汇总统计排除
+- [x] 极短真实行程只标 `REVIEW`，不自动删除、不自动排除
+- [x] 用户仍通过显式确认删除无效/测试 Trip
+
+### Physical reliability remaining
+
+#77 保留为新的 post-RC 真机可靠性验收，不重新打开已经完成的 RC #41：
+
+- [ ] 另一 App 前台 5–10 分钟时可信距离继续增加
+- [ ] 2–3 分钟停车/红灯能累计 stopped time，不产生 false LONG_GAP
+- [ ] 真正 callback/provider loss 仍产生 LOST / LONG_GAP
+- [ ] stationary heartbeat 不产生过量 TripPoint
+
+相关：#77、#67、#42、#26。
 
 ---
 
-## v0.3 - Local Analytics & Reliability
+## v0.3 - Local Analytics & Data Reliability
 
-状态: **Feature Complete Candidate / Reliability Follow-up**
+状态: **Feature Complete / Incremental Follow-up Only**
 
 已实现：
 
 - charging interval odometer distance
-- cost/100km estimate
-- charged kWh/100km estimate
+- cost / 100km estimate
+- charged kWh / 100km estimate
 - Trip + odometer coverage evidence
 - SOC confidence hints
 - six-month cost / energy trend
@@ -74,38 +103,139 @@ PR #36 第一阶段代码已通过 Android Build Run #184：Build/Test + Debug A
 - charger type mix
 - ChargingPlace aggregation + common-place reuse
 - selected-vehicle charging CSV analysis export
-- non-blocking anomaly hints
+- non-blocking charging anomaly hints
+- Local JSON Backup / Restore
+- Trip validity-aware analytics
+- Trip SOC energy estimate 与桩端充电事实分层展示
 
-真实 Trip #7 观察到 12-15 分钟级 GPS gap，因此 reliability 优先级高于继续扩统计展示。
-
-下一阶段：
-
-1. long-gap distance aggregation correction
-2. GPS / Network provider fusion / dedupe
-3. Trip completeness summary / persistent diagnostics
-4. lock-screen physical verification
-5. segmented speed + continuous color route
+Issue #19 已完成关闭。HOME / WORK 结构化地点、Privacy Zone、DataSource metadata 等只在真实需求出现时增量实现，不为了“数据治理完整度”新增重表或框架。
 
 ---
 
 ## v0.4 - Cloud & Catalog Sync
 
-状态: Foundation started; feature expansion deferred until Trip P0 reliability is observable
+状态: **Phase A Complete / Expansion Deferred Until v0.5 Physical Closeout**
 
-已存在 Local First Sync Foundation 不回退：stable identity / tombstone / protocol 文档继续保留。
+### 已完成 Phase A
 
-Cloud sync must not become the only recovery path. Existing local JSON backup remains supported。
+- [x] Vehicle stable `syncId`
+- [x] Vehicle `updatedAtEpochMillis`
+- [x] ChargingRecord stable `syncId`
+- [x] ChargingRecord `updatedAtEpochMillis`
+- [x] ChargingRecord tombstone
+- [x] Room migration + old-row identity generation
+- [x] Backup / Restore 保留 sync metadata
+- [x] active UI / analytics 排除 tombstone
+- [x] pure JVM sync identity tests
+
+Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
+
+### 下一阶段 #27
+
+- [ ] protocol/schema version runtime implementation
+- [ ] Vehicle / ChargingRecord sync envelope DTO
+- [ ] push changed entities
+- [ ] pull changes since cursor/revision
+- [ ] idempotent upsert by `syncId`
+- [ ] explicit delete/tombstone propagation
+- [ ] last successful sync cursor/status
+- [ ] conflict policy pure Kotlin tests
+- [ ] smallest HTTPS + Spring Boot monolith + PostgreSQL slice
+
+约束不变：云端不能成为 App 运行前提或唯一恢复路径；第一批不做 TripSession / TripPoint cloud sync，不做 CRDT / 微服务 / MQ。
+
+### Catalog #20
+
+现有本地 versioned JSON seed、离线搜索、自定义车辆 fallback 继续使用。完整车型管道仍是独立长期任务：
+
+- [ ] 可追溯公开数据来源
+- [ ] 品牌 / 车系 / 年款 / 配置归一化
+- [ ] 可重复导入 / 校验工具
+- [ ] 增量更新、弃用和纠错
+- [ ] catalog 更新不自动改写用户 Vehicle snapshot
+
+---
+
+## v0.5 - Local Experience & VehicleState Closure
+
+状态: **Code Baseline Implemented / Physical Closeout**
+
+### UI baseline
+
+- [x] Dark First design language / persisted Light mode
+- [x] Dashboard / Records / Stats / Trip / Vehicle 核心页面重构（#71）
+- [x] Dashboard dynamic Vehicle Hero（#96）
+- [x] Dashboard recent Trip card（#100）
+- [x] release updater UI 对齐 Dashboard dark/green language（#126）
+
+### VehicleState / SOC / mileage
+
+- [x] VehicleState 当前 SOC / 当前里程作为当前车辆事实层
+- [x] Trip start 保存当前 SOC / mileage 快照
+- [x] Trip completion 要求 explicit end SOC
+- [x] end mileage 可按 start mileage + GPS distance 预填并允许修正
+- [x] Trip end SOC / mileage 回写 VehicleState
+- [x] 正 SOC drop 才估算 consumed kWh / kWh per 100km
+- [x] 删除完成 Trip 后重新构建 VehicleState
+- [x] 后发生的 Charge / manual VehicleState 保持 authority
+
+代码基线由 #87/#89 等已合并 PR 提供；真机闭环由 #124 验收。
+
+### Location / address
+
+- [x] coordinates 是事实，address 是派生展示
+- [x] Add Charge 自动请求当前位置
+- [x] Geocoder failure 不阻塞坐标保存
+- [x] LocationProvider / AddressResolver 分离
+- [x] successful geocode process-local bounded cache
+- [x] failed / blank geocode 不缓存，允许真实 retry（#129）
+
+真机权限 / Geocoder / restore 验收仍由 #14 保留。
+
+### Lock-screen / background notification
+
+- [x] ongoing notification 显示 Trip elapsed time + trusted persisted distance（#130）
+- [x] notification tap / `打开行程` 直接进入 active Trip（#130）
+- [x] provider / Location permission runtime loss -> Trip `INTERRUPTED` + one-shot repair notification（#131）
+- [x] repair action deep-link 到 App 权限设置或系统 Location 设置（#131）
+- [x] 修复后由用户明确 resume，不自动后台恢复（#131）
+- [x] Android 13+ Trip 通知权限在 tracking 已开始/恢复后再请求（#132）
+- [x] 通知权限拒绝不阻塞、不回滚 Trip（#132）
+
+#26 保持 Open，只做上述行为的真机验收；trusted speed / battery optimization guidance 为 evidence-driven optional，不是代码 blocker。
+
+### Production updater
+
+- [x] updater infrastructure / latest.json / SHA-256 / installer handoff
+- [x] root composition wiring（#103）
+- [x] Dashboard-style update card（#126）
+- [ ] old production APK -> newer production APK 真机覆盖升级（#102）
+
+### v0.5 physical closeout
+
+仍需真实设备验收，不由 CI 代替：
+
+- #70 五个一级页面 + Light mode
+- #94 Dashboard Hero
+- #95 recent Trip card
+- #42 accessibility / large font / small screen / active-Trip state safety
+- #22 top spacing / density
+- #14 Location / Geocoder
+- #77 background callback / stationary hold
+- #124 Trip SOC -> VehicleState
+- #26 lock-screen / repair notifications
+- #102 release APK updater
 
 ---
 
 ## P3 - Optional Vehicle Data Source / OBD-II
 
-状态: Future Exploration / Not Product Blocker
+状态: **Future Exploration / Not Product Blocker**
 
 首个最小 PoC：
 
 - [ ] 定义轻量 `VehicleSpeedSource` 边界
-- [ ] 外接 OBD-II Bluetooth/BLE/Wi-Fi adapter
+- [ ] 外接 OBD-II Bluetooth / BLE / Wi-Fi adapter
 - [ ] 查询标准 Vehicle Speed 支持能力
 - [ ] 读取 OBD Vehicle Speed
 - [ ] 与 GNSS `Location.speed` 对照
@@ -124,22 +254,35 @@ Cloud sync must not become the only recovery path. Existing local JSON backup re
 ## 当前执行顺序
 
 ```text
-Trip P0 reliability
-  -> long-gap distance correction
-  -> GPS / Network dedupe + quality policy
-  -> Trip completeness summary / diagnostics
-  -> physical lock-screen long-drive verification
-  -> Trip P1 segmented speed + colored route
-  -> v0.3 reliability closeout
-  -> resume v0.4 sync expansion
-  -> P3 OBD-II optional PoC when product value justifies it
+v0.5 physical acceptance bundle
+  -> #77 background / stationary Trip reliability
+  -> #124 Trip SOC -> VehicleState
+  -> #26 lock-screen + repair notification
+  -> #14 Location / Geocoder
+  -> #70 / #94 / #95 / #42 / #22 UI-device checks
+  -> #102 old-production -> new-production updater flow
+  -> only fix concrete device regressions
+  -> resume #27 minimal Local First sync protocol/runtime
+  -> advance #20 catalog pipeline when source/coverage work is justified
+  -> P3 OBD-II optional PoC only when product value justifies it
 ```
 
-MapLibre 继续保持低优先级；没有必要为了彩色速度轨迹先引入地图 SDK。
+MapLibre 继续保持低优先级；当前已有真实 WGS84 route preview，不为了“看起来完整”提前引入地图 SDK。
 
 ---
 
 ## 变更记录
+
+### v2.7.0
+
+- reconciled ROADMAP with current `main` after Trip reliability/data-quality work through #123/#127/#128/#129
+- recorded Trip SOC/mileage/energy -> VehicleState baseline from #87/#89 and physical acceptance owner #124
+- recorded v0.5 Dashboard Hero/recent-Trip implementation (#96/#100)
+- recorded updater wiring/UI implementation (#103/#126) while preserving #102 physical release acceptance
+- recorded lock-screen Trip progress and direct active-Trip navigation (#130)
+- recorded provider/permission repair notifications and explicit INTERRUPTED -> user resume semantics (#131)
+- recorded Android 13+ non-blocking Trip notification permission flow (#132)
+- moved the active stage from “implement Trip P0 slices” to “physical acceptance bundle, then resume minimal sync”
 
 ### v2.6.0
 


### PR DESCRIPTION
## Summary

Reconcile the two authority status documents with the actual current `main` after the v0.5 reliability/data-quality/notification sequence.

### ROADMAP
- moves the active stage from stale "implement Trip P0 slices" to a physical-acceptance bundle
- records completed Trip continuity/speed/elevation/validity work through #123/#127/#128
- records coordinate-first geocode cache/retry closure from #129
- records Trip SOC/mileage/energy -> VehicleState baseline and #124 acceptance owner
- records Dashboard Hero/recent Trip implementation (#96/#100)
- records updater wiring/UI implementation (#103/#126) while retaining #102 physical release acceptance
- records lock-screen progress, repair notifications, and Android 13+ non-blocking notification permission (#130/#131/#132)
- keeps #27 minimal sync and #20 catalog pipeline as the next actual expansion work after device closeout

### PROJECT_MASTER
- preserves existing product principles, source-of-truth rules, CI/release separation, OBD optional boundary, and simple architecture constraints
- updates current Trip/VehicleState/Location/notification facts to match current code
- explicitly separates code/CI/physical/visual/Production Release acceptance
- updates current Issues into physical-acceptance vs future-expansion vs repository-maintenance groups

No product code, build configuration, schema, or workflow behavior is changed.

Refs #6