### PR TITLE
fix(ui): enforce Dashboard touch targets

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -182,6 +183,7 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
 
         Row(
             modifier = Modifier
+                .heightIn(min = 48.dp)
                 .clip(CircleShape)
                 .clickable(onClick = onViewAll)
                 .padding(start = 10.dp, top = 8.dp, bottom = 8.dp),

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -118,6 +119,7 @@ private fun RecentChargingHeader(
         Row(verticalAlignment = Alignment.CenterVertically) {
             Row(
                 modifier = Modifier
+                    .heightIn(min = 48.dp)
                     .clip(CircleShape)
                     .clickable(onClick = onViewAll)
                     .padding(horizontal = 8.dp, vertical = 8.dp),
@@ -138,7 +140,7 @@ private fun RecentChargingHeader(
             Spacer(Modifier.size(4.dp))
             Box(
                 modifier = Modifier
-                    .size(42.dp)
+                    .size(48.dp)
                     .clip(CircleShape)
                     .background(EVDesignTokens.Energy.green)
                     .clickable(onClick = onAddClick),


### PR DESCRIPTION
## Summary

Close a concrete code-side accessibility gap from #42 without changing Dashboard hierarchy or visual language.

- enlarge the custom Dashboard `记录充电` circular clickable target from 42dp to 48dp
- give the charging `查看全部` custom clickable row a 48dp minimum height
- give the recent-Trip `查看全部` custom clickable row a 48dp minimum height
- leave decorative 36–38dp route/charging icons unchanged because they are not interactive and correctly use null semantics
- leave Material3 IconButton/FAB/Button controls unchanged because they already provide their own interaction sizing behavior

No data flow, navigation behavior, colors, typography, schema, or business logic changes.

This is one verified code-side slice of #42; TalkBack order, fontScale, small-screen, Light/Dark contrast, and full-device touch-target acceptance remain physical/device work.

Refs #42