### PR TITLE
fix(ui): align Dashboard with approved Hero mockup

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -1,6 +1,7 @@
 package com.evchargebook.ui.dashboard
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -124,19 +125,15 @@ fun DashboardRecentTripCard(
                     verticalAlignment = Alignment.Top
                 ) {
                     TripRouteRail()
-                    Spacer(Modifier.width(10.dp))
+                    Spacer(Modifier.width(12.dp))
                     Column(
                         modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
                         TripEndpointRow(
-                            label = "起点",
-                            labelColor = EVDesignTokens.Energy.green,
                             address = endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)
                         )
                         TripEndpointRow(
-                            label = "终点",
-                            labelColor = Color(0xFFFF7373),
                             address = endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)
                         )
                     }
@@ -217,41 +214,38 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
 }
 
 @Composable
-private fun TripEndpointRow(label: String, labelColor: Color, address: String) {
-    Row(
+private fun TripEndpointRow(address: String) {
+    Text(
+        text = address,
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.Top
-    ) {
-        Text(
-            text = label,
-            modifier = Modifier.width(34.dp),
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Medium,
-            color = labelColor
-        )
-        Spacer(Modifier.width(8.dp))
-        Text(
-            text = address,
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
 }
 
 @Composable
 private fun TripRouteRail() {
+    val markerColor = MaterialTheme.colorScheme.onSurfaceVariant
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(Modifier.size(8.dp).background(EVDesignTokens.Energy.green, CircleShape))
         Box(
             Modifier
-                .size(width = 1.dp, height = 44.dp)
-                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f))
+                .size(10.dp)
+                .border(1.5.dp, markerColor.copy(alpha = 0.90f), CircleShape)
         )
-        Box(Modifier.size(8.dp).background(Color(0xFFFF7373), CircleShape))
+        Box(
+            Modifier
+                .size(width = 1.dp, height = 42.dp)
+                .background(markerColor.copy(alpha = 0.42f))
+        )
+        Box(
+            Modifier
+                .size(10.dp)
+                .background(markerColor.copy(alpha = 0.68f), CircleShape)
+                .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.22f), CircleShape)
+        )
     }
 }
 
