### PR TITLE
fix(ui): preserve Dashboard Hero and improve device readability

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -89,36 +90,22 @@ fun DashboardRecentTripCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clip(MaterialTheme.shapes.medium)
                     .clickable { onOpenTrip(trip.id) }
-                    .padding(vertical = 2.dp),
+                    .padding(top = 2.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+
                 Row(
                     modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    TripRouteRail()
-                    Spacer(Modifier.width(10.dp))
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(3.dp)
-                    ) {
-                        Text(
-                            "${endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)} → ${endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)}",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Text(
-                            formatTime(trip.startedAtEpochMillis),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        formatTime(trip.startedAtEpochMillis),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                     Surface(
                         shape = CircleShape,
                         color = EVDesignTokens.Energy.green.copy(alpha = 0.10f)
@@ -134,17 +121,42 @@ fun DashboardRecentTripCard(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    TripRouteRail()
+                    Spacer(Modifier.width(10.dp))
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        TripEndpointRow(
+                            label = "起点",
+                            labelColor = EVDesignTokens.Energy.green,
+                            address = endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)
+                        )
+                        TripEndpointRow(
+                            label = "终点",
+                            labelColor = Color(0xFFFF7373),
+                            address = endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)
+                        )
+                    }
+                }
+
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.8f))
+                    TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.72f))
                     MetricSeparator()
-                    TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.82f))
+                    TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.74f))
                     MetricSeparator()
-                    TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "能耗", Modifier.weight(0.9f))
+                    TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "能耗", Modifier.weight(0.74f))
                     MetricSeparator()
-                    TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1.2f))
+                    TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1.0f))
                     MetricSeparator()
-                    TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程", Modifier.weight(1.45f))
+                    TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程", Modifier.weight(1.8f))
                 }
             }
         }
@@ -205,15 +217,41 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
 }
 
 @Composable
+private fun TripEndpointRow(label: String, labelColor: Color, address: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.width(34.dp),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Medium,
+            color = labelColor
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = address,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
 private fun TripRouteRail() {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
+        Box(Modifier.size(8.dp).background(EVDesignTokens.Energy.green, CircleShape))
         Box(
             Modifier
-                .size(width = 1.dp, height = 18.dp)
+                .size(width = 1.dp, height = 44.dp)
                 .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f))
         )
-        Box(Modifier.size(7.dp).background(Color(0xFFFF7373), CircleShape))
+        Box(Modifier.size(8.dp).background(Color(0xFFFF7373), CircleShape))
     }
 }
 
@@ -308,8 +346,8 @@ private fun formatMileageRange(start: Double?, end: Double?): String = when {
 }
 
 private fun formatMileage(value: Double): String =
-    if (value % 1.0 == 0.0) String.format(Locale.US, "%.0f", value)
-    else String.format(Locale.US, "%.1f", value)
+    if (value % 1.0 == 0.0) String.format(Locale.US, "%,.0f", value)
+    else String.format(Locale.US, "%,.1f", value)
 
 private fun formatConsumptionValue(value: Double?): String =
     value?.takeIf { it.isFinite() && it >= 0.0 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -124,35 +124,21 @@ fun HeroVehicleCard(
                     )
             )
 
