### PR TITLE
fix(ui): tighten Dashboard density and enlarge Hero stage

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.ui.theme.EVDesignTokens
@@ -83,8 +84,8 @@ fun DashboardRecentTripCard(
         color = Color(0xFF0A1210)
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             RecentTripHeader(onViewAll)
 
@@ -92,10 +93,10 @@ fun DashboardRecentTripCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onOpenTrip(trip.id) }
-                    .padding(top = 2.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                    .padding(top = 1.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.50f))
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -104,7 +105,7 @@ fun DashboardRecentTripCard(
                 ) {
                     Text(
                         formatTime(trip.startedAtEpochMillis),
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Surface(
@@ -113,8 +114,8 @@ fun DashboardRecentTripCard(
                     ) {
                         Text(
                             "已完成",
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.labelMedium,
+                            modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+                            style = MaterialTheme.typography.labelSmall,
                             color = EVDesignTokens.Energy.green
                         )
                     }
@@ -125,10 +126,10 @@ fun DashboardRecentTripCard(
                     verticalAlignment = Alignment.Top
                 ) {
                     TripRouteRail()
-                    Spacer(Modifier.width(12.dp))
+                    Spacer(Modifier.width(10.dp))
                     Column(
                         modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         TripEndpointRow(
                             address = endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)
@@ -139,7 +140,7 @@ fun DashboardRecentTripCard(
                     }
                 }
 
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.50f))
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -170,7 +171,7 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
                 modifier = Modifier
-                    .size(38.dp)
+                    .size(34.dp)
                     .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
@@ -178,13 +179,13 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
                     Icons.Default.Route,
                     contentDescription = null,
                     tint = EVDesignTokens.Energy.green,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(18.dp)
                 )
             }
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.width(8.dp))
             Text(
                 "最近行程",
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -192,22 +193,22 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
 
         Row(
             modifier = Modifier
-                .heightIn(min = 48.dp)
+                .heightIn(min = 44.dp)
                 .clip(CircleShape)
                 .clickable(onClick = onViewAll)
-                .padding(start = 10.dp, top = 8.dp, bottom = 8.dp),
+                .padding(start = 8.dp, top = 6.dp, bottom = 6.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 "查看全部",
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
                 color = EVDesignTokens.Energy.green
             )
             Icon(
                 Icons.Default.ChevronRight,
                 contentDescription = "查看全部行程",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(18.dp)
             )
         }
     }
@@ -219,6 +220,7 @@ private fun TripEndpointRow(address: String) {
         text = address,
         modifier = Modifier.fillMaxWidth(),
         style = MaterialTheme.typography.bodyMedium,
+        fontSize = 13.sp,
         fontWeight = FontWeight.Medium,
         color = MaterialTheme.colorScheme.onSurface,
         maxLines = 2,
@@ -232,19 +234,19 @@ private fun TripRouteRail() {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Box(
             Modifier
-                .size(10.dp)
-                .border(1.5.dp, markerColor.copy(alpha = 0.90f), CircleShape)
+                .size(9.dp)
+                .border(1.4.dp, markerColor.copy(alpha = 0.88f), CircleShape)
         )
         Box(
             Modifier
-                .size(width = 1.dp, height = 42.dp)
-                .background(markerColor.copy(alpha = 0.42f))
+                .size(width = 1.dp, height = 36.dp)
+                .background(markerColor.copy(alpha = 0.40f))
         )
         Box(
             Modifier
-                .size(10.dp)
-                .background(markerColor.copy(alpha = 0.68f), CircleShape)
-                .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.22f), CircleShape)
+                .size(9.dp)
+                .background(markerColor.copy(alpha = 0.66f), CircleShape)
+                .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.20f), CircleShape)
         )
     }
 }
