### PR TITLE
ui: tighten Trip device fidelity for slider trends and history

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveTelemetryV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveTelemetryV06.kt
@@ -1,7 +1,6 @@
 package com.evchargebook.ui.trip
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material3.Icon
@@ -35,7 +33,6 @@ import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
-import kotlin.math.max
 
 private const val ACTIVE_TREND_LONG_GAP_MS = 120_000L
 
@@ -83,12 +80,12 @@ internal fun TripActiveTelemetryV06(
     }
     val speedSamples = remember(points) {
         points.mapNotNull { point ->
-            trustedSpeed(point)?.let { TrendSample(point.capturedAtEpochMillis, it * 3.6) }
+            trustedSpeed(point)?.let { TripTrendSampleV06(point.capturedAtEpochMillis, it * 3.6) }
         }
     }
     val altitudeSamples = remember(points) {
         points.mapNotNull { point ->
-            trustedAltitude(point)?.let { TrendSample(point.capturedAtEpochMillis, it) }
+            trustedAltitude(point)?.let { TripTrendSampleV06(point.capturedAtEpochMillis, it) }
         }
     }
 
@@ -174,45 +171,58 @@ internal fun TripActiveTelemetryV06(
             }
         }
 
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
             TripTrendMiniCard(
                 title = "速度趋势",
                 unit = "km/h",
                 samples = speedSamples,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 emptyText = "暂无可信速度"
             )
             TripTrendMiniCard(
                 title = "海拔趋势",
                 unit = "m",
                 samples = altitudeSamples,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 emptyText = "暂无可信海拔"
             )
         }
     }
 }
 
-private data class TrendSample(
-    val timestamp: Long,
-    val value: Double
-)
-
 @Composable
 private fun TripTrendMiniCard(
     title: String,
     unit: String,
-    samples: List<TrendSample>,
+    samples: List<TripTrendSampleV06>,
     modifier: Modifier,
     emptyText: String
 ) {
-    val accent = EVDesignTokens.Energy.green
     Surface(modifier = modifier, shape = MaterialTheme.shapes.large, color = MaterialTheme.colorScheme.surfaceContainerLow) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom) {
+                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                    Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (samples.isNotEmpty()) {
+                        Text(
+                            formatActiveTrendValue(samples.last().value, unit),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+                if (samples.size >= 2) {
+                    Text(
+                        "${formatActiveTrendAxis(samples.minOf { it.value })}–${formatActiveTrendAxis(samples.maxOf { it.value })} $unit",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
             if (samples.size < 2) {
                 Column(
                     modifier = Modifier.fillMaxWidth().height(68.dp),
@@ -221,41 +231,11 @@ private fun TripTrendMiniCard(
                     Text(emptyText, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             } else {
-                val latest = samples.last().value
-                Text(
-                    String.format(Locale.US, if (unit == "m") "%.0f %s" else "%.0f %s", latest, unit),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
+                TripTrendPlotV06(
+                    samples = samples,
+                    unit = unit,
+                    longGapMs = ACTIVE_TREND_LONG_GAP_MS
                 )
-                Canvas(Modifier.fillMaxWidth().height(56.dp)) {
-                    val values = samples.map { it.value }
-                    val minValue = values.minOrNull() ?: 0.0
-                    val maxValue = values.maxOrNull() ?: minValue
-                    val range = max(1.0, maxValue - minValue)
-                    val minTime = samples.first().timestamp
-                    val maxTime = samples.last().timestamp
-                    val timeRange = max(1L, maxTime - minTime).toDouble()
-                    val padY = 4.dp.toPx()
-                    val usableHeight = (size.height - padY * 2).coerceAtLeast(1f)
-                    fun point(sample: TrendSample): Offset {
-                        val x = ((sample.timestamp - minTime) / timeRange).toFloat() * size.width
-                        val normalized = ((sample.value - minValue) / range).toFloat().coerceIn(0f, 1f)
-                        val y = padY + (1f - normalized) * usableHeight
-                        return Offset(x, y)
-                    }
-
-                    samples.zipWithNext().forEach { (from, to) ->
-                        if (to.timestamp - from.timestamp <= ACTIVE_TREND_LONG_GAP_MS) {
-                            drawLine(
-                                color = accent.copy(alpha = .78f),
-                                start = point(from),
-                                end = point(to),
-                                strokeWidth = 2.dp.toPx(),
-                                cap = StrokeCap.Round
-                            )
-                        }
-                    }
-                }
             }
         }
     }
@@ -282,3 +262,8 @@ private fun trustedAltitude(point: TripPointEntity): Double? {
     if (horizontalAccuracy != null && (!horizontalAccuracy.isFinite() || horizontalAccuracy > 80.0)) return null
     return altitude
 }
+
+private fun formatActiveTrendValue(value: Double, unit: String): String =
+    String.format(Locale.US, "%.0f %s", value, unit)
+
+private fun formatActiveTrendAxis(value: Double): String = String.format(Locale.US, "%.0f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,6 +19,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -130,6 +132,7 @@ internal fun TripDetailScreenV06(
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
@@ -139,6 +142,7 @@ internal fun TripDetailScreenV06(
                         Icon(Icons.Default.ArrowBack, contentDescription = "返回")
                     }
                 },
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }
@@ -169,7 +173,12 @@ internal fun TripDetailScreenV06(
             }
 
             geometry?.takeIf { it.isDrawable }?.let {
-                item { CompletedTripRoutePreviewV06(points) }
+                item {
+                    CompletedTripRoutePreviewV06(
+                        points = points,
+                        finalEndpoint = trip.status == TripStatus.COMPLETED
+                    )
+                }
             }
 
             if (hasAltitude) {
@@ -279,6 +288,7 @@ private fun CompletedTripEndpointCardV06(
     resolving: Boolean
 ) {
     val accent = EVDesignTokens.Energy.green
+    val finalEndpoint = trip.status == TripStatus.COMPLETED
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -294,6 +304,7 @@ private fun CompletedTripEndpointCardV06(
                 address = startAddress,
                 resolving = resolving,
                 recording = trip.status == TripStatus.RECORDING,
+                recordingText = "行程进行中，结束后解析地址",
                 icon = {
                     Icon(
                         Icons.Default.PlayArrow,
@@ -304,21 +315,40 @@ private fun CompletedTripEndpointCardV06(
                 }
             )
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .22f))
-            EndpointLineV06(
-                label = "终点",
-                point = endPoint,
-                address = endAddress,
-                resolving = resolving,
-                recording = trip.status == TripStatus.RECORDING,
-                icon = {
-                    Icon(
-                        Icons.Default.Flag,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.size(17.dp)
-                    )
-                }
-            )
+            if (finalEndpoint) {
+                EndpointLineV06(
+                    label = "终点",
+                    point = endPoint,
+                    address = endAddress,
+                    resolving = resolving,
+                    recording = false,
+                    icon = {
+                        Icon(
+                            Icons.Default.Flag,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(17.dp)
+                        )
+                    }
+                )
+            } else {
+                EndpointLineV06(
+                    label = if (trip.status == TripStatus.RECORDING) "当前点" else "最后记录点",
+                    point = endPoint,
+                    address = endAddress,
+                    resolving = resolving,
+                    recording = trip.status == TripStatus.RECORDING,
+                    recordingText = "当前最新定位点",
+                    icon = {
+                        Icon(
+                            Icons.Default.LocationOn,
+                            contentDescription = null,
+                            tint = accent,
+                            modifier = Modifier.size(17.dp)
+                        )
+                    }
+                )
+            }
         }
     }
 }
@@ -330,6 +360,7 @@ private fun EndpointLineV06(
     address: String?,
     resolving: Boolean,
     recording: Boolean,
+    recordingText: String? = null,
     icon: @Composable () -> Unit
 ) {
     Row(
@@ -349,7 +380,7 @@ private fun EndpointLineV06(
             Text(
                 when {
                     point == null -> "暂无保存的${label}"
-                    recording -> if (label == "终点") "行程进行中，终点尚未确定" else "行程进行中，结束后解析地址"
+                    recording -> recordingText ?: "行程进行中"
                     resolving -> "地址解析中…"
                     !address.isNullOrBlank() -> address
                     else -> "地址暂不可用"
@@ -403,7 +434,7 @@ private fun SummaryMetricGridV06(metrics: List<SummaryMetricV06>) {
 }
 
 @Composable
-private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>) {
+private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEndpoint: Boolean) {
     val accent = EVDesignTokens.Energy.green
     val geometry = remember(points) {
         TripRouteGeometryBuilder.build(points.map { it.toV06RoutePoint() })
@@ -434,7 +465,11 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>) {
                     .fillMaxWidth()
                     .height(150.dp)
                     .semantics {
-                        contentDescription = "真实行程轨迹；绿色播放标记为起点，红旗标记为终点，长 GPS 缺口保持断开"
+                        contentDescription = if (finalEndpoint) {
+                            "真实行程轨迹；绿色播放标记为起点，红旗标记为终点，长 GPS 缺口保持断开"
+                        } else {
+                            "真实行程轨迹；绿色播放标记为起点，绿色圆点为当前或最后记录点，长 GPS 缺口保持断开"
+                        }
                     }
             ) {
                 val pad = 12.dp.toPx()
@@ -465,15 +500,20 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>) {
                 }
                 drawPath(startTriangle, accent)
 
-                val poleHeight = 13.dp.toPx()
-                drawLine(endColor, end, Offset(end.x, end.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
-                val flag = Path().apply {
-                    moveTo(end.x, end.y - poleHeight)
-                    lineTo(end.x + 9.dp.toPx(), end.y - poleHeight + 3.dp.toPx())
-                    lineTo(end.x, end.y - poleHeight + 6.dp.toPx())
-                    close()
+                if (finalEndpoint) {
+                    val poleHeight = 13.dp.toPx()
+                    drawLine(endColor, end, Offset(end.x, end.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
+                    val flag = Path().apply {
+                        moveTo(end.x, end.y - poleHeight)
+                        lineTo(end.x + 9.dp.toPx(), end.y - poleHeight + 3.dp.toPx())
+                        lineTo(end.x, end.y - poleHeight + 6.dp.toPx())
+                        close()
+                    }
+                    drawPath(flag, endColor)
+                } else {
+                    drawCircle(accent.copy(alpha = .22f), 6.dp.toPx(), end)
+                    drawCircle(accent, 3.dp.toPx(), end)
                 }
-                drawPath(flag, endColor)
             }
 
             if (geometry.gapCount > 0) {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -1,6 +1,5 @@
 package com.evchargebook.ui.trip
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -14,34 +13,25 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.domain.TripSpeedTrustRules
-import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
-import kotlin.math.max
 
 private const val DETAIL_TREND_LONG_GAP_MS = 120_000L
-
-private data class DetailTrendSampleV06(
-    val timestamp: Long,
-    val value: Double
-)
 
 @Composable
 internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
     val speedSamples = remember(points) {
         points.mapNotNull { point ->
-            trustedDetailSpeedV06(point)?.let { DetailTrendSampleV06(point.capturedAtEpochMillis, it * 3.6) }
+            trustedDetailSpeedV06(point)?.let { TripTrendSampleV06(point.capturedAtEpochMillis, it * 3.6) }
         }
     }
     val altitudeSamples = remember(points) {
         points.mapNotNull { point ->
-            trustedDetailAltitudeV06(point)?.let { DetailTrendSampleV06(point.capturedAtEpochMillis, it) }
+            trustedDetailAltitudeV06(point)?.let { TripTrendSampleV06(point.capturedAtEpochMillis, it) }
         }
     }
 
@@ -57,7 +47,7 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text("趋势", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 Text(
-                    "仅使用可信定位样本；超过 2 分钟的缺口保持断开。",
+                    "横轴为行程时间，纵轴为可信样本值；超过 2 分钟的缺口保持断开。",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -88,11 +78,10 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
 private fun DetailTrendCardV06(
     title: String,
     unit: String,
-    samples: List<DetailTrendSampleV06>,
+    samples: List<TripTrendSampleV06>,
     modifier: Modifier,
     emptyText: String
 ) {
-    val accent = EVDesignTokens.Energy.green
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.medium,
@@ -100,52 +89,56 @@ private fun DetailTrendCardV06(
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             if (samples.size < 2) {
                 Text(
                     emptyText,
-                    modifier = Modifier.height(72.dp),
+                    modifier = Modifier.height(96.dp),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             } else {
-                Text(
-                    formatDetailTrendValueV06(samples.last().value, unit),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
+                TrendSummaryV06(unit = unit, samples = samples)
+                TripTrendPlotV06(
+                    samples = samples,
+                    unit = unit,
+                    longGapMs = DETAIL_TREND_LONG_GAP_MS
                 )
-                Canvas(Modifier.fillMaxWidth().height(58.dp)) {
-                    val minValue = samples.minOf { it.value }
-                    val maxValue = samples.maxOf { it.value }
-                    val valueRange = max(1.0, maxValue - minValue)
-                    val minTime = samples.first().timestamp
-                    val maxTime = samples.last().timestamp
-                    val timeRange = max(1L, maxTime - minTime).toDouble()
-                    val padY = 4.dp.toPx()
-                    val usableHeight = (size.height - padY * 2).coerceAtLeast(1f)
-
-                    fun point(sample: DetailTrendSampleV06): Offset {
-                        val x = ((sample.timestamp - minTime) / timeRange).toFloat() * size.width
-                        val normalized = ((sample.value - minValue) / valueRange).toFloat().coerceIn(0f, 1f)
-                        return Offset(x, padY + (1f - normalized) * usableHeight)
-                    }
-
-                    samples.zipWithNext().forEach { (from, to) ->
-                        if (to.timestamp - from.timestamp <= DETAIL_TREND_LONG_GAP_MS) {
-                            drawLine(
-                                color = accent.copy(alpha = .78f),
-                                start = point(from),
-                                end = point(to),
-                                strokeWidth = 2.dp.toPx(),
-                                cap = StrokeCap.Round
-                            )
-                        }
-                    }
-                }
             }
         }
+    }
+}
+
+@Composable
+private fun TrendSummaryV06(unit: String, samples: List<TripTrendSampleV06>) {
+    val min = samples.minOf { it.value }
+    val max = samples.maxOf { it.value }
+    val average = samples.map { it.value }.average()
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        if (unit == "km/h") {
+            TrendSummaryValueV06("平均", average, unit)
+            TrendSummaryValueV06("最高", max, unit)
+        } else {
+            TrendSummaryValueV06("最低", min, unit)
+            TrendSummaryValueV06("最高", max, unit)
+        }
+    }
+}
+
+@Composable
+private fun TrendSummaryValueV06(label: String, value: Double, unit: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(
+            formatDetailTrendValueV06(value, unit),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold
+        )
     }
 }
 
@@ -172,5 +165,4 @@ private fun trustedDetailAltitudeV06(point: TripPointEntity): Double? {
 }
 
 private fun formatDetailTrendValueV06(value: Double, unit: String): String =
-    if (unit == "m") String.format(Locale.US, "%.0f %s", value, unit)
-    else String.format(Locale.US, "%.0f %s", value, unit)
+    String.format(Locale.US, "%.0f %s", value, unit)

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Route
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -71,30 +71,30 @@ internal fun TripHistoryCardV06(
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
+        shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainerLow
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            modifier = Modifier.fillMaxWidth().padding(start = 10.dp, top = 7.dp, bottom = 7.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
-                modifier = Modifier.size(40.dp).background(accent.copy(alpha = 0.10f), CircleShape),
+                modifier = Modifier.size(32.dp).background(accent.copy(alpha = 0.09f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = Icons.Default.Route,
+                    imageVector = Icons.Default.PlayArrow,
                     contentDescription = null,
                     tint = accent,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(18.dp)
                 )
             }
 
-            Spacer(Modifier.width(12.dp))
+            Spacer(Modifier.width(9.dp))
 
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -114,27 +114,22 @@ internal fun TripHistoryCardV06(
                     )
                 }
 
-                Text(
-                    text = "起 ${endpoints.start}  →  终 ${endpoints.end}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                EndpointHistoryLineV06("起", endpoints.start)
+                EndpointHistoryLineV06("终", endpoints.end)
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         text = formatTripHistoryDistance(trip.distanceMeters),
-                        style = MaterialTheme.typography.bodySmall,
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Text(
                         text = formatTripHistoryDuration(trip.elapsedSeconds),
-                        style = MaterialTheme.typography.bodySmall,
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Text(
@@ -142,7 +137,7 @@ internal fun TripHistoryCardV06(
                             ?.takeIf { it.isFinite() && it >= 0.0 }
                             ?.let { String.format(Locale.US, "%.1f kWh/100km", it) }
                             ?: "能耗 --",
-                        style = MaterialTheme.typography.bodySmall,
+                        style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.weight(1f),
                         maxLines = 1,
@@ -157,11 +152,36 @@ internal fun TripHistoryCardV06(
                         imageVector = Icons.Default.Delete,
                         contentDescription = "删除行程",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(17.dp)
                     )
                 }
+            } else {
+                Spacer(Modifier.width(8.dp))
             }
         }
+    }
+}
+
+@Composable
+private fun EndpointHistoryLineV06(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -61,6 +62,7 @@ fun TripReadyScreen(
     val accent = EVDesignTokens.Energy.green
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
@@ -70,6 +72,7 @@ fun TripReadyScreen(
                         Text("TRIP READY", style = MaterialTheme.typography.labelSmall, color = accent)
                     }
                 },
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -95,6 +96,7 @@ fun TripScreen(
     val accent = EVDesignTokens.Energy.green
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
@@ -109,6 +111,7 @@ fun TripScreen(
                         )
                     }
                 },
+                windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripSlideAction.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripSlideAction.kt
@@ -118,6 +118,7 @@ internal fun TripSlideAction(
                             .fillMaxWidth(
                                 ((displayedOffsetPx + thumbSizePx) / trackWidthPx).coerceIn(0f, 1f)
                             )
+                            .clip(CircleShape)
                             .background(accent.copy(alpha = 0.10f))
                     )
                 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
@@ -1,0 +1,148 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.evchargebook.ui.theme.EVDesignTokens
+import java.util.Locale
+import kotlin.math.max
+
+internal data class TripTrendSampleV06(
+    val timestamp: Long,
+    val value: Double
+)
+
+/**
+ * Lightweight Compose-native trend plot used by active and completed Trip surfaces.
+ * Text values remain authoritative; the chart never smooths or bridges long GPS gaps.
+ */
+@Composable
+internal fun TripTrendPlotV06(
+    samples: List<TripTrendSampleV06>,
+    unit: String,
+    longGapMs: Long,
+    modifier: Modifier = Modifier
+) {
+    if (samples.size < 2) return
+
+    val accent = EVDesignTokens.Energy.green
+    val minValue = samples.minOf { it.value }
+    val maxValue = samples.maxOf { it.value }
+    val valueRange = max(1.0, maxValue - minValue)
+    val midValue = minValue + valueRange / 2.0
+    val minTime = samples.first().timestamp
+    val maxTime = samples.last().timestamp
+    val timeRangeMs = max(1L, maxTime - minTime)
+    val midElapsedMs = timeRangeMs / 2
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.width(44.dp).height(76.dp),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                AxisValue(formatTripTrendAxisValue(maxValue, unit))
+                AxisValue(formatTripTrendAxisValue(midValue, unit))
+                AxisValue(formatTripTrendAxisValue(minValue, unit))
+            }
+
+            Canvas(Modifier.weight(1f).height(76.dp)) {
+                val padY = 5.dp.toPx()
+                val usableHeight = (size.height - padY * 2).coerceAtLeast(1f)
+                val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
+
+                listOf(0f, 0.5f, 1f).forEach { fraction ->
+                    val y = padY + fraction * usableHeight
+                    drawLine(
+                        color = gridColor,
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                }
+
+                fun point(sample: TripTrendSampleV06): Offset {
+                    val x = ((sample.timestamp - minTime).toDouble() / timeRangeMs.toDouble()).toFloat() * size.width
+                    val normalized = ((sample.value - minValue) / valueRange).toFloat().coerceIn(0f, 1f)
+                    return Offset(x, padY + (1f - normalized) * usableHeight)
+                }
+
+                samples.zipWithNext().forEach { (from, to) ->
+                    if (to.timestamp - from.timestamp <= longGapMs) {
+                        drawLine(
+                            color = accent.copy(alpha = 0.82f),
+                            start = point(from),
+                            end = point(to),
+                            strokeWidth = 2.dp.toPx(),
+                            cap = StrokeCap.Round
+                        )
+                    }
+                }
+            }
+        }
+
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Spacer(Modifier.width(44.dp))
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                AxisTime("0s", TextAlign.Start)
+                AxisTime(formatTripTrendElapsed(midElapsedMs), TextAlign.Center)
+                AxisTime(formatTripTrendElapsed(timeRangeMs), TextAlign.End)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AxisValue(value: String) {
+    Text(
+        text = value,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1
+    )
+}
+
+@Composable
+private fun AxisTime(value: String, align: TextAlign) {
+    Text(
+        text = value,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = align
+    )
+}
+
+private fun formatTripTrendAxisValue(value: Double, unit: String): String =
+    when (unit) {
+        "km/h" -> String.format(Locale.US, "%.0f", value)
+        "m" -> String.format(Locale.US, "%.0f", value)
+        else -> String.format(Locale.US, "%.1f", value)
+    }
+
+private fun formatTripTrendElapsed(elapsedMs: Long): String {
+    val totalSeconds = (elapsedMs / 1000L).coerceAtLeast(0L)
+    val hours = totalSeconds / 3600L
+    val minutes = (totalSeconds % 3600L) / 60L
+    val seconds = totalSeconds % 60L
+    return when {
+        hours > 0 -> String.format(Locale.US, "%d:%02d", hours, minutes)
+        minutes > 0 -> String.format(Locale.US, "%d:%02d", minutes, seconds)
+        else -> "${seconds}s"
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
@@ -39,6 +39,7 @@ internal fun TripTrendPlotV06(
     if (samples.size < 2) return
 
     val accent = EVDesignTokens.Energy.green
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
     val minValue = samples.minOf { it.value }
     val maxValue = samples.maxOf { it.value }
     val valueRange = max(1.0, maxValue - minValue)
@@ -62,7 +63,6 @@ internal fun TripTrendPlotV06(
             Canvas(Modifier.weight(1f).height(76.dp)) {
                 val padY = 5.dp.toPx()
                 val usableHeight = (size.height - padY * 2).coerceAtLeast(1f)
-                val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.20f)
 
                 listOf(0f, 0.5f, 1f).forEach { fraction ->
                     val y = padY + fraction * usableHeight


### PR DESCRIPTION
## Summary

Physical-fidelity correction for #168 after comparing the 2026-08-29 real-device screenshots against the already approved Trip v0.6 board. This reuses the approved design rather than introducing a new visual direction.

### Slider
- clips the animated progress fill to the same capsule shape as the start/end slider track
- removes the hard rectangular moving edge
- keeps restrained `EVDesignTokens.Energy.green` and accessibility semantic click fallback

### Trend charts
- adds one shared Compose-native trend plot with sparse Y reference values and X elapsed-time labels
- applies it to active and completed speed/altitude trends
- preserves >2 minute gap discontinuity; no smoothing/interpolation
- completed speed summarizes trusted average + max instead of promoting the final stopped `0 km/h` sample
- altitude summarizes trusted min + max
- no chart framework/dependency added

### Trip history
- reduces row/card weight and leading icon size
- restores the approved dense scan order: time/status -> start/end -> distance/duration/consumption
- preserves the explicit 48dp delete target and existing confirmation flow
- address / coordinate / unavailable fallbacks remain truthful

### Top spacing / inset ownership
- root `MainActivity` remains the system safe-area owner
- nested Trip READY, active and detail Scaffolds/TopAppBars now use zero nested window insets
- removes the double top safe-area gap visible in the device screenshots without drawing under the system bar

### Recording endpoint semantics
- completed Trip still uses the small red flag for the real recorded endpoint
- RECORDING uses a primary-green `当前点` marker instead of presenting the latest sample as a completed `终点`
- INTERRUPTED/non-final detail uses `最后记录点`, also without a red final flag
- route preview likewise reserves the red flag for completed Trips and uses a green current/last-point marker otherwise

## Scope boundary

No Trip persistence, tracking service, schema, backend, destination planning, fake map/background, or route-truth changes. Existing LONG_GAP behavior remains authoritative.

## Acceptance
- [x] slider progress moving edge is rounded
- [x] active + completed trends have sparse X/Y references
- [x] completed speed summary uses average/max trusted samples
- [x] history rows are materially denser and show both endpoints
- [x] nested Trip screens no longer claim a second system top inset
- [x] recording/interrupted detail no longer uses completed red-flag endpoint semantics
- [x] Android Build #482 Green (build + tests + Debug APK upload)
- [x] merged to `main` as `7963389`
- [ ] physical-device comparison against the approved v0.6 board

Issue: #168
Parent: #145