### PR TITLE
docs: sync Trip v0.6 detail section authority

### DIFF
--- a/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
+++ b/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
@@ -129,7 +129,7 @@ Add:
 
 # Trip v0.6 Approved Follow-up
 
-The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are now tracked as correction slices instead of starting another redesign.
+The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are tracked as correction slices instead of starting another redesign. A final code/design comparison also found that completed Trip detail was still one long scroll while the approved board used separate reading surfaces; #178 / PR #179 closes that information-architecture gap.
 
 Authority: `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
 Owning issue: #145
@@ -151,8 +151,22 @@ Documentation owner: #6
 - [x] #171 — READY information density + active cockpit metric de-duplication — PR #172
 - [x] #173 — compact Trip completion form + remove redundant intermediate confirmation — PR #174
 - [x] #175 — split Trip home/history from READY preparation — PR #176
+- [x] #178 — split completed Trip detail into `概览` / `轨迹` / `数据` supported sections — PR #179, merged as `88e1e2b`, Android CI run `33198331727` Green
 
 Code-side Trip v0.6 work above is in `main`. These Issues remain open only where their explicit physical-device checks are still pending.
+
+## Completed Trip detail section ownership
+
+The selected/completed Trip no longer stacks all supporting evidence into one long scroll.
+
+- `概览` owns completed summary + the compact start/end endpoint card
+- `轨迹` owns truthful route geometry + trusted speed/altitude trends
+- `数据` owns altitude/reliability evidence + raw GPS point progressive disclosure
+- detail opens on `概览`
+- switching sections is presentation-only and must not mutate Trip data
+- missing route/altitude uses truthful compact unavailable states
+- no unsupported `充电`, `备注`, destination or navigation tabs
+- no fake basemap
 
 ## Trip v0.6 guardrails
 
@@ -180,9 +194,10 @@ Remaining work is physical, not another broad code rewrite:
 2. READY — back/start behavior, compact GPS truth, slide gesture
 3. Active — live route, current speed, trends, interrupted state
 4. Completion — keyboard/IME, 320–360dp, fontScale 1.3, continue/save safety
-5. Completed detail — endpoint card and metric hierarchy
-6. Route — real geometry, start/end/current marker semantics, LONG_GAP discontinuity
-7. Trends — X/Y references, speed/altitude truth, no interpolation
-8. Diagnostics — collapsed by default, `查看轨迹点` explicit
+5. Completed detail `概览` — endpoint card and metric hierarchy
+6. Route `轨迹` — real geometry, start/end/current marker semantics, LONG_GAP discontinuity, trusted trends
+7. Data `数据` — altitude/reliability evidence, collapsed diagnostics, `查看轨迹点` explicit
+8. Detail tabs — switching remains readable and stable on 320–360dp / fontScale 1.3
+9. Dark/Light — shared-theme contrast/readability where supported
 
 Do not close #145 from CI alone. Use the latest Debug APK from `main` for the final physical comparison against the approved v0.6 board.

--- a/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
+++ b/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
@@ -1,6 +1,6 @@
 # EV Charge Book Trip v0.6 Approved UI Baseline
 
-Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison.
+Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison and the completed-detail information-architecture correction.
 
 Owning issue: #145
 
@@ -190,6 +190,30 @@ Raw recent GPS points must not be expanded by default. Provide an explicit troub
 
 If altitude is unavailable or untrustworthy, omit the metric rather than showing a synthetic value.
 
+## Completed Trip detail information architecture — #178 / PR #179
+
+The approved board treats completed/selected Trip detail as separate reading surfaces rather than one long scroll. This presentation correction is now implemented in `main` by PR #179, merged as `88e1e2b` after Android CI run `33198331727` passed.
+
+Supported sections:
+
+- `概览` — completed Trip summary + one compact start/end endpoint card
+- `轨迹` — truthful route preview + trusted speed/altitude trends
+- `数据` — altitude summary + GPS reliability and raw-point progressive disclosure
+
+Rules:
+
+- detail opens on `概览`
+- switching sections is presentation-only and must not mutate Trip data
+- `概览` stays materially shorter than the old all-in-one scroll
+- `轨迹` owns route and trend evidence
+- `数据` owns reliability / diagnostic evidence
+- unavailable route or altitude uses a compact truthful empty state
+- no unsupported `充电`, `备注`, destination-planning or navigation tabs are added merely because an early mock contained them
+- no fake basemap is introduced
+- completed red-flag, active green `当前点`, LONG_GAP discontinuity and raw-point collapsed-by-default semantics remain unchanged
+
+Physical comparison against approved detail-board screens remains required before final UI acceptance.
+
 ## Completion flow — #173
 
 The final completion form is part of the Trip interaction language even though it is not one of the six browsing surfaces.
@@ -274,6 +298,7 @@ Physical-device corrections:
 - #171 / PR #172 — compact READY information group + active metric de-duplication
 - #173 / PR #174 — compact completion flow + removal of redundant intermediate confirmation
 - #175 / PR #176 — separate Trip home/history from READY preparation
+- #178 / PR #179 — split completed Trip detail into `概览` / `轨迹` / `数据` supported surfaces; Android CI Green
 
 #152 remains the future destination-selection capability and is not part of v0.6.
 
@@ -294,9 +319,11 @@ Final closure of #145 requires one physical-device pass across:
 2. READY preparation
 3. active cockpit
 4. completion form
-5. completed overview
-6. route
+5. completed overview / `概览`
+6. route / `轨迹`
 7. speed + altitude trends
-8. diagnostics disclosure
+8. diagnostics / `数据` disclosure
+9. detail-section switching and truthful unavailable states
+10. Dark / Light readability where the shared theme supports both
 
 Also verify 320–360dp width and fontScale 1.3 before declaring UI acceptance complete.


### PR DESCRIPTION
## Summary

Synchronize the Trip v0.6 authority documents after #178 / PR #179 closed the remaining completed-detail information-architecture gap.

### Updates
- record `概览` / `轨迹` / `数据` section ownership
- record PR #179 merge baseline `88e1e2b`
- record Android CI run `33198331727` Green
- keep unsupported `充电` / `备注` / destination / fake-map capabilities explicitly out of scope
- update final physical acceptance matrix for section switching, 320–360dp, fontScale 1.3 and Dark/Light readability

Docs only; no Android/runtime behavior changes.

Related: #145 #178 #6