@@ -258,12 +260,12 @@ private fun TripMetric(value: String, label: String, modifier: Modifier = Modifi
         Text(
             value,
             style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.SemiBold,
+            fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-        Spacer(Modifier.height(2.dp))
+        Spacer(Modifier.height(1.dp))
         Text(
             label,
             style = MaterialTheme.typography.labelSmall,
@@ -278,8 +280,8 @@ private fun TripMetric(value: String, label: String, modifier: Modifier = Modifi
 private fun MetricSeparator() {
     Box(
         Modifier
-            .size(width = 1.dp, height = 34.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
+            .size(width = 1.dp, height = 30.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.42f))
     )
 }
 
@@ -291,8 +293,8 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
         color = Color(0xFF0A1210)
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 13.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             RecentTripHeader(onViewAll)
             Row(
@@ -300,11 +302,11 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 TripRouteRail()
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
                         "完成第一段行程后，这里会显示距离、SOC、里程与可信的能耗估算。",
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -108,7 +108,7 @@ private fun RecentChargingHeader(onViewAll: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column {
-            Text("最近充电", style = MaterialTheme.typography.titleLarge)
+            Text("最近充电", style = MaterialTheme.typography.titleMedium)
             Text(
                 "RECENT CHARGING",
                 style = MaterialTheme.typography.labelSmall,
@@ -117,15 +117,15 @@ private fun RecentChargingHeader(onViewAll: () -> Unit) {
         }
         Row(
             modifier = Modifier
-                .heightIn(min = 48.dp)
+                .heightIn(min = 44.dp)
                 .clip(CircleShape)
                 .clickable(onClick = onViewAll)
-                .padding(horizontal = 8.dp, vertical = 8.dp),
+                .padding(horizontal = 7.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 "查看全部",
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
                 color = EVDesignTokens.Energy.green
             )
             Icon(
@@ -152,19 +152,19 @@ private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 "等待第一笔充电",
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold
             )
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
             Text(
                 "记录后会在这里形成连续的充电时间轴。",
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
             Text(
                 "记录第一次充电  →",
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.bodySmall,
                 color = EVDesignTokens.Energy.green
             )
         }
@@ -193,12 +193,12 @@ private fun ChargingTimelineRow(
             ) {
                 Text(
                     record.location ?: "未命名充电地点",
-                    style = MaterialTheme.typography.titleMedium,
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
                     "¥ ${two(record.cost)}",
-                    style = MaterialTheme.typography.titleMedium,
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold
                 )
             }
@@ -209,12 +209,12 @@ private fun ChargingTimelineRow(
             ) {
                 Text(
                     "${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}",
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
                     "+ ${one(record.energyKwh)} kWh",
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodySmall,
                     color = EVDesignTokens.Energy.green
                 )
             }
@@ -227,7 +227,7 @@ private fun TimelineRail(isLast: Boolean) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Box(
             modifier = Modifier
-                .size(36.dp)
+                .size(32.dp)
                 .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
             contentAlignment = Alignment.Center
         ) {
@@ -235,13 +235,13 @@ private fun TimelineRail(isLast: Boolean) {
                 Icons.Default.Bolt,
                 contentDescription = null,
                 tint = EVDesignTokens.Energy.green,
-                modifier = Modifier.size(18.dp)
+                modifier = Modifier.size(16.dp)
             )
         }
         if (!isLast) {
             Box(
                 modifier = Modifier
-                    .size(width = 1.dp, height = 36.dp)
+                    .size(width = 1.dp, height = 32.dp)
                     .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f))
             )
         }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -48,8 +48,8 @@ fun EnergyCockpitCard(
         Column(
             modifier = Modifier
                 .background(surfaceBrush)
-                .padding(horizontal = 14.dp, vertical = 13.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(horizontal = 12.dp, vertical = 11.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -59,7 +59,7 @@ fun EnergyCockpitCard(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Box(
                         modifier = Modifier
-                            .size(36.dp)
+                            .size(34.dp)
                             .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
                         contentAlignment = Alignment.Center
                     ) {
@@ -67,19 +67,19 @@ fun EnergyCockpitCard(
                             Icons.Default.Bolt,
                             contentDescription = null,
                             tint = EVDesignTokens.Energy.green,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(18.dp)
                         )
                     }
-                    Spacer(Modifier.size(10.dp))
+                    Spacer(Modifier.size(8.dp))
                     Column {
                         Text(
                             "ENERGY FLOW",
-                            style = MaterialTheme.typography.labelMedium,
+                            style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
                             "本月能源",
-                            style = MaterialTheme.typography.titleLarge,
+                            style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Medium,
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -89,12 +89,12 @@ fun EnergyCockpitCard(
                     modifier = Modifier
                         .clip(CircleShape)
                         .clickable(onClick = onOpenRecords)
-                        .padding(start = 10.dp, top = 8.dp, bottom = 8.dp),
+                        .padding(start = 8.dp, top = 6.dp, bottom = 6.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         "${state.chargingCount} 次充电",
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.bodySmall,
                         color = EVDesignTokens.Energy.green,
                         maxLines = 1
                     )
@@ -102,7 +102,7 @@ fun EnergyCockpitCard(
                         Icons.Default.ChevronRight,
                         contentDescription = "查看充电记录",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(18.dp)
                     )
                 }
             }
@@ -124,7 +124,7 @@ fun EnergyCockpitCard(
                     value = "¥ ${two(state.monthCost)}",
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 10.dp)
+                        .padding(horizontal = 9.dp)
                 )
                 EnergyDivider()
                 EnergyMetric(
@@ -134,7 +134,7 @@ fun EnergyCockpitCard(
                     compact = true,
                     modifier = Modifier
                         .weight(1.08f)
-                        .padding(start = 10.dp)
+                        .padding(start = 9.dp)
                 )
             }
         }
@@ -153,15 +153,15 @@ private fun EnergyMetric(
     Column(modifier = modifier) {
         Text(
             label,
-            style = MaterialTheme.typography.labelMedium,
+            style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1
         )
-        Spacer(Modifier.size(4.dp))
+        Spacer(Modifier.size(3.dp))
         Row(verticalAlignment = Alignment.Bottom) {
             Text(
                 value,
-                style = if (compact) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleLarge,
+                style = if (compact) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
@@ -171,7 +171,7 @@ private fun EnergyMetric(
                 Spacer(Modifier.size(3.dp))
                 Text(
                     unit,
-                    style = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodySmall,
                     color = if (highlightUnit) EVDesignTokens.Energy.green else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Clip
@@ -185,8 +185,8 @@ private fun EnergyMetric(
 private fun EnergyDivider() {
     Box(
         Modifier
-            .size(width = 1.dp, height = 52.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f))
+            .size(width = 1.dp, height = 44.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.42f))
     )
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
@@ -108,8 +109,9 @@ fun HeroVehicleCard(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        // The artwork stage stays matched to the 1600x1100 production assets.
-                        .aspectRatio(1.46f)
+                        // Keep the 1600x1100 source asset; use a slightly taller viewport so the
+                        // vehicle has more presence. Crop remains modest and symmetric.
+                        .aspectRatio(1.38f)
                 ) {
                     VehicleStage(vehicle, effectiveArtworkKey, Modifier.fillMaxSize())
                     Box(
@@ -133,11 +135,12 @@ fun HeroVehicleCard(
                         modifier = Modifier
                             .align(Alignment.TopStart)
                             .padding(
-                                start = 16.dp,
-                                top = topSystemInset + 14.dp,
-                                end = 72.dp
+                                start = 14.dp,
+                                top = topSystemInset + 6.dp,
+                                end = 64.dp
                             ),
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontSize = 18.sp,
                         fontWeight = FontWeight.Medium,
                         color = cockpit.primaryText,
                         maxLines = 1,
@@ -148,14 +151,14 @@ fun HeroVehicleCard(
                         Box(
                             modifier = Modifier
                                 .align(Alignment.TopEnd)
-                                .padding(top = topSystemInset + 10.dp, end = 12.dp)
+                                .padding(top = topSystemInset + 6.dp, end = 12.dp)
                         ) {
                             Box(
                                 modifier = Modifier
-                                    .size(46.dp)
+                                    .size(42.dp)
                                     .clip(CircleShape)
                                     .background(Color(0x6607110F))
-                                    .border(1.dp, Color.White.copy(alpha = 0.16f), CircleShape)
+                                    .border(1.dp, Color.White.copy(alpha = 0.14f), CircleShape)
                                     .clickable(enabled = canSwitchVehicle) {
                                         vehicleMenuExpanded = true
                                     },
@@ -165,7 +168,7 @@ fun HeroVehicleCard(
                                     imageVector = Icons.Default.DirectionsCar,
                                     contentDescription = if (vehicleSwitchEnabled) "切换车辆" else "行程进行中不可切换车辆",
                                     tint = Color.White.copy(alpha = if (vehicleSwitchEnabled) 0.94f else 0.45f),
-                                    modifier = Modifier.size(22.dp)
+                                    modifier = Modifier.size(20.dp)
                                 )
                             }
 
@@ -200,8 +203,6 @@ fun HeroVehicleCard(
                     }
                 }
 
-                // Reserve real layout space below the 1600x1100 artwork stage. The panel is then
-                // bottom-aligned across this total height, overlapping only 28dp of the artwork.
                 if (vehicle != null) {
                     Spacer(modifier = Modifier.height(52.dp))
                 }


### PR DESCRIPTION
## Problem

The latest physical Dashboard screenshot still feels crowded at the top and oversized below: the status-bar-to-title gap is too generous, the Hero artwork stage reads too short, the vehicle title is too large, and Recent Trip / Energy / Recent Charging typography feels like a large-text mode.

## Fix

- enlarge the Hero artwork viewport by moving from 1.46 to 1.38 while keeping the existing 1600x1100 remote assets and symmetric `ContentScale.Crop`;
- reduce extra top spacing under the system status bar from 14dp to 6dp;
- reduce the vehicle title to 18sp and slightly shrink the vehicle switch control;
- compact Recent Trip padding, header, endpoint text, timestamps and route rail;
- compact Energy Flow header, metrics, padding and dividers;
- compact Recent Charging header and timeline typography;
- keep bottom-navigation touch targets and all business/data logic unchanged.

## Scope

Dashboard visual density only. No Room, vehicle catalog, Trip calculation, updater, release pipeline, Hero remote asset pipeline or navigation behavior changes.

## Acceptance

- [ ] Android CI green
- [ ] vehicle title no longer dominates the Hero
- [ ] status-bar-to-title gap is visibly tighter
- [ ] Hero vehicle image has more vertical presence without changing source assets
- [ ] Recent Trip / Energy / Recent Charging read denser and less like large-text mode
- [ ] physical-device screenshot pass before closing #94/#95

Refs #94 #95.