@@ -306,7 +300,7 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 TripRouteRail()
-                Spacer(Modifier.width(10.dp))
+                Spacer(Modifier.width(12.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
                         "完成第一段行程后，这里会显示距离、SOC、里程与可信的能耗估算。",

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
@@ -88,7 +87,7 @@ fun DashboardScreen(
             )
         }
         item { EnergyCockpitCard(state, onOpenChargingRecords) }
-        item { RecentChargingHeader(onOpenChargingRecords, onAddClick) }
+        item { RecentChargingHeader(onOpenChargingRecords) }
 
         if (state.chargingRecords.isEmpty()) {
             item { EmptyChargingTimeline(onAddClick) }
@@ -102,10 +101,7 @@ fun DashboardScreen(
 }
 
 @Composable
-private fun RecentChargingHeader(
-    onViewAll: () -> Unit,
-    onAddClick: () -> Unit
-) {
+private fun RecentChargingHeader(onViewAll: () -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -119,42 +115,25 @@ private fun RecentChargingHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Row(
-                modifier = Modifier
-                    .heightIn(min = 48.dp)
-                    .clip(CircleShape)
-                    .clickable(onClick = onViewAll)
-                    .padding(horizontal = 8.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    "查看全部",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = EVDesignTokens.Energy.green
-                )
-                Icon(
-                    Icons.Default.ChevronRight,
-                    contentDescription = "查看全部充电记录",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-            Spacer(Modifier.size(4.dp))
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(CircleShape)
-                    .background(EVDesignTokens.Energy.green)
-                    .clickable(onClick = onAddClick),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Default.Add,
-                    contentDescription = "记录充电",
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
+        Row(
+            modifier = Modifier
+                .heightIn(min = 48.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onViewAll)
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "查看全部",
+                style = MaterialTheme.typography.bodyMedium,
+                color = EVDesignTokens.Energy.green
+            )
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = "查看全部充电记录",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.Route
@@ -105,6 +106,7 @@ fun HeroVehicleCard(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                // Production Hero assets are 1600x1100 (~1.455:1); 1.46 keeps crop negligible.
                 .aspectRatio(1.46f)
         ) {
             VehicleStage(vehicle, effectiveArtworkKey, Modifier.fillMaxSize())
@@ -114,11 +116,11 @@ fun HeroVehicleCard(
                     .background(
                         Brush.verticalGradient(
                             listOf(
-                                Color(0xA8020806),
-                                Color(0x28020806),
+                                Color(0x98020806),
+                                Color(0x20020806),
                                 Color.Transparent,
-                                Color(0x26020806),
-                                Color(0x9806100C)
+                                Color(0x18020806),
+                                Color(0x7606100C)
                             )
                         )
                     )
@@ -130,7 +132,7 @@ fun HeroVehicleCard(
                     .align(Alignment.TopStart)
                     .padding(
                         start = 16.dp,
-                        top = topSystemInset + 16.dp,
+                        top = topSystemInset + 14.dp,
                         end = 72.dp
                     ),
                 style = MaterialTheme.typography.titleLarge,
@@ -144,14 +146,14 @@ fun HeroVehicleCard(
                 Box(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .padding(top = topSystemInset + 12.dp, end = 12.dp)
+                        .padding(top = topSystemInset + 10.dp, end = 12.dp)
                 ) {
                     Box(
                         modifier = Modifier
-                            .size(48.dp)
+                            .size(46.dp)
                             .clip(CircleShape)
-                            .background(Color(0x7207110F))
-                            .border(1.dp, Color.White.copy(alpha = 0.18f), CircleShape)
+                            .background(Color(0x6607110F))
+                            .border(1.dp, Color.White.copy(alpha = 0.16f), CircleShape)
                             .clickable(enabled = canSwitchVehicle) {
                                 vehicleMenuExpanded = true
                             },
@@ -160,8 +162,8 @@ fun HeroVehicleCard(
                         Icon(
                             imageVector = Icons.Default.DirectionsCar,
                             contentDescription = if (vehicleSwitchEnabled) "切换车辆" else "行程进行中不可切换车辆",
-                            tint = Color.White.copy(alpha = if (vehicleSwitchEnabled) 1f else 0.45f),
-                            modifier = Modifier.size(23.dp)
+                            tint = Color.White.copy(alpha = if (vehicleSwitchEnabled) 0.94f else 0.45f),
+                            modifier = Modifier.size(22.dp)
                         )
                     }
 
@@ -200,7 +202,7 @@ fun HeroVehicleCard(
                     latestTrip = latestTrip,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .padding(start = 12.dp, end = 12.dp, bottom = 12.dp)
+                        .padding(start = 12.dp, end = 12.dp, bottom = 10.dp)
                 )
             }
         }
@@ -287,24 +289,25 @@ private fun HeroDynamicStatePanel(
         animationSpec = tween(durationMillis = 650),
         label = "dashboard_hero_soc"
     )
-    val panelShape = MaterialTheme.shapes.large
+    val panelShape = RoundedCornerShape(22.dp)
 
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .height(92.dp)
             .shadow(
-                elevation = 18.dp,
+                elevation = 8.dp,
                 shape = panelShape,
-                ambientColor = Color.Black.copy(alpha = 0.38f),
-                spotColor = Color.Black.copy(alpha = 0.50f)
+                ambientColor = Color.Black.copy(alpha = 0.24f),
+                spotColor = Color.Black.copy(alpha = 0.30f)
             )
             .clip(panelShape)
             .background(
                 Brush.verticalGradient(
                     listOf(
-                        Color.White.copy(alpha = 0.10f),
-                        Color(0xB013211C),
-                        Color(0xD00A1512)
+                        Color.White.copy(alpha = 0.055f),
+                        Color(0x9413211C),
+                        Color(0xB80A1512)
                     )
                 )
             )
@@ -312,27 +315,23 @@ private fun HeroDynamicStatePanel(
                 width = 1.dp,
                 brush = Brush.linearGradient(
                     listOf(
-                        Color.White.copy(alpha = 0.30f),
-                        Color.White.copy(alpha = 0.10f),
-                        EVDesignTokens.Energy.green.copy(alpha = 0.16f)
+                        Color.White.copy(alpha = 0.18f),
+                        Color.White.copy(alpha = 0.055f),
+                        EVDesignTokens.Energy.green.copy(alpha = 0.10f)
                     )
                 ),
                 shape = panelShape
             )
     ) {
-        // The panel now sits on top of the artwork. The translucent smoke/highlight layers
-        // intentionally preserve some of the underlying image so the surface reads as glass
-        // instead of a second opaque card. Compose has no true arbitrary backdrop blur here,
-        // so the frost is created with controlled translucency and edge highlights.
         Box(
             Modifier
                 .fillMaxSize()
                 .background(
                     Brush.horizontalGradient(
                         listOf(
-                            Color(0x381D6D49),
+                            Color(0x241D6D49),
                             Color.Transparent,
-                            Color(0x24174634)
+                            Color(0x12174634)
                         )
                     )
                 )
@@ -340,7 +339,7 @@ private fun HeroDynamicStatePanel(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 12.dp),
+                .padding(horizontal = 14.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             HeroSocMetric(
@@ -397,13 +396,13 @@ private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modi
                 color = cockpit.primaryText
             )
         }
-        Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(6.dp))
         Box(
             Modifier
                 .fillMaxWidth()
-                .height(5.dp)
+                .height(4.dp)
                 .clip(CircleShape)
-                .background(cockpit.secondaryText.copy(alpha = 0.24f))
+                .background(cockpit.secondaryText.copy(alpha = 0.22f))
         ) {
             if (safeSoc != null) {
                 Box(
@@ -526,8 +525,8 @@ private fun HeroRecentTripMetric(trip: TripSessionEntity?, modifier: Modifier = 
 private fun MetricDivider() {
     Box(
         Modifier
-            .size(width = 1.dp, height = 56.dp)
-            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .24f))
+            .size(width = 1.dp, height = 52.dp)
+            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .22f))
     )
 }
 


### PR DESCRIPTION
## Scope

Minimal Dashboard-only visual correction based on the approved mockup. Existing data, vehicle catalog, Hero transport, Room, Trip logic and other screens are intentionally untouched.

## Changes

- Fix the Hero glass state strip regression by giving it a fixed 92dp height so the frost layer can no longer expand to the full Hero and cover the vehicle title/status bar.
- Keep the current 1.46:1 Hero slot, which is effectively matched to the 1600x1100 production artwork ratio, with only negligible crop.
- Flatten the glass treatment: lower elevation, softer highlight/border, darker smoke, thinner SOC progress bar; no extra `剩余电量` label.
- Keep the existing edge-to-edge status-bar behavior and existing vehicle/title logic.
- Replace green/red recent-trip endpoints with neutral map-style markers: hollow origin, filled destination, neutral connector; remove colored 起点/终点 labels.
- Remove the Dashboard Recent Charging `+` shortcut only; empty-state add flow and record flows remain available.

## Non-goals

- No Android data-model changes
- No Room migrations
- No vehicle/Hero manifest changes
- No Trip calculation changes
- No broad redesign of already-correct cards

Physical-device screenshot remains the final visual acceptance gate.