### PR TITLE
fix: make Hero cache-first and stop update prompt double flash

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/HeroArtworkManifestRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/HeroArtworkManifestRepository.kt
@@ -2,7 +2,10 @@ package com.evchargebook.ui.vehicle
 
 import android.content.Context
 import com.evchargebook.BuildConfig
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -13,8 +16,12 @@ import java.net.URL
 /**
  * Small, dependency-free manifest loader for vehicle Hero artwork.
  *
- * The manifest is cached in SharedPreferences so Coil can continue resolving the same versioned
- * image URL while offline. Image bytes themselves are handled by Coil's memory/disk cache.
+ * Hero resolution is deliberately local-first:
+ * 1. read the last successful manifest from SharedPreferences and return it immediately;
+ * 2. let Coil resolve the versioned image from memory/disk cache before network;
+ * 3. refresh the manifest once in the background for the next Hero resolve.
+ *
+ * A network failure must never delay or clear an already cached Hero mapping.
  */
 object HeroArtworkManifestRepository {
     data class RemoteArtwork(
@@ -28,34 +35,54 @@ object HeroArtworkManifestRepository {
     private const val READ_TIMEOUT_MS = 5_000
 
     private val loadMutex = Mutex()
-    @Volatile private var loaded = false
+    private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile private var cacheLoaded = false
+    @Volatile private var refreshStarted = false
     @Volatile private var artworks: Map<String, RemoteArtwork> = emptyMap()
 
     suspend fun resolve(context: Context, artworkKey: String): RemoteArtwork? {
-        ensureLoaded(context.applicationContext)
+        val appContext = context.applicationContext
+        ensureCachedManifestLoaded(appContext)
+        startRemoteRefresh(appContext)
         return artworks[artworkKey]
     }
 
-    private suspend fun ensureLoaded(context: Context) {
-        if (loaded) return
+    private suspend fun ensureCachedManifestLoaded(context: Context) {
+        if (cacheLoaded) return
         loadMutex.withLock {
-            if (loaded) return
+            if (cacheLoaded) return
 
             val cachedJson = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
                 .getString(KEY_MANIFEST_JSON, null)
-            val cached = cachedJson?.let(::parseManifest).orEmpty()
+            artworks = cachedJson?.let(::parseManifest).orEmpty()
+            cacheLoaded = true
+        }
+    }
 
+    /**
+     * Refresh once per app process without blocking the current Hero render.
+     *
+     * The refreshed mapping is persisted and becomes available on the next Hero resolve
+     * (for example when returning to Dashboard or on the next app launch).
+     */
+    private fun startRemoteRefresh(context: Context) {
+        if (refreshStarted) return
+        synchronized(this) {
+            if (refreshStarted) return
+            refreshStarted = true
+        }
+
+        refreshScope.launch {
             val remoteJson = fetchManifest(BuildConfig.HERO_ARTWORK_MANIFEST_URL)
             val remote = remoteJson?.let(::parseManifest).orEmpty()
+            if (remote.isEmpty() || remoteJson == null) return@launch
 
-            artworks = if (remote.isNotEmpty()) remote else cached
-            if (remote.isNotEmpty() && remoteJson != null) {
-                context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-                    .edit()
-                    .putString(KEY_MANIFEST_JSON, remoteJson)
-                    .apply()
-            }
-            loaded = true
+            artworks = remote
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_MANIFEST_JSON, remoteJson)
+                .apply()
         }
     }
 

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
@@ -60,19 +60,21 @@ fun AppUpdatePrompt() {
     LaunchedEffect(Unit) {
         runCatching { manager.checkForUpdate() }
             .onSuccess { info ->
-                update = info
-                if (info != null) phase = UpdatePhase.DISCOVERED
+                if (info != null) {
+                    // Move out of IDLE before publishing the update payload so the dialog is
+                    // created only once. IDLE itself never renders a dialog.
+                    phase = UpdatePhase.DISCOVERED
+                    update = info
+                }
             }
             .onFailure { error ->
                 Log.w(TAG, "Update discovery failed for ${BuildConfig.UPDATE_MANIFEST_URL}", error)
             }
     }
 
-    val info = update ?: return
-
     LaunchedEffect(downloadToken) {
         if (downloadToken <= 0) return@LaunchedEffect
-        phase = UpdatePhase.DOWNLOADING
+        val info = update ?: return@LaunchedEffect
         errorMessage = null
         downloadedUri = null
         runCatching { manager.downloadAndVerify(info) }
@@ -87,8 +89,20 @@ fun AppUpdatePrompt() {
             }
     }
 
+    val info = update
+
     fun deferOptionalUpdate() {
-        if (!info.mandatory) update = null
+        if (info?.mandatory != true) {
+            phase = UpdatePhase.IDLE
+            update = null
+        }
+    }
+
+    fun startDownload() {
+        if (info == null) return
+        // Hide the decision dialog synchronously before starting background work.
+        phase = UpdatePhase.DOWNLOADING
+        downloadToken += 1
     }
 
     fun continueInstall() {
@@ -103,61 +117,73 @@ fun AppUpdatePrompt() {
 
     when (phase) {
         UpdatePhase.IDLE,
-        UpdatePhase.DISCOVERED -> UpdateDecisionDialog(
-            icon = Icons.Rounded.SystemUpdateAlt,
-            accent = EVDesignTokens.Energy.green,
-            title = "发现新版本 ${info.versionName}",
-            lines = listOf(
-                "是否现在下载更新？",
-                "确认后由 Android 下载管理器在后台下载并校验，进度会显示在系统通知栏。",
-                "下载期间总览、记录、统计、行程和车辆页面都可以正常使用。"
-            ),
-            confirmText = "更新",
-            dismissText = if (info.mandatory) null else "稍后",
-            onConfirm = { downloadToken += 1 },
-            onDismiss = ::deferOptionalUpdate
-        )
-
         UpdatePhase.DOWNLOADING -> Unit
 
-        UpdatePhase.READY -> UpdateDecisionDialog(
-            icon = Icons.Rounded.CheckCircle,
-            accent = EVDesignTokens.Energy.success,
-            title = "${info.versionName} 已准备好",
-            lines = listOf(
-                "更新包已下载并通过 SHA-256 完整性校验。",
-                "点击安装后会进入 Android 系统安装界面；安装前不会退出当前应用。"
-            ),
-            confirmText = "安装",
-            dismissText = if (info.mandatory) null else "稍后",
-            onConfirm = ::continueInstall,
-            onDismiss = ::deferOptionalUpdate
-        )
+        UpdatePhase.DISCOVERED -> {
+            val current = info ?: return
+            UpdateDecisionDialog(
+                icon = Icons.Rounded.SystemUpdateAlt,
+                accent = EVDesignTokens.Energy.green,
+                title = "发现新版本 ${current.versionName}",
+                lines = listOf(
+                    "是否现在下载更新？",
+                    "确认后由 Android 下载管理器在后台下载并校验，进度会显示在系统通知栏。",
+                    "下载期间总览、记录、统计、行程和车辆页面都可以正常使用。"
+                ),
+                confirmText = "更新",
+                dismissText = if (current.mandatory) null else "稍后",
+                onConfirm = ::startDownload,
+                onDismiss = ::deferOptionalUpdate
+            )
+        }
 
-        UpdatePhase.PERMISSION_REQUIRED -> UpdateDecisionDialog(
-            icon = Icons.Rounded.CheckCircle,
-            accent = EVDesignTokens.Energy.warning,
-            title = "允许安装此来源应用",
-            lines = listOf(
-                "Android 需要先允许 EV Charge Book 安装下载的更新包。",
-                "完成系统授权后返回这里，再点击继续安装。"
-            ),
-            confirmText = "继续安装",
-            dismissText = if (info.mandatory) null else "稍后",
-            onConfirm = ::continueInstall,
-            onDismiss = ::deferOptionalUpdate
-        )
+        UpdatePhase.READY -> {
+            val current = info ?: return
+            UpdateDecisionDialog(
+                icon = Icons.Rounded.CheckCircle,
+                accent = EVDesignTokens.Energy.success,
+                title = "${current.versionName} 已准备好",
+                lines = listOf(
+                    "更新包已下载并通过 SHA-256 完整性校验。",
+                    "点击安装后会进入 Android 系统安装界面；安装前不会退出当前应用。"
+                ),
+                confirmText = "安装",
+                dismissText = if (current.mandatory) null else "稍后",
+                onConfirm = ::continueInstall,
+                onDismiss = ::deferOptionalUpdate
+            )
+        }
 
-        UpdatePhase.FAILED -> UpdateDecisionDialog(
-            icon = Icons.Rounded.ErrorOutline,
-            accent = EVDesignTokens.Energy.danger,
-            title = "更新失败",
-            lines = listOf(errorMessage ?: "更新包下载失败，请稍后重试"),
-            confirmText = "重试",
-            dismissText = if (info.mandatory) null else "稍后",
-            onConfirm = { downloadToken += 1 },
-            onDismiss = ::deferOptionalUpdate
-        )
+        UpdatePhase.PERMISSION_REQUIRED -> {
+            val current = info ?: return
+            UpdateDecisionDialog(
+                icon = Icons.Rounded.CheckCircle,
+                accent = EVDesignTokens.Energy.warning,
+                title = "允许安装此来源应用",
+                lines = listOf(
+                    "Android 需要先允许 EV Charge Book 安装下载的更新包。",
+                    "完成系统授权后返回这里，再点击继续安装。"
+                ),
+                confirmText = "继续安装",
+                dismissText = if (current.mandatory) null else "稍后",
+                onConfirm = ::continueInstall,
+                onDismiss = ::deferOptionalUpdate
+            )
+        }
+
+        UpdatePhase.FAILED -> {
+            val current = info ?: return
+            UpdateDecisionDialog(
+                icon = Icons.Rounded.ErrorOutline,
+                accent = EVDesignTokens.Energy.danger,
+                title = "更新失败",
+                lines = listOf(errorMessage ?: "更新包下载失败，请稍后重试"),
+                confirmText = "重试",
+                dismissText = if (current.mandatory) null else "稍后",
+                onConfirm = ::startDownload,
+                onDismiss = ::deferOptionalUpdate
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Superseded by a clean replay on the latest `main` because #158 merged while this PR's CI was running. The code changes themselves passed Android CI; replacement PR is based on current main.