### PR TITLE
ui: densify Trip history list and endpoint summary

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.TripValidityRules
+import com.evchargebook.domain.TripValidityStatus
 import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.ui.theme.EVDesignTokens
 import java.text.SimpleDateFormat
@@ -52,11 +54,18 @@ internal fun TripHistoryCardV06(
     onDelete: () -> Unit
 ) {
     val endpoints = rememberTripEndpointLabels(trip)
+    val validity = remember(trip) { TripValidityRules.assess(trip) }
     val accent = EVDesignTokens.Energy.green
-    val statusColor = if (trip.status == TripStatus.INTERRUPTED) {
-        MaterialTheme.colorScheme.error
-    } else {
-        accent
+    val statusLabel = when (validity.status) {
+        TripValidityStatus.INVALID -> "无效 · 不计汇总"
+        TripValidityStatus.REVIEW -> "建议检查"
+        else -> compactTripStatus(trip.status)
+    }
+    val statusColor = when {
+        validity.status == TripValidityStatus.INVALID -> MaterialTheme.colorScheme.error
+        validity.status == TripValidityStatus.REVIEW -> MaterialTheme.colorScheme.tertiary
+        trip.status == TripStatus.INTERRUPTED -> MaterialTheme.colorScheme.error
+        else -> accent
     }
 
     Surface(
@@ -98,9 +107,10 @@ internal fun TripHistoryCardV06(
                         modifier = Modifier.weight(1f)
                     )
                     Text(
-                        text = compactTripStatus(trip.status),
+                        text = statusLabel,
                         style = MaterialTheme.typography.labelSmall,
-                        color = statusColor
+                        color = statusColor,
+                        maxLines = 1
                     )
                 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
@@ -1,0 +1,230 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.location.AndroidGeocoderAddressResolver
+import com.evchargebook.ui.theme.EVDesignTokens
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * v0.6 compact history row.
+ *
+ * Presentation only: addresses are reverse-geocoded from persisted Trip coordinates and always
+ * retain a coordinate / unavailable fallback. No route or endpoint is invented by the UI.
+ */
+@Composable
+internal fun TripHistoryCardV06(
+    trip: TripSessionEntity,
+    onClick: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val endpoints = rememberTripEndpointLabels(trip)
+    val accent = EVDesignTokens.Energy.green
+    val statusColor = if (trip.status == TripStatus.INTERRUPTED) {
+        MaterialTheme.colorScheme.error
+    } else {
+        accent
+    }
+
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier.size(40.dp).background(accent.copy(alpha = 0.10f), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Route,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = formatTripHistoryTime(trip.startedAtEpochMillis),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = compactTripStatus(trip.status),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = statusColor
+                    )
+                }
+
+                Text(
+                    text = "起 ${endpoints.start}  →  终 ${endpoints.end}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = formatTripHistoryDistance(trip.distanceMeters),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = formatTripHistoryDuration(trip.elapsedSeconds),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = trip.averageConsumptionKwhPer100Km
+                            ?.takeIf { it.isFinite() && it >= 0.0 }
+                            ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
+                            ?: "能耗 --",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            if (trip.status == TripStatus.COMPLETED) {
+                IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "删除行程",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class TripEndpointLabels(
+    val start: String,
+    val end: String
+)
+
+@Composable
+private fun rememberTripEndpointLabels(trip: TripSessionEntity): TripEndpointLabels {
+    val context = LocalContext.current
+    val resolver = remember(context) { AndroidGeocoderAddressResolver(context) }
+    val startFallback = endpointFallback(trip.startLatitude, trip.startLongitude)
+    val endFallback = endpointFallback(trip.endLatitude, trip.endLongitude)
+
+    var start by remember(trip.id, trip.startLatitude, trip.startLongitude) {
+        mutableStateOf(startFallback)
+    }
+    var end by remember(trip.id, trip.endLatitude, trip.endLongitude) {
+        mutableStateOf(endFallback)
+    }
+
+    LaunchedEffect(trip.id, trip.startLatitude, trip.startLongitude) {
+        val latitude = trip.startLatitude
+        val longitude = trip.startLongitude
+        start = if (latitude != null && longitude != null) {
+            resolver.reverse(latitude, longitude) ?: startFallback
+        } else {
+            startFallback
+        }
+    }
+
+    LaunchedEffect(trip.id, trip.endLatitude, trip.endLongitude) {
+        val latitude = trip.endLatitude
+        val longitude = trip.endLongitude
+        end = if (latitude != null && longitude != null) {
+            resolver.reverse(latitude, longitude) ?: endFallback
+        } else {
+            endFallback
+        }
+    }
+
+    return TripEndpointLabels(start = start, end = end)
+}
+
+private fun endpointFallback(latitude: Double?, longitude: Double?): String {
+    if (latitude == null || longitude == null) return "未记录"
+    return String.format(Locale.US, "%.4f, %.4f", latitude, longitude)
+}
+
+private fun formatTripHistoryTime(epochMillis: Long): String =
+    SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))
+
+private fun formatTripHistoryDistance(meters: Double): String =
+    if (meters >= 1000.0) {
+        String.format(Locale.US, "%.1f km", meters / 1000.0)
+    } else {
+        String.format(Locale.US, "%.0f m", meters)
+    }
+
+private fun formatTripHistoryDuration(seconds: Long): String {
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return when {
+        hours > 0 -> "${hours}h ${minutes}m"
+        minutes > 0 -> "${minutes}m"
+        else -> "<1m"
+    }
+}
+
+private fun compactTripStatus(status: String): String = when (status) {
+    TripStatus.COMPLETED -> "已完成"
+    TripStatus.INTERRUPTED -> "已中断"
+    TripStatus.RECORDING -> "记录中"
+    else -> status
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -60,7 +60,7 @@ fun TripReadyScreen(
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
         ) {
             item { ReadyGpsCard() }
             item {
@@ -131,7 +131,7 @@ fun TripReadyScreen(
                 }
             } else {
                 items(orderedTrips, key = { it.id }) { trip ->
-                    ReadyRecentTripRow(
+                    TripHistoryCardV06(
                         trip = trip,
                         onClick = { onOpenDetail(trip.id) },
                         onDelete = { deleteTarget = trip }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -81,7 +81,7 @@ fun TripScreen(
     var deleteTarget by remember { mutableStateOf<TripSessionEntity?>(null) }
     var confirmStop by remember { mutableStateOf(false) }
     val activeVehicle = activeTrip?.let { trip -> vehicles.firstOrNull { it.id == trip.vehicleId } }
-    val savedTrips = trips.filter { it.id != activeTrip?.id }.sortedByDescending { it.startedAtEpochMillis }
+    val savedTrips = trips.filter { it.id != activeTrip?.id }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -100,7 +100,7 @@ fun TripScreen(
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             item {
                 ActiveTripPanel(
@@ -115,15 +115,15 @@ fun TripScreen(
             }
             item {
                 SectionHeading(
-                    "全部行程",
-                    if (savedTrips.isEmpty()) "真实行程会按时间顺序沉淀在这里" else "共 ${savedTrips.size} 条 · 点击查看轨迹与明细"
+                    "历史行程",
+                    if (savedTrips.isEmpty()) "真实行程会按时间顺序沉淀在这里" else "${savedTrips.size} 条已保存行程"
                 )
             }
             if (savedTrips.isEmpty()) {
                 item { EmptyTripTimeline() }
             } else {
                 items(savedTrips, key = { it.id }) { trip ->
-                    TripHistoryCardV06(
+                    TripHistoryRow(
                         trip = trip,
                         onClick = { onOpenDetail(trip.id) },
                         onDelete = { deleteTarget = trip }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -81,7 +81,7 @@ fun TripScreen(
     var deleteTarget by remember { mutableStateOf<TripSessionEntity?>(null) }
     var confirmStop by remember { mutableStateOf(false) }
     val activeVehicle = activeTrip?.let { trip -> vehicles.firstOrNull { it.id == trip.vehicleId } }
-    val savedTrips = trips.filter { it.id != activeTrip?.id }
+    val savedTrips = trips.filter { it.id != activeTrip?.id }.sortedByDescending { it.startedAtEpochMillis }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -100,7 +100,7 @@ fun TripScreen(
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
         ) {
             item {
                 ActiveTripPanel(
@@ -115,15 +115,15 @@ fun TripScreen(
             }
             item {
                 SectionHeading(
-                    "历史行程",
-                    if (savedTrips.isEmpty()) "真实行程会按时间顺序沉淀在这里" else "${savedTrips.size} 条已保存行程"
+                    "全部行程",
+                    if (savedTrips.isEmpty()) "真实行程会按时间顺序沉淀在这里" else "共 ${savedTrips.size} 条 · 点击查看轨迹与明细"
                 )
             }
             if (savedTrips.isEmpty()) {
                 item { EmptyTripTimeline() }
             } else {
                 items(savedTrips, key = { it.id }) { trip ->
-                    TripHistoryRow(
+                    TripHistoryCardV06(
                         trip = trip,
                         onClick = { onOpenDetail(trip.id) },
                         onDelete = { deleteTarget = trip }


### PR DESCRIPTION
## Summary

Implements the first Trip v0.6 slice from #146 / parent #145 on the **actual READY/history route** (`TripReadyScreen`).

### Changes
- adds reusable compact `TripHistoryCardV06`
- wires the card into `TripReadyScreen`, which is the current no-active-Trip landing surface
- reduces READY/history vertical gaps so more completed Trips fit on screen
- shows truthful recorded `起 -> 终` information in each row
- reverse-geocodes persisted Trip coordinates when available
- falls back to compact coordinates / `未记录` instead of fabricating place names
- keeps distance, duration and recorded average consumption visible in one scan line
- preserves invalid/review Trip semantics (`无效 · 不计汇总` / `建议检查`)
- uses existing `EVDesignTokens.Energy.green` (`#32F080`) as the restrained route/status accent
- preserves delete action and existing Trip business/navigation flow

## Scope boundary

This PR deliberately leaves active/detail `TripScreen` unchanged. READY slide interaction, active cockpit, completed-detail restructuring, map-marker polish and diagnostics disclosure remain #147–#151.

No schema or Trip persistence changes.

## Acceptance
- [ ] Android CI green
- [ ] 5+ history rows remain readable on a normal phone
- [ ] long endpoint labels ellipsize rather than expanding the card
- [ ] no fake address/endpoint/consumption data
- [ ] invalid/review semantics remain visible
- [ ] fontScale 1.3 visual pass
- [ ] physical-device comparison against `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`

Closes #146 when physical acceptance is complete.