### PR TITLE
fix(ui): finalize Dashboard Hero and recent Trip card

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -1,7 +1,6 @@
 package com.evchargebook.ui.dashboard
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +16,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -146,15 +147,13 @@ fun DashboardRecentTripCard(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(0.72f))
+                    TripMetric(formatDistanceValue(trip.distanceMeters), "km", Modifier.weight(1f))
                     MetricSeparator()
-                    TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(0.74f))
+                    TripMetric(formatDuration(trip.elapsedSeconds), "时长", Modifier.weight(1f))
                     MetricSeparator()
-                    TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "能耗", Modifier.weight(0.74f))
+                    TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "kWh/100km", Modifier.weight(1.15f))
                     MetricSeparator()
-                    TripMetric(formatSocRange(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1.0f))
-                    MetricSeparator()
-                    TripMetric(formatMileageRange(trip.startMileageKm, trip.endMileageKm), "里程", Modifier.weight(1.8f))
+                    TripMetric(formatSocConsumed(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1f))
                 }
             }
         }
@@ -232,21 +231,22 @@ private fun TripEndpointRow(address: String) {
 private fun TripRouteRail() {
     val markerColor = MaterialTheme.colorScheme.onSurfaceVariant
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            Modifier
-                .size(9.dp)
-                .border(1.4.dp, markerColor.copy(alpha = 0.88f), CircleShape)
+        Icon(
+            imageVector = Icons.Default.PlayArrow,
+            contentDescription = "起点",
+            tint = markerColor.copy(alpha = 0.92f),
+            modifier = Modifier.size(16.dp)
         )
         Box(
             Modifier
-                .size(width = 1.dp, height = 36.dp)
-                .background(markerColor.copy(alpha = 0.40f))
+                .size(width = 1.dp, height = 28.dp)
+                .background(markerColor.copy(alpha = 0.38f))
         )
-        Box(
-            Modifier
-                .size(9.dp)
-                .background(markerColor.copy(alpha = 0.66f), CircleShape)
-                .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.20f), CircleShape)
+        Icon(
+            imageVector = Icons.Default.Flag,
+            contentDescription = "终点",
+            tint = markerColor.copy(alpha = 0.82f),
+            modifier = Modifier.size(15.dp)
         )
     }
 }
@@ -305,7 +305,7 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
-                        "完成第一段行程后，这里会显示距离、SOC、里程与可信的能耗估算。",
+                        "完成第一段行程后，这里会显示距离、SOC 与可信的能耗估算。",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -331,19 +331,11 @@ private fun endpointText(address: String?, latitude: Double?, longitude: Double?
     else -> "地点信息不可用"
 }
 
-private fun formatSocRange(start: Int?, end: Int?): String =
-    "${start?.let { "$it%" } ?: "--"}→${end?.let { "$it%" } ?: "--"}"
-
-private fun formatMileageRange(start: Double?, end: Double?): String = when {
-    start != null && end != null -> "${formatMileage(start)}→${formatMileage(end)}"
-    start != null -> "${formatMileage(start)}→--"
-    end != null -> "--→${formatMileage(end)}"
-    else -> "--"
+private fun formatSocConsumed(start: Int?, end: Int?): String = when {
+    start == null || end == null -> "--"
+    end > start -> "--"
+    else -> "消耗 ${start - end}%"
 }
-
-private fun formatMileage(value: Double): String =
-    if (value % 1.0 == 0.0) String.format(Locale.US, "%,.0f", value)
-    else String.format(Locale.US, "%,.1f", value)
 
 private fun formatConsumptionValue(value: Double?): String =
     value?.takeIf { it.isFinite() && it >= 0.0 }

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -109,9 +109,9 @@ fun HeroVehicleCard(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        // Keep the 1600x1100 source asset; use a slightly taller viewport so the
-                        // vehicle has more presence. Crop remains modest and symmetric.
-                        .aspectRatio(1.38f)
+                        // The source remains 1600x1100. A taller stage intentionally trades a
+                        // modest symmetric side crop for the stronger Hero presence approved on device.
+                        .aspectRatio(1.24f)
                 ) {
                     VehicleStage(vehicle, effectiveArtworkKey, Modifier.fillMaxSize())
                     Box(
@@ -305,12 +305,15 @@ private fun HeroDynamicStatePanel(
     val recentDistance = latestTrip
         ?.distanceMeters
         ?.takeIf { it.isFinite() && it > 0.0 }
+    val recentConsumption = latestTrip
+        ?.averageConsumptionKwhPer100Km
+        ?.takeIf { it.isFinite() && it >= 0.0 }
     val panelShape = RoundedCornerShape(20.dp)
 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(80.dp)
+            .height(84.dp)
             .shadow(
                 elevation = 6.dp,
                 shape = panelShape,
@@ -355,7 +358,7 @@ private fun HeroDynamicStatePanel(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 8.dp),
+                .padding(horizontal = 14.dp, vertical = 7.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             HeroSocMetric(
@@ -379,8 +382,9 @@ private fun HeroDynamicStatePanel(
                 label = "最近行程",
                 value = recentDistance?.let(::formatTripDistance) ?: "--",
                 unit = recentDistance?.let { if (it >= 1000.0) "km" else "m" },
+                secondaryValue = recentConsumption?.let { String.format(Locale.US, "%.1f kWh/100km", it) },
                 modifier = Modifier
-                    .weight(0.96f)
+                    .weight(1.0f)
                     .padding(start = 10.dp)
             )
         }
@@ -441,6 +445,7 @@ private fun HeroMetric(
     label: String,
     value: String,
     unit: String? = null,
+    secondaryValue: String? = null,
     modifier: Modifier = Modifier
 ) {
     val cockpit = LocalCockpitColors.current
@@ -462,7 +467,7 @@ private fun HeroMetric(
                 overflow = TextOverflow.Clip
             )
         }
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(3.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.Bottom
@@ -486,6 +491,17 @@ private fun HeroMetric(
                     softWrap = false
                 )
             }
+        }
+        if (secondaryValue != null) {
+            Spacer(Modifier.height(1.dp))
+            Text(
+                text = secondaryValue,
+                style = MaterialTheme.typography.labelSmall,
+                color = cockpit.secondaryText,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip
+            )
         }
     }
 }


### PR DESCRIPTION
## Final visual pass

Match the approved Dashboard concept without touching Trip persistence or other business logic.

### Hero
- increase Hero artwork presence with a taller 1.24:1 stage while keeping existing 1600x1100 assets and center crop;
- keep the compact vehicle title and switch control;
- keep the floating glass state strip;
- show recent distance plus consumption as a secondary line.

### Recent Trip
- reuse the Trip-detail PlayArrow / Flag endpoint icon semantics in a neutral color;
- replace `82%→79%` with compact consumed SOC such as `消耗 3%`;
- remove the mileage delta metric entirely;
- keep only distance / duration / consumption / consumed SOC.

## Scope
Dashboard presentation only. No Room, route recording, vehicle catalog, updater or release pipeline changes.

Refs #94 #95.