-            Column(
+            Text(
+                text = vehicle?.let { "${it.brand}  ${it.model}" } ?: "EV Charge Book",
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(
                         start = 16.dp,
-                        top = topSystemInset + 14.dp,
+                        top = topSystemInset + 16.dp,
                         end = 72.dp
-                    )
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(Modifier.size(7.dp).background(EVDesignTokens.Energy.green, CircleShape))
-                    Spacer(Modifier.size(8.dp))
-                    Text(
-                        "MY EV",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = cockpit.primaryText
-                    )
-                }
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    vehicle?.let { "${it.brand}  ${it.model}" } ?: "EV Charge Book",
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = cockpit.primaryText,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
+                    ),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Medium,
+                color = cockpit.primaryText,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
 
             if (vehicle != null) {
                 Box(
@@ -230,8 +216,7 @@ private fun VehicleStage(
     val context = LocalContext.current
     val artwork = OfficialVehicleImageCatalog.resolve(vehicle, artworkKey)
     var remoteArtwork by remember(artwork?.key) {
-        mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null)
-    }
+        mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null) }
 
     LaunchedEffect(artwork?.key) {
         remoteArtwork = artwork?.let { HeroArtworkManifestRepository.resolve(context, it.key) }
@@ -334,10 +319,6 @@ private fun HeroDynamicStatePanel(
                 shape = panelShape
             )
     ) {
-        // The panel now sits on top of the artwork. The translucent smoke/highlight layers
-        // intentionally preserve some of the underlying image so the surface reads as glass
-        // instead of a second opaque card. Compose has no true arbitrary backdrop blur here,
-        // so the frost is created with controlled translucency and edge highlights.
         Box(
             Modifier
                 .fillMaxSize()
@@ -360,7 +341,7 @@ private fun HeroDynamicStatePanel(
             HeroSocMetric(
                 safeSoc = safeSoc,
                 animatedProgress = animatedProgress,
-                modifier = Modifier.weight(0.92f)
+                modifier = Modifier.weight(0.84f)
             )
             MetricDivider()
             HeroMetric(
@@ -369,15 +350,15 @@ private fun HeroDynamicStatePanel(
                 value = currentMileageKm?.let(::formatMileage) ?: "--",
                 unit = if (currentMileageKm != null) "km" else null,
                 modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 12.dp)
+                    .weight(1.18f)
+                    .padding(horizontal = 10.dp)
             )
             MetricDivider()
             HeroRecentTripMetric(
                 trip = latestTrip,
                 modifier = Modifier
-                    .weight(1.08f)
-                    .padding(start = 12.dp)
+                    .weight(1.02f)
+                    .padding(start = 10.dp)
             )
         }
     }
@@ -386,7 +367,7 @@ private fun HeroDynamicStatePanel(
 @Composable
 private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modifier = Modifier) {
     val cockpit = LocalCockpitColors.current
-    Column(modifier = modifier.padding(end = 12.dp)) {
+    Column(modifier = modifier.padding(end = 10.dp)) {
         if (safeSoc != null) {
             Row(verticalAlignment = Alignment.Bottom) {
                 Text(
@@ -452,19 +433,27 @@ private fun HeroMetric(
             Text(label, style = MaterialTheme.typography.labelMedium, color = cockpit.secondaryText)
         }
         Spacer(Modifier.height(4.dp))
-        Row(verticalAlignment = Alignment.Bottom) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom
+        ) {
             Text(
                 value,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
-                color = cockpit.primaryText
+                color = cockpit.primaryText,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip
             )
             if (unit != null) {
                 Spacer(Modifier.size(3.dp))
                 Text(
                     unit,
                     style = MaterialTheme.typography.labelMedium,
-                    color = cockpit.primaryText.copy(alpha = 0.86f)
+                    color = cockpit.primaryText.copy(alpha = 0.86f),
+                    maxLines = 1,
+                    softWrap = false
                 )
             }
         }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -216,7 +216,8 @@ private fun VehicleStage(
     val context = LocalContext.current
     val artwork = OfficialVehicleImageCatalog.resolve(vehicle, artworkKey)
     var remoteArtwork by remember(artwork?.key) {
-        mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null) }
+        mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null)
+    }
 
     LaunchedEffect(artwork?.key) {
         remoteArtwork = artwork?.let { HeroArtworkManifestRepository.resolve(context, it.key) }
@@ -319,6 +320,10 @@ private fun HeroDynamicStatePanel(
                 shape = panelShape
             )
     ) {
+        // The panel now sits on top of the artwork. The translucent smoke/highlight layers
+        // intentionally preserve some of the underlying image so the surface reads as glass
+        // instead of a second opaque card. Compose has no true arbitrary backdrop blur here,
+        // so the frost is created with controlled translucency and edge highlights.
         Box(
             Modifier
                 .fillMaxSize()


### PR DESCRIPTION
## Summary

Rebased onto the current `main` after #136 and retained only the non-conflicting physical-device readability fixes from #139.

### Hero
- remove the redundant `MY EV` eyebrow and keep the actual vehicle name as the identity
- preserve #136 edge-to-edge Hero/status-bar integration and smoked-glass state panel
- give current mileage more horizontal room
- force mileage value/unit to stay on one line so values such as `3,539.9 km`, `12,674 km` and `103,542 km` do not split into broken `k` / `m` lines
- preserve existing SOC/recent-Trip data truth and #134 touch-target behavior

### Recent Trip
- move Trip date/time to the top of the Trip content
- split route into explicit `起点` / `终点` rows
- allow each address up to two lines so reverse-geocoded addresses are shown as completely as practical
- keep truthful coordinate fallback
- remove the inner rounded/clip treatment and use a flat content hierarchy with separators
- keep consumption as the numeric value (for example `11.0`) with `能耗` as its metric label
- give the mileage metric more room and add thousands separators

### Conflict resolution with #136

#136 already owns the correct system-bar behavior in `MainActivity`: Dashboard remains visually dark under the status bar and therefore uses light status-bar icons, while other screens follow the selected app theme. The older #140 attempt to add a second global system-bar SideEffect in `EvChargeTheme.kt` was intentionally dropped because it could override #136. `EvChargeTheme.kt` is no longer changed by this PR.

## Boundaries

- no Trip distance algorithm changes; physical distance discrepancy is tracked separately in #137
- no energy-source/OBD changes; higher-fidelity research is tracked in #138
- no schema, repository, network or business-flow changes
- current-head Android Build must be Green before merge

Physical Dark/Light, normal/1.3x fontScale and long-mileage/address acceptance remains required in #94/#95/#42/#70 after merge.

Fixes #139
Refs #94 #95 #42 #70 #136 #137 #138