### PR TITLE
ui: compact Trip completion confirmation

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -14,14 +14,12 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -35,7 +33,6 @@ import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.export.ChargingCsvExporter
 import com.evchargebook.data.repository.ChargingRepository
 import com.evchargebook.domain.TripNotificationPermissionPolicy
-import com.evchargebook.domain.trip.TripEnergyCalculator
 import com.evchargebook.ui.dashboard.DashboardScreen
 import com.evchargebook.ui.records.AddRecordScreen
 import com.evchargebook.ui.records.RecordEditScreen
@@ -43,6 +40,7 @@ import com.evchargebook.ui.records.RecordsScreen
 import com.evchargebook.ui.stats.StatsScreen
 import com.evchargebook.ui.theme.EvChargeTheme
 import com.evchargebook.ui.theme.LocalAppThemeController
+import com.evchargebook.ui.trip.TripCompletionDialogV06
 import com.evchargebook.ui.trip.TripReadyScreen
 import com.evchargebook.ui.trip.TripScreen
 import com.evchargebook.ui.vehicle.BluetoothPromptScreen
@@ -517,86 +515,35 @@ fun MainApp(
             showTripCompletion = false
         } else {
             val tripVehicle = state.vehicles.firstOrNull { it.id == active.vehicleId } ?: state.vehicle
-            val endSoc = tripEndSocText.toIntOrNull()
-            val estimate = TripEnergyCalculator.estimate(
+            TripCompletionDialogV06(
+                activeTrip = active,
                 batteryCapacityKwh = tripVehicle?.batteryCapacityKwh,
-                startSoc = active.startSoc,
-                endSoc = endSoc,
-                distanceMeters = active.distanceMeters
-            )
-            AlertDialog(
-                onDismissRequest = { showTripCompletion = false },
-                title = { Text("完成本次行程") },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        Text(
-                            "开始 SOC ${active.startSoc?.let { "$it%" } ?: "未知"} · GPS 距离 ${String.format(Locale.US, "%.1f", active.distanceMeters / 1000.0)} km",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        OutlinedTextField(
-                            value = tripEndSocText,
-                            onValueChange = { tripEndSocText = it.filter(Char::isDigit).take(3); tripCompletionError = null },
-                            label = { Text("结束 SOC") },
-                            suffix = { Text("%") },
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        OutlinedTextField(
-                            value = tripEndMileageText,
-                            onValueChange = { tripEndMileageText = it; tripCompletionError = null },
-                            label = { Text("结束总里程") },
-                            suffix = { Text("km") },
-                            supportingText = { Text("已按开始里程 + GPS 距离预填，可修改；留空则保存时自动估算") },
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        if (estimate.consumedEnergyKwh != null) {
-                            HorizontalDivider()
-                            Text(
-                                "SOC ${active.startSoc}% → ${endSoc}% · 估算消耗 ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            Text(
-                                estimate.averageConsumptionKwhPer100Km?.let { "估算平均能耗 ${String.format(Locale.US, "%.1f", it)} kWh/100km" }
-                                    ?: "距离不足，暂不能计算平均能耗",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                        } else if (active.startSoc != null && endSoc != null && endSoc in 0..100) {
-                            HorizontalDivider()
-                            Text(
-                                if (endSoc >= active.startSoc) {
-                                    "SOC 未下降或出现回升；可能来自取整、回收制动或补能，本次不强行计算行驶能耗。"
-                                } else {
-                                    "当前数据不足以形成可靠的 SOC 能耗估算。"
-                                },
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        tripCompletionError?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+                endSocText = tripEndSocText,
+                onEndSocChange = {
+                    tripEndSocText = it
+                    tripCompletionError = null
+                },
+                endMileageText = tripEndMileageText,
+                onEndMileageChange = {
+                    tripEndMileageText = it
+                    tripCompletionError = null
+                },
+                errorText = tripCompletionError,
+                onContinue = { showTripCompletion = false },
+                onSaveAndStop = {
+                    val parsedSoc = tripEndSocText.toIntOrNull()
+                    val parsedMileage = tripEndMileageText.toDoubleOrNull()
+                    tripCompletionError = when {
+                        parsedSoc == null || parsedSoc !in 0..100 -> "请输入 0~100 的结束 SOC"
+                        tripEndMileageText.isNotBlank() && (parsedMileage == null || parsedMileage < 0.0) -> "请输入有效的结束总里程"
+                        active.startMileageKm != null && parsedMileage != null && parsedMileage < active.startMileageKm -> "结束里程不能低于开始里程"
+                        else -> null
                     }
-                },
-                confirmButton = {
-                    TextButton(onClick = {
-                        val parsedSoc = tripEndSocText.toIntOrNull()
-                        val parsedMileage = tripEndMileageText.toDoubleOrNull()
-                        tripCompletionError = when {
-                            parsedSoc == null || parsedSoc !in 0..100 -> "请输入 0~100 的结束 SOC"
-                            tripEndMileageText.isNotBlank() && (parsedMileage == null || parsedMileage < 0.0) -> "请输入有效的结束总里程"
-                            active.startMileageKm != null && parsedMileage != null && parsedMileage < active.startMileageKm -> "结束里程不能低于开始里程"
-                            else -> null
-                        }
-                        if (tripCompletionError == null) {
-                            showTripCompletion = false
-                            viewModel.stopTrip(parsedSoc!!, parsedMileage)
-                        }
-                    }) { Text("保存并结束") }
-                },
-                dismissButton = { TextButton(onClick = { showTripCompletion = false }) { Text("继续行驶") } }
+                    if (tripCompletionError == null) {
+                        showTripCompletion = false
+                        viewModel.stopTrip(parsedSoc!!, parsedMileage)
+                    }
+                }
             )
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripCompletionDialogV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripCompletionDialogV06.kt
@@ -1,0 +1,228 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.domain.trip.TripEnergyCalculator
+import com.evchargebook.ui.theme.EVDesignTokens
+import com.evchargebook.ui.theme.spacing
+import java.util.Locale
+
+/**
+ * Compact final confirmation after the slide-to-end gesture.
+ *
+ * This intentionally keeps the existing Trip stop/validation contract outside the component.
+ * It only presents the already-owned Trip facts and the existing SOC-derived estimate.
+ */
+@Composable
+fun TripCompletionDialogV06(
+    activeTrip: TripSessionEntity,
+    batteryCapacityKwh: Double?,
+    endSocText: String,
+    onEndSocChange: (String) -> Unit,
+    endMileageText: String,
+    onEndMileageChange: (String) -> Unit,
+    errorText: String?,
+    onContinue: () -> Unit,
+    onSaveAndStop: () -> Unit
+) {
+    val accent = EVDesignTokens.Energy.green
+    val parsedEndSoc = endSocText.toIntOrNull()
+    val estimate = TripEnergyCalculator.estimate(
+        batteryCapacityKwh = batteryCapacityKwh,
+        startSoc = activeTrip.startSoc,
+        endSoc = parsedEndSoc,
+        distanceMeters = activeTrip.distanceMeters
+    )
+
+    Dialog(
+        onDismissRequest = onContinue,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .widthIn(max = 520.dp)
+                .imePadding(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 0.dp
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        "完成本次行程",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        "确认结束状态后保存真实行程记录",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                ) {
+                    CompletionMetric(
+                        label = "GPS 距离",
+                        value = formatCompletionDistance(activeTrip.distanceMeters),
+                        modifier = Modifier.weight(1f)
+                    )
+                    CompletionMetric(
+                        label = "开始 SOC",
+                        value = activeTrip.startSoc?.let { "$it%" } ?: "--",
+                        modifier = Modifier.weight(1f)
+                    )
+                    CompletionMetric(
+                        label = "开始里程",
+                        value = activeTrip.startMileageKm?.let(::formatCompletionMileage) ?: "--",
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .22f))
+
+                OutlinedTextField(
+                    value = endSocText,
+                    onValueChange = { onEndSocChange(it.filter(Char::isDigit).take(3)) },
+                    label = { Text("结束 SOC") },
+                    suffix = { Text("%") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                OutlinedTextField(
+                    value = endMileageText,
+                    onValueChange = onEndMileageChange,
+                    label = { Text("结束总里程") },
+                    suffix = { Text("km") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    "里程已按开始值 + GPS 距离预填，可修改；留空时沿用现有自动估算逻辑。",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                when {
+                    estimate.consumedEnergyKwh != null -> {
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = MaterialTheme.shapes.medium,
+                            color = accent.copy(alpha = .07f)
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+                                verticalArrangement = Arrangement.spacedBy(2.dp)
+                            ) {
+                                Text(
+                                    "估算能耗",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Text(
+                                    "SOC ${activeTrip.startSoc}% → ${parsedEndSoc}% · ${String.format(Locale.US, "%.1f", estimate.consumedEnergyKwh)} kWh",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Text(
+                                    estimate.averageConsumptionKwhPer100Km?.let {
+                                        "约 ${String.format(Locale.US, "%.1f", it)} kWh/100km · 非 BMS 实测"
+                                    } ?: "距离不足，暂不能计算平均能耗 · 非 BMS 实测",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    activeTrip.startSoc != null && parsedEndSoc != null && parsedEndSoc in 0..100 -> {
+                        Text(
+                            if (parsedEndSoc >= activeTrip.startSoc) {
+                                "SOC 未下降或出现回升，本次不强行计算行驶能耗。"
+                            } else {
+                                "当前数据不足以形成可靠的 SOC 能耗估算。"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                errorText?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+                ) {
+                    TextButton(
+                        onClick = onContinue,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("继续行驶")
+                    }
+                    Button(
+                        onClick = onSaveAndStop,
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = accent,
+                            contentColor = Color(0xFF03120A)
+                        )
+                    ) {
+                        Text("保存并结束", fontWeight = FontWeight.SemiBold)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompletionMetric(label: String, value: String, modifier: Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1)
+    }
+}
+
+private fun formatCompletionDistance(meters: Double): String =
+    if (meters.isFinite() && meters >= 1000.0) String.format(Locale.US, "%.1f km", meters / 1000.0)
+    else if (meters.isFinite() && meters >= 0.0) String.format(Locale.US, "%.0f m", meters)
+    else "--"
+
+private fun formatCompletionMileage(value: Double): String =
+    if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.WarningAmber
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -31,14 +30,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -56,7 +51,7 @@ import java.util.Locale
  * Trip router + active v0.6 cockpit.
  *
  * The no-active state is owned by TripReadyScreen. Selected/completed detail is intentionally
- * isolated in TripDetailScreen.kt so #149-#151 can evolve it without destabilizing live tracking.
+ * isolated in TripDetailScreen.kt so detail/map/diagnostics can evolve without destabilizing live tracking.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -89,7 +84,6 @@ fun TripScreen(
         return
     }
 
-    var confirmStop by remember(activeTrip.id) { mutableStateOf(false) }
     val activeVehicle = vehicles.firstOrNull { it.id == activeTrip.vehicleId } ?: vehicle
     val interrupted = activeTrip.status == TripStatus.INTERRUPTED
     val telemetry = remember(selectedTripPoints) { summarizeActiveTripTelemetry(selectedTripPoints) }
@@ -227,12 +221,12 @@ fun TripScreen(
                 TripSlideAction(
                     label = if (interrupted) "滑动结束已中断行程" else "滑动结束行程",
                     enabled = true,
-                    onConfirmed = { confirmStop = true },
+                    onConfirmed = onStop,
                     icon = Icons.Default.Stop,
                     releaseLabel = "松开结束"
                 )
                 Text(
-                    "结束前仍会保留一次确认，避免驾驶中误操作。",
+                    "滑动后确认结束状态；取消时行程继续记录。",
                     modifier = Modifier.padding(top = 6.dp),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -241,22 +235,6 @@ fun TripScreen(
 
             item { Spacer(Modifier.size(MaterialTheme.spacing.md)) }
         }
-    }
-
-    if (confirmStop) {
-        AlertDialog(
-            onDismissRequest = { confirmStop = false },
-            title = { Text("结束当前行程？") },
-            text = { Text("结束后会停止持续定位并保存当前已经记录的真实行程数据。") },
-            confirmButton = {
-                TextButton(onClick = { confirmStop = false; onStop() }) {
-                    Text("结束行程", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { confirmStop = false }) { Text("继续记录") }
-            }
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #173 under parent #145. This refines the post-slide Trip completion step shown in the 2026-08-29 device screenshot without changing stop rules or Trip data.

### Completion surface
- replaces the oversized generic Trip completion AlertDialog with a Trip-specific compact Dialog surface
- shows GPS distance, starting SOC and starting mileage as a concise evidence row
- keeps ending SOC and ending mileage editable
- keeps the existing mileage prefill from start mileage + GPS distance
- moves explanatory copy out of the text-field supporting area so it no longer dominates the form
- uses restrained `EVDesignTokens.Energy.green` only for the primary save action / estimate evidence

### Interaction simplification
- the slide-to-end gesture now opens this completion form directly
- removes the redundant intermediate `结束当前行程？` alert
- the completion form itself remains the explicit post-slide confirmation
- dismiss / `继续行驶` leaves the Trip active; only validated `保存并结束` stops it

### Estimate / truth semantics
- reuses the existing `TripEnergyCalculator`
- estimated consumption remains explicitly `非 BMS 实测`
- SOC non-decrease still refuses to fabricate energy
- missing/insufficient values remain unavailable

### Validation / safety
- retains 0..100 ending SOC validation
- retains optional numeric non-negative ending mileage
- retains `ending mileage >= starting mileage`
- only validated `保存并结束` calls `stopTrip(endSoc, endMileageKm)`

## Scope boundary
No schema, repository, tracking-service, endpoint, destination or BMS changes.

## Acceptance
- [x] Trip completion uses the compact v0.6 visual language
- [x] current Trip evidence appears before editable ending state
- [x] energy remains explicitly estimated / non-BMS
- [x] redundant intermediate confirmation removed while one explicit confirmation remains
- [x] validation behavior preserved
- [x] continue/dismiss does not stop the Trip
- [x] Android Build #489 Green (build + tests + Debug APK upload)
- [x] merged to `main` as `0b2bdc8`
- [ ] physical-device 320–360dp + fontScale 1.3 pass

Issue: #173
Parent: #145