### PR TITLE
docs: reconcile Trip authority with current main

### DIFF
--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -1,7 +1,8 @@
 # EV Charge Book Feature Matrix
 
-Version: v1.1.0
-更新时间: 2026-08-26
+Version: v1.2.0
+更新时间: 2026-08-29
+状态说明: `[x]` 仅表示对应代码/交付项已完成；真机功能、真机视觉和 Production Release 验收单独列出，不从代码状态推导。
 
 ## v0.1 - Local Charging Book
 
@@ -12,11 +13,10 @@ Version: v1.1.0
 ### Charging
 - [x] Add charging record
 - [x] Charging history
-- [x] Delete charging record
-- [ ] Edit charging record
-- [ ] Date/time selection
-- [ ] Charger type / remark
-- [ ] Delete confirmation / save feedback
+- [x] Edit charging record
+- [x] Date/time selection
+- [x] Charger type / remark
+- [x] Delete confirmation / save feedback
 
 ### Dashboard / Stats
 - [x] Monthly cost
@@ -26,80 +26,214 @@ Version: v1.1.0
 - [x] Total cost / energy
 
 ### Delivery
-- [ ] Android CI Green
-- [ ] Debug APK Artifact
-- [ ] First signed production APK
+- [x] Android CI baseline
+- [x] Debug APK Artifact
+- [x] First signed production APK
+- [x] v0.1 physical core CRUD acceptance
 
 ---
 
-## v0.2 - Vehicle & Trip Foundation
+## v0.2 - Vehicle, Location & Trip Foundation
 
 ### Multi Vehicle
-- [ ] Add multiple vehicles
-- [ ] Current/default vehicle switcher
-- [ ] Vehicle archive
-- [ ] Dashboard / Records / Stats scoped by vehicle
+- [x] Add multiple vehicles
+- [x] Current/default vehicle switcher
+- [x] Vehicle archive
+- [x] Dashboard / Records / Stats scoped by selected vehicle
+- [x] Trip bound to selected vehicle at start
 
 ### Vehicle Catalog
-- [ ] Local vehicle catalog seed
-- [ ] Brand / series / model-year / trim search
-- [ ] Catalog parameter confirmation/override
-- [ ] Custom vehicle fallback
+- [x] Bundled/offline catalog seed
+- [x] Brand / series / model-year / trim search baseline
+- [x] Catalog parameter confirmation/override
+- [x] Custom vehicle fallback
+- [x] managed/offline-first catalog refresh platform
+- [ ] broader auditable coverage / bulk data pipeline (#20)
 
-### Location / Map
-- [ ] Get current location
-- [ ] Charging record location capture
-- [ ] MapLibre map adapter
-- [ ] Route polyline display
+### Location
+- [x] Get current location
+- [x] Charging record location capture
+- [x] WGS84 raw coordinate persistence
+- [x] AddressResolver / Android Geocoder fallback
+- [x] Geocoder failure does not block coordinate facts
+- [ ] physical permission / Geocoder / restore acceptance (#14)
 
-### Trip Tracking
-- [ ] Manual start/stop trip
-- [ ] Location foreground service
-- [ ] Record lat/lng/altitude/speed/accuracy/time
-- [ ] Distance / duration / avg speed / max speed
-- [ ] Trip history and detail
-- [ ] Trip bound to vehicle
-
----
-
-## v0.3 - Analytics
-
-- [ ] Cost / energy trends
-- [ ] Fast/slow charge ratio
-- [ ] Monthly comparison
-- [ ] Cost per 100 km
-- [ ] Trip / charging relationship
-- [ ] Altitude / speed / efficiency analysis where data is reliable
-
----
-
-## v0.4 - Cloud & Catalog Sync
-
-- [ ] Account system
-- [ ] Charging / vehicle / trip sync
-- [ ] Backup
-- [ ] Vehicle catalog update service
+### Trip tracking core
+- [x] Manual start / completion
+- [x] `RECORDING / INTERRUPTED / COMPLETED`
+- [x] Location foreground service
+- [x] Record lat/lng/altitude/speed/bearing/accuracy/time
+- [x] Distance / elapsed / moving / stopped / average / max speed
+- [x] Trip history and detail
+- [x] Local Backup / Restore Trip coverage
+- [x] provider / permission / lifecycle diagnostics
+- [x] callback heartbeat separated from accepted-point heartbeat
+- [x] time-based callback liveness (`SAMPLE_DISTANCE_METERS = 0f`)
+- [x] app-level stationary heartbeat/write throttling
+- [x] LONG_GAP continuity semantics
+- [x] real route geometry preview without fake map
+- [x] trusted speed coloring and legend
+- [x] elevation start/end/min/max/gain/loss
+- [x] validity/review cleanup semantics
+- [ ] background-other-app / stationary physical reliability acceptance (#77)
 
 ---
 
-## v0.5 - Smart Input
+## v0.3 - Local Analytics & Data Reliability
 
-- [ ] OCR charging receipt/order
-- [ ] Smart field completion
-- [ ] Frequent station / tariff reuse
+- [x] Cost / energy trends
+- [x] Fast/slow charger mix
+- [x] Monthly comparison
+- [x] Cost per 100 km estimate
+- [x] charged kWh per 100 km estimate
+- [x] Trip / charging interval evidence
+- [x] common charging places
+- [x] CSV analysis export
+- [x] Local JSON Backup / Restore
+- [x] non-blocking anomaly warnings
+- [x] Trip validity-aware analytics
+- [x] Charge facts vs Trip SOC-derived energy estimate separation
 
 ---
 
-## v1.0 - AI Assistant
+## v0.4 - Local First Sync & Catalog
 
-- [ ] Charging advice
-- [ ] Usage and cost analysis
-- [ ] Driving efficiency suggestions
-- [ ] Explain anomalies from real user data
+### Sync foundation
+- [x] Vehicle stable `syncId`
+- [x] Vehicle `updatedAtEpochMillis`
+- [x] ChargingRecord stable `syncId`
+- [x] ChargingRecord tombstone
+- [x] Room migration / old-row identity generation
+- [x] Backup / Restore sync metadata
+- [ ] protocol/schema runtime implementation (#27)
+- [ ] push/pull cursor
+- [ ] idempotent upsert / tombstone propagation
+- [ ] smallest HTTPS + Spring Boot + PostgreSQL slice
+
+TripSession / TripPoint cloud sync is intentionally not part of the first cloud slice.
+
+### Catalog data pipeline
+- [x] managed catalog runtime/update platform
+- [x] Android offline-first refresh
+- [ ] source provenance
+- [ ] repeatable bulk import/validation
+- [ ] broader production coverage
+
+---
+
+## v0.5 / v0.6 - Local Experience & Trip UI Closeout
+
+### Global UI
+- [x] Dark First design system
+- [x] persisted Light mode
+- [x] Dashboard / Records / Stats / Trip / Vehicle core rebuild
+- [x] shared density / low-elevation surface language
+- [ ] final five-page physical visual pass (#70)
+- [ ] accessibility / large font / small screen / touch-target pass (#42 / #22)
+
+### Dashboard
+- [x] dynamic Vehicle Hero
+- [x] current VehicleState SOC / mileage
+- [x] information-dense latest completed Trip card
+- [ ] physical Hero/recent-Trip visual closeout (#94 / #95)
+
+### Records / Stats v0.6
+- [x] compact ledger summary + dense charging timeline
+- [x] compact analytics hierarchy + lightweight evidence bars
+- [ ] Dark/Light + 320-360dp + fontScale physical pass (#159 / #164 / #165)
+
+### Trip v0.6 UI
+- [x] Trip home/history separated from READY preparation
+- [x] dense truthful history rows
+- [x] READY vehicle/SOC/mileage/GPS preparation
+- [x] restrained slide-to-start
+- [x] active cockpit with trusted route/speed/altitude trends
+- [x] active primary metric de-duplication
+- [x] slide-to-end -> single compact completion form
+- [x] completed overview + compact endpoint card
+- [x] completed detail split into `概览` / `轨迹` / `数据`
+- [x] route start / completed end / active current-point semantics
+- [x] LONG_GAP remains disconnected
+- [x] sparse X/Y context on speed/altitude trends
+- [x] raw GPS diagnostics collapsed by default
+- [x] no fake destination / route planning / fake basemap introduced
+- [ ] full design-device matrix (#145 / #168)
+- [ ] completed detail tabs / narrow width / fontScale / Dark-Light pass (#178)
+
+### Trip -> VehicleState
+- [x] start SOC / mileage snapshot
+- [x] explicit end SOC
+- [x] optional validated end mileage
+- [x] SOC-derived energy estimate when trustworthy
+- [x] Trip completion updates VehicleState
+- [x] deletion rebuilds VehicleState
+- [ ] physical data-closure acceptance (#124)
+
+### Background / notification
+- [x] ongoing elapsed time + trusted distance
+- [x] active Trip deep link
+- [x] provider/permission interruption -> repair notification
+- [x] explicit user resume after repair
+- [x] Android 13+ non-blocking notification permission flow
+- [ ] physical lock-screen / repair round-trip (#26)
+
+---
+
+## Production Updater
+
+- [x] `latest.json` discovery
+- [x] DownloadManager
+- [x] SHA-256 verification
+- [x] unknown-source permission flow
+- [x] Android installer handoff
+- [x] root composition wiring
+- [x] Dashboard-style non-modal update UI
+- [ ] old-production -> new-production physical upgrade acceptance (#102)
+
+---
+
+## Future / Optional
+
+### Destination planning
+- [ ] optional destination selection / pre-trip endpoint planning (#152)
+
+Not part of Trip v0.6 and must not appear as placeholder UI before product capability exists.
+
+### Map renderer
+- [ ] MapProvider abstraction when needed
+- [ ] MapLibre real-map prototype when justified
+
+Current truthful WGS84 route preview is sufficient for Trip v0.6; map SDK is not a completion blocker.
+
+### OBD-II
+- [ ] optional Vehicle Speed PoC
+- [ ] evaluate supported telemetry only if product evidence justifies it
+
+---
+
+## Current physical acceptance bundle
+
+- [ ] #145 Trip v0.6 design-device matrix
+- [ ] #168 Trip device-fidelity corrections
+- [ ] #178 completed-detail tabs / responsive readability
+- [ ] #77 background callback / stationary hold
+- [ ] #124 Trip SOC -> VehicleState
+- [ ] #26 lock-screen / repair notifications
+- [ ] #14 Location / Geocoder
+- [ ] #70 / #94 / #95 / #42 / #22 UI closeout
+- [ ] #102 production updater
+
+---
 
 ## Change Log
 
+### v1.2.0
+- reconciled stale v0.1/v0.2 unchecked items with current `main`
+- recorded current Trip reliability, analytics and VehicleState code baselines
+- added Trip v0.6 home/READY/active/completion/detail information architecture
+- separated code completion from physical acceptance owners
+- clarified MapLibre/destination/OBD remain optional or future, not current Trip blockers
+
 ### v1.1.0
-- Reconciled actual v0.1 progress
-- Added v0.2 multi-vehicle / catalog / location / trip scope
-- Shifted analytics, cloud and smart input to later phases
+- reconciled early v0.1 progress
+- added initial v0.2 multi-vehicle / catalog / location / trip scope

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,7 +1,8 @@
 # EV Charge Book 前端设计
 
-版本: v1.4.0
-更新时间: 2026-08-26
+版本: v1.5.0
+更新时间: 2026-08-29
+状态: Authority Document
 
 ## 1. 技术方案
 
@@ -12,274 +13,293 @@ Android Native:
 - ViewModel + StateFlow
 - Room / SQLite
 - Coroutines
+- DataStore
+- Android LocationManager / foreground service
 - Repository Gradle Wrapper
-- DataStore（v0.2 selectedVehicleId）
-- Android Location API / foreground service（v0.2）
-- MapLibre Native adapter（v0.2 地图展示）
 
-当前包名 `com.evchargebook`。继续避免为早期功能引入不必要的 DI 或形式化 Clean Architecture 层级。
+当前包名 `com.evchargebook`。
+
+架构继续保持单体、简单可维护，不为当前规模引入 Hilt/Koin、多 module Clean Architecture、第二套 Trip tracking service 或 WorkManager tracking。
 
 ---
 
-## 2. v0.1 当前数据流
+## 2. 当前主数据流
 
 ```text
-Compose
+Compose UI
  -> MainViewModel
- -> ChargingRepository
+ -> ChargingRepository / domain rules
  -> Room DAO
- -> Flow
+ -> Flow / StateFlow
  -> UI
 ```
 
-Dashboard / Records / Stats 共享同一真实数据口径。
+当前车辆上下文通过统一状态/DataStore 管理；Dashboard / Records / Stats / Trip / Add Record 不各自维护一份 selected vehicle。
 
-v0.1 已完成：
-
-- 车辆读取 / 编辑 / 保存
-- 充电记录新增 / 编辑 / 删除
-- 日期 / 时间选择
-- charger type / remark
-- 删除确认
-- success / error Snackbar
-- empty state
-- Material 3 theme
-- edge-to-edge
-- ChargingRecordRules
-- ChargingStatistics
-- domain rules / statistics unit tests
-
-当前前端阶段不是继续扩功能，而是通过 CI / APK / 真机走查验证完整闭环。
+Trip tracking 的持续定位不放进 Composable/ViewModel 循环，而由 foreground service 负责。
 
 ---
 
-## 3. v0.1 页面状态
+## 3. 当前一级 UI
+
+```text
+Dashboard
+Records
+Stats
+Trip
+Vehicle
+```
+
+Dark First 为默认视觉语言，Light mode 可切换。核心 UI token 由 `EVDesignTokens` / MaterialTheme 统一提供。
+
+页面安全区由 root app/scaffold 统一拥有；嵌套 Trip Scaffold/TopAppBar 不重复申请系统顶部 inset。
+
+---
+
+## 4. Dashboard / Records / Stats
 
 ### Dashboard
 
-- 真实车辆信息
-- 本月费用 / 电量 / 次数 / 平均电价
-- Energy Hero 使用月充电量与车辆电池容量做等效展示
-- 最近充电记录
-- 无记录时 EmptyState
+- dynamic Vehicle Hero
+- current VehicleState SOC / mileage
+- latest valid completed Trip summary
+- recent charging evidence
+- generated Hero artwork slot
 
-Energy Hero 是展示型派生指标，不代表车辆实时 SOC、剩余电量或 SOH。
+Hero 不伪造实时 SOC / remaining range，不在 Compose 里重建复杂极光/倒影。
 
 ### Records
 
-- Room 实时记录列表
-- 新增入口
-- 点击进入编辑
-- 删除前确认
+- compact ledger summary
+- chronological charging timeline
+- row edit
+- explicit delete + confirmation
+- Add/Edit Charge 共用当前真实业务规则
 
-### Record Edit / Add
+### Stats
 
-字段：
+- current month summary
+- previous-month comparison
+- Trip SOC-derived energy estimate
+- monthly trends / mix / places
+- lifetime / interval evidence
 
-- charge time
-- start SOC
-- end SOC
-- energy kWh
-- final paid cost
-- charger type
-- location
-- remark
-
-保存前统一通过 ChargingRecordRules 校验。
-
-### Vehicle
-
-- 读取 Room Vehicle
-- 编辑品牌 / 车型 / 电池容量 / 标称续航
-- 不展示无法从当前数据源获得的实时 SOC / SOH / 实时续航
+UI 不自行重新计算已经由 domain/repository 拥有的业务统计。
 
 ---
 
-## 4. Domain Rules
+## 5. Trip 数据与服务边界
 
-v0.1 已将核心规则从 UI / Repository 内联判断中抽出。
+### 5.1 Room facts
 
-ChargingRecordRules 负责：
+Trip 持久化核心仍是:
 
-- startSoc 0..100
-- endSoc 0..100
-- endSoc >= startSoc
-- energyKwh > 0
-- cost >= 0
+- `TripSession`
+- `TripPoint`
+- diagnostic events / runtime evidence
 
-ChargingStatistics 负责基础聚合：
+原始 GPS facts 与派生统计分离；raw point 不因为派生统计过滤而被静默重写。
 
-- monthCost
-- monthEnergy
-- chargingCount
-- totalCost
-- totalEnergy
-- averagePrice
+### 5.2 `TripTrackingService`
 
-UI 不重复实现这些计算规则。
+当前 foreground service 负责:
 
----
+- start/resume active Trip tracking
+- LocationManager callback registration
+- provider / permission health checks
+- Location callback -> sampling/trust rules
+- TripPoint persistence
+- elapsed / distance / moving / stopped aggregates
+- ongoing notification
+- interrupted state / service diagnostic evidence
 
-## 5. v0.2 模块扩展
+当前 callback baseline:
 
-推荐新增:
+- request interval ~4s
+- `SAMPLE_DISTANCE_METERS = 0f`
+- callback liveness 保持 time-based
+- stationary Room write 仍由 `TripSamplingRules` 约 15s 节流
 
-```text
-com.evchargebook
-├── data
-│   ├── local
-│   │   ├── trip
-│   │   └── catalog
-│   └── repository
-│       ├── VehicleRepository
-│       └── TripRepository
-├── location
-│   ├── LocationProvider
-│   ├── AndroidLocationProvider
-│   └── TripTrackingService
-├── map
-│   ├── MapProvider
-│   └── MapLibreProvider
-└── ui
-    ├── trip
-    └── vehiclecatalog
-```
+不要重新在 LocationManager 层加 8m 之类的大位移门槛，否则会破坏 stationary heartbeat 与 callback health 诊断。
 
-接口以实际替换需求为目的，不创建多层空抽象。
+#77 仍只负责真实 Android/ROM 后台 callback 验收。
 
 ---
 
-## 6. 多车辆 App State
+## 6. Trip UI 组件边界
 
-v0.2 引入统一 `selectedVehicleId`。
+Trip 当前已经从早期单页结构拆分为稳定的 v0.6 状态/阅读面。
 
-```text
-DataStore selectedVehicleId
- -> VehicleRepository
- -> App/ViewModel State
- -> Dashboard / Records / Stats / Add Record / Trip
-```
+### `TripReadyScreen`
 
-页面不各自保存当前车辆。
+拥有 no-active Trip 的两阶段入口:
 
-任何新增充电/行程都必须显式绑定 vehicleId。
+1. Trip home/history
+2. READY preparation
 
----
+进入 Trip 默认显示 history；用户明确点击 `开始行程` 才进入 READY。
 
-## 7. Vehicle Catalog
+READY back 不创建空 Trip。
 
-车型目录与 UserVehicle 分离。
+### `TripScreen`
 
-v0.2 首先采用本地版本化 JSON/Room seed，实现离线搜索，不让 App 依赖在线免费 API 才能添加车辆。
+拥有 active/interrupted cockpit:
 
-流程:
+- distance + trusted latest speed 主指标
+- elapsed / moving average / max recorded speed / start SOC 辅助指标
+- active truthful route/trends
+- interrupted resume
+- slide-to-end
 
-```text
-Catalog Search
- -> Select model
- -> User confirms/overrides values
- -> Save UserVehicle snapshot
-```
+active Trip 始终绑定启动时的 `vehicleId`，之后切换 selected vehicle 不重绑当前 Trip。
 
-必须保留 Custom Vehicle fallback。
+### completion surface
 
----
+slide-to-end 进入唯一 Trip completion form:
 
-## 8. LocationProvider
+- GPS distance + start SOC/mileage evidence
+- end SOC required
+- end mileage optional / validated
+- SOC-derived energy estimate when trustworthy
+- `继续行驶`
+- `保存并结束`
 
-定位核心定义最小接口:
+不要重新加入通用 intermediate `AlertDialog` 作为第二次“是否结束”确认。
 
-- getCurrentLocation()
-- startUpdates(config)
-- stopUpdates()
+### `TripDetailScreenV06`
 
-核心业务使用统一 LocationSample，不让 ViewModel 直接依赖地图 SDK 的 location object。
+完成/选中 Trip detail 当前分为:
 
-建议 LocationSample 包含:
+- `概览`: summary + endpoint card
+- `轨迹`: route + speed/altitude trends
+- `数据`: altitude/reliability + raw-point disclosure
 
-- lat/lng
-- altitude?
-- speed?
-- bearing?
-- accuracy
-- timestamp
+默认 `概览`。section state 是 presentation state，不写回 Trip 数据。
 
-原始数据库坐标统一 WGS84。
+不增加当前产品不支持的 `充电`、`备注`、destination planning 或 fake map tab。
 
 ---
 
-## 9. TripTrackingService
+## 7. Trip route / trend rendering
 
-v0.2 使用用户主动启动的 location foreground service。
+当前 route renderer 直接消费真实 TripPoint 派生 geometry，不要求外部地图 SDK。
 
-职责:
+规则:
 
-- 启动/结束 TripSession
-- 订阅定位更新
-- 过滤明显无效点
-- 批量写入 TripPoint
-- 更新 ongoing notification
-- 处理进程/服务异常结束状态
+- WGS84 原始坐标为事实
+- LONG_GAP segment 断开
+- gap 两端不计可信连续距离
+- trusted speed 可用于 route color
+- untrusted/unknown speed 使用中性语义
+- completed endpoint 使用 red flag
+- active latest point 保持 green current point
+- trend >2min gaps 不插值
+- speed / altitude trend 提供稀疏 X/Y reference
 
-UI 不承担持续采样逻辑。
-
-Android 10+ 声明 `foregroundServiceType="location"`；持续记录过程中必须有通知。
-
-v0.2 不默认申请“永久后台自动位置追踪”来做自动开车识别。
-
----
-
-## 10. Map Adapter
-
-地图只消费已有轨迹数据:
-
-```text
-TripPoint Flow/List
- -> MapProvider
- -> Polyline / Start / End
-```
-
-MapLibre 作为首选开源实现；tile/style provider 单独配置。
-
-地图失败不影响 Trip 数据读取、统计和删除。
-
-高德等中国地图可作为后续 adapter，不能把其 SDK 类型渗透到 Room/Repository。
+MapLibre 仍是未来可选 renderer。当前代码不应假装 MapLibre 已是 Trip 主依赖，也不应为了地图外观提前加入道路吸附。
 
 ---
 
-## 11. Build Baseline
+## 8. Location / address frontend boundary
 
-当前已具备 Gradle Wrapper。CI / Release 使用 `./gradlew`，Android SDK 与 `compileSdk` 保持一致。
+`LocationProvider` 与 `AddressResolver` 分离。
 
-当前验收优先级：
+前端语义:
 
-1. CI Green
-2. Debug APK Artifact
-3. 真机安装和业务走查
-4. assembleRelease
-5. signed production publish
+- coordinates 先作为事实保存
+- reverse geocode 是 optional enhancement
+- Geocoder 失败仍允许保存/继续业务
+- 地址不可用时显示真实 fallback，不编造 place name
+
+Location permission/provider 丢失时 active Trip 进入 `INTERRUPTED`，修复后由用户显式 resume。
 
 ---
 
-## 12. 变更记录
+## 9. Notification / deep link
+
+Trip ongoing notification 当前承担状态可见性:
+
+- elapsed time
+- trusted persisted distance
+- active Trip deep link
+
+repair notification 用于 permission/provider interruption。
+
+notification permission 被拒绝不能成为 Trip tracking 的业务阻塞；notification 也不能绕过 completion form 直接结束 Trip。
+
+---
+
+## 10. Responsive / accessibility baseline
+
+当前 UI code 需要遵守:
+
+- >=48dp interaction target where applicable
+- icon-only action 提供 contentDescription/语义
+- 320-360dp 不崩溃、不裁切关键操作
+- fontScale 1.3 可用
+- 关键状态不能只靠颜色表达
+- Dark/Light 均需实际设备对比
+
+active cockpit 的 metric grid 会在窄屏/大字体下降低列数，而不是缩小字体逃避布局问题。
+
+---
+
+## 11. Build / acceptance baseline
+
+开发顺序:
+
+1. current-head Android test/build
+2. Android CI Green
+3. Debug APK
+4. owning Issue/PR 状态同步
+5. physical function/visual acceptance
+6. Production Release（需要下发 APK 时）
+
+CI Green 不等于 Trip 真机验收。
+
+当前 Trip UI code-side baseline 已完成；physical owners 主要是 #145 / #168 / #178 / #77 / #42 / #22。
+
+---
+
+## 12. Future map / sync boundary
+
+### Map
+
+可选未来方向:
+
+- `MapProvider`
+- MapLibre renderer
+- China map adapter
+
+只有当真实地图体验有明确价值时推进。地图 provider 类型不得渗透到 Room/Trip domain facts。
+
+### Sync
+
+第一批 cloud sync 仍只考虑 Vehicle + ChargingRecord。TripSession / TripPoint 不进入最小 v0.4 cloud slice。
+
+---
+
+## 13. 变更记录
+
+### v1.5.0
+
+- 对齐当前五一级页面与 Dark First v0.5/v0.6 UI
+- 记录真实 `TripTrackingService` time-based callback + app-level stationary throttle baseline
+- 对齐 `TripReadyScreen` / active `TripScreen` / completion / `TripDetailScreenV06` 职责
+- 记录 completed detail `概览 / 轨迹 / 数据` 三 section
+- 移除“MapLibre 已是当前 Trip 实现”的过时表述，恢复 optional renderer 边界
+- 明确 CI 与 physical Trip acceptance 的区别
 
 ### v1.4.0
 
-- 对齐 commit `7204c56` 的完整 Record CRUD 与 UI 重构
+- 对齐早期完整 Record CRUD 与 UI 重构
 - 记录 ChargingRecordRules / ChargingStatistics domain 抽取
 - 增加删除确认、Snackbar、EmptyState、日期时间和充电类型
 - 明确 Energy Hero 不是实时电池状态
-- 前端阶段切换为 CI / APK / 真机验收
 
 ### v1.3.0
 
 - 增加 DataStore 当前车辆上下文
 - 定义车型目录本地 seed 方案
 - 定义 LocationProvider / TripTrackingService
-- 定义 MapLibre 可替换 MapProvider
 - 明确 WGS84、foreground location 和统计口径
-- 更新构建基线为使用已提交 Gradle Wrapper
-
-### v1.2.0
-
-- 对齐 Room CRUD 和真实 Dashboard / Records / Stats

--- a/docs/PROJECT_MASTER.md
+++ b/docs/PROJECT_MASTER.md
@@ -1,14 +1,14 @@
 # EV Charge Book 项目总纲（PROJECT MASTER）
 
-版本: v2.3.0
-更新时间: 2026-08-28
+版本: v2.4.0
+更新时间: 2026-08-29
 状态: Authority Document / Single Source of Truth
 
 ## 1. 项目定位
 
 EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 
-演进顺序：
+演进顺序:
 
 1. 充电记账与成本
 2. 多车辆与车型目录
@@ -24,298 +24,345 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 
 ## 2. 权威文档
 
-- PRODUCT.md
-- FEATURE_MATRIX.md
-- UIUX.md
-- FRONTEND.md
-- BACKEND.md
-- DATABASE.md
-- CI_CD.md
-- APK_AUTO_UPDATE.md
-- ROADMAP.md
-- DEVELOPMENT.md
-- LOCATION_TRIP.md
-- TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
-- VEHICLE_CATALOG_MULTI_VEHICLE.md
-- DATA_QUALITY_BACKUP.md
-- SYNC_PROTOCOL.md
-- LOCAL_AGENT_HANDOFF.md
-- NEXT_PHASE_DESIGN.md
+- `PRODUCT.md`
+- `FEATURE_MATRIX.md`
+- `UIUX.md`
+- `FRONTEND.md`
+- `BACKEND.md`
+- `DATABASE.md`
+- `CI_CD.md`
+- `APK_AUTO_UPDATE.md`
+- `ROADMAP.md`
+- `DEVELOPMENT.md`
+- `LOCATION_TRIP.md`
+- `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
+- `TRIP_V0.6_APPROVED_UI_BASELINE.md`
+- `EVChargeBook_UI_Redesign_Task_Breakdown.md`
+- `VEHICLE_CATALOG_MULTI_VEHICLE.md`
+- `DATA_QUALITY_BACKUP.md`
+- `SYNC_PROTOCOL.md`
+- `LOCAL_AGENT_HANDOFF.md`
+- `NEXT_PHASE_DESIGN.md`
 
 实现与文档冲突时，先以当前代码、CI 与真机事实为准，再修正文档。
 
-阶段状态必须区分：代码已实现、CI Green、真机功能验收、真机视觉验收和 Production Release 验收。不得用其中一个替代另一个。
+阶段状态必须严格区分:
+
+- 代码已实现
+- Android CI Green
+- 真机功能验收
+- 真机视觉验收
+- Production Release 验收
+
+不得用其中一个替代另一个；Open Issue 也不代表代码一定未实现。
 
 ---
 
 ## 3. 产品原则
 
 - 简单可维护
-- Local First
+- Local First / Offline First
 - 真实数据来源
 - 用户录入成本低
 - 统计口径可解释
 - 原始事实 / 派生值 / 估算值明确区分
 - 不伪造实时 SOC / SOH / 续航
 - 定位记录与地图 SDK 解耦
-- 车型目录与用户车辆分离
-- 外部供应商可替换
-- 云同步不能成为唯一恢复路径
-- 无网络和云端故障不能阻塞本地记账 / Trip
-- GPS 缺失不得通过假路线或假距离静默补齐
-- 速度必须保留来源语义，不把 GNSS / 派生值 / future OBD 混成无来源真值
-- 地址是坐标的派生展示，不能反过来成为 Location 事实的前置条件
-- notification 是后台状态可见性，不得成为 Trip 是否能记录的业务前置条件
-- 正式 APK 版本只在真正执行 Production Release 时生成；普通业务提交不得为了代码变化而升级正式版本
+- GPS 缺失不通过假路线 / 假距离补齐
+- coordinates 是位置事实，address 是派生展示
+- 速度保留来源语义，不把 GNSS / derived / future OBD 混成无来源真值
+- notification 是后台状态可见性，不是 Trip 是否能记录的业务前置条件
+- 云同步不能成为 App 运行前提或唯一恢复路径
+- 正式 APK 版本只在真正执行 Production Release 时生成
 
 ---
 
-## 4. v0.1 状态: Released / Accepted
+## 4. v0.1 - Local Charging Book
 
-已完成充电记录 CRUD、车辆编辑、Dashboard / Records / Stats、核心规则测试、Android CI、真机 CRUD、signed production APK 与原子发布。
+状态: **Released / Accepted**
+
+已完成:
+
+- Vehicle CRUD
+- ChargingRecord add/edit/delete
+- Dashboard / Records / Stats
+- ChargingRecordRules / ChargingStatistics
+- Android CI / Debug APK
+- 真机核心 CRUD
+- signed production APK / atomic release
 
 ---
 
-## 5. v0.2 状态: Core Implemented / Physical Reliability Revalidation
+## 5. v0.2 - Vehicle, Location & Trip Foundation
 
-基础能力已经实现：
+状态: **Core Implemented / Physical Reliability Revalidation**
 
-- odometer + migration
-- Local Backup / Restore
-- Multi Vehicle / Vehicle Catalog
-- Bluetooth 指定设备连接 / 已连接状态 -> Trip 用户确认
-- Android LocationManager + WGS84 + accuracy
+### 5.1 已实现基础
+
+- Multi Vehicle / selected vehicle context
+- managed/offline-first Vehicle Catalog baseline
+- Bluetooth selected-device -> Trip confirmation
+- Android LocationManager + WGS84
 - AddressResolver + Android Geocoder
 - TripSession / TripPoint
-- foreground tracking / notification
-- Trip start / completion / interrupted resume / detail
-- distance / elapsed / moving / stopped
-- speed / bearing / GPS altitude / accuracy
-- GPS bad-point / jump filtering
-- app-level stationary write throttling
-- TripRouteGeometry + 无底图真实轨迹预览
+- foreground tracking + ongoing notification
+- Trip start / completion / interrupted resume
+- distance / elapsed / moving / stopped / average / max speed
+- speed / bearing / altitude / accuracy
+- bad-point / jump filtering
+- route geometry / no-basemap truthful preview
+- Local Backup / Restore Trip coverage
 
-### 5.1 post-RC Trip reliability 当前事实
+### 5.2 post-RC Trip reliability
 
-真实 Trip #7 和后续 2026-08-27 设备数据证明：`COMPLETED` 只表示业务收口，不代表 GPS 全程连续；foreground service 存在也不等于 Location callback 必然持续。
-
-当前代码已经继续补齐：
+当前代码已经实现:
 
 - runtime `TripGpsHealth`
-- callback heartbeat 与 accepted-point heartbeat 分离
 - WAITING / GOOD / DEGRADED / LOST / LONG_GAP
-- long-gap route segmentation，不画假实线
-- long-gap 两端不计可信连续距离
-- foreground Location callback 使用 time-based liveness，不再依赖 8m displacement gate
-- stationary write throttling 继续留在 `TripSamplingRules`
-- provider / permission / service lifecycle / re-delivery diagnostics
+- callback heartbeat 与 accepted-point heartbeat 分离
+- `lastLocationCallbackAt` 与 accepted-point evidence 分离诊断
+- provider / permission / service lifecycle / re-delivery evidence
+- LONG_GAP route segmentation
+- LONG_GAP 两端不计可信连续距离
+- foreground Location callback 使用 time-based liveness
+- `SAMPLE_DISTANCE_METERS = 0f`，不再依赖旧 8m displacement gate
+- stationary write throttling 保留在 `TripSamplingRules`（约 15s heartbeat）
 - coarse/network max-speed peak rejection
-- extreme GPS speed 缺失 speedAccuracy 时降低信任
-- trusted speed-colored route presentation
-- 起点/终点形状 + 文本语义
+- trusted speed-colored route
+- start/end 非纯颜色语义
 
-Issue #77 保留为 post-RC 真机可靠性验收：另一 App 前台、2–3 分钟 stationary hold、真实 callback/provider loss 和 stationary write volume 必须通过真实设备验证。不得因为当前 CI Green 就关闭。
+PR #80 已完成 8m callback gate 的代码修复并通过 Android CI；Issue #77 现在只负责真实设备上的“另一 App 前台 / 2-3 分钟 stationary hold / genuine callback-provider loss / stationary write volume”验收。
 
-### 5.2 海拔与 Trip validity
+### 5.3 Trip altitude / validity
 
-当前 `main` 已实现：
+已实现:
 
-- Trip start/end/min/max altitude
-- trusted cumulative elevation gain / loss
+- start/end/min/max altitude
+- trusted elevation gain/loss
 - vertical accuracy filtering + jitter deadband
-- cumulative elevation 不跨 LONG_GAP
+- elevation 不跨 LONG_GAP 拼接
 - conservative Trip validity classification
-- 明确空/异常完成 Trip 从 Dashboard 与汇总 analytics 排除
-- 极短真实 Trip 只进入 REVIEW，不自动删除、不自动排除
-- 删除始终由用户显式确认
-
-对应代码工作 #69/#68 已完成关闭。
-
-MapLibre 继续作为可选展示层，不是当前业务阶段门槛。
+- invalid/empty completed Trip 不进入 Dashboard/aggregate
+- short real Trip 使用 REVIEW，不自动删除
+- 删除由用户明确确认
 
 ---
 
-## 6. 速度与距离事实模型
+## 6. Trip 距离与速度事实模型
 
 ### 6.1 距离
 
-Trip distance 来自连续可信 accepted location point 的地理距离累计。
+Trip distance 是连续可信 accepted location point 的地理距离累计，不是道路里程或车辆轮速里程。
 
-它不是道路里程，也不是车辆轮速里程，因此弯路、采样稀疏、provider switch、GPS gap 都可能影响结果。
+LONG_GAP 两端不进入可信连续距离。原始 TripPoint 保留，派生统计只决定哪些证据可进入汇总。
 
-当前规则：LONG_GAP 两端不能继续作为可信连续距离；原始 TripPoint 证据保留，派生统计只决定“什么可以进入汇总”。
+### 6.2 速度
 
-### 6.2 瞬时 / 最高速度
+区分:
 
-TripPoint `speedMps` 主要来自 Android `Location.speed`，不是简单的两点直线距离 / 时间。
+- `Location.speed`: Android/GNSS 报告速度
+- derived segment evidence: 连续点距离/时间校验证据
+- whole-trip / moving average: 基于可信累计距离的派生统计
+- future OBD: 可选独立来源
 
-产品继续区分：
+最高速度只允许可信 GPS evidence 更新。UI 应理解为“最高已记录可信速度”，不得宣称车辆真实绝对峰值。
 
-- `Location.speed`：定位系统报告的时刻速度
-- derived segment evidence：连续可信点的距离 / 时间及窗口证据
-- whole-trip / moving average：依赖累计 trusted distance 的派生统计
+### 6.3 route speed visualization
 
-最高速度只允许可信 GPS evidence 更新；coarse/network provider 和缺失关键 accuracy evidence 的 extreme peak 不应成为 max-speed 真值。
+当前 route 支持可信 GPS speed 颜色表达，同时保留:
 
-UI 应称“最高已记录速度”，不得宣称未采样到的真实车辆峰值。
-
-### 6.3 速度轨迹
-
-当前 route 已能按可信 GPS speed 进行颜色表达，同时保留：
-
-- unknown speed 灰色语义
+- unknown/untrusted speed 中性语义
 - LONG_GAP 断开
 - legend / 区间说明
-- “颜色表示本车速度，不代表真实道路交通状态”说明
+- “本车速度，不代表道路拥堵”说明
 
-不为了速度轨迹提前引入 MapLibre 或道路限速/拥堵语义。
+不为了 route 外观提前引入道路吸附、限速/拥堵语义或 MapLibre 依赖。
 
 ---
 
-## 7. v0.3 状态: Feature Complete / Incremental Follow-up Only
+## 7. v0.3 - Local Analytics & Data Reliability
 
-已实现：
+状态: **Feature Complete / Incremental Follow-up Only**
+
+已实现:
 
 - charging interval odometer distance
 - cost / 100km estimate
 - charged kWh / 100km estimate
 - Trip + odometer coverage evidence
 - SOC confidence hints
-- month trend / month-over-month
+- monthly trends / month-over-month
 - charger type mix
 - ChargingPlace aggregation / common-place reuse
 - charging CSV analysis export
 - non-blocking anomaly hints
 - Local JSON Backup / Restore
 - Trip validity-aware analytics
-- Charge 桩端事实与 Trip SOC energy estimate 分层展示
+- Charge facts 与 Trip SOC-derived energy estimate 分层展示
 
 Issue #19 已完成关闭。
 
-不为了“数据治理框架完整”新增独立 ChargingPlace Room 表、统一 confidence 分数或不必要的 source metadata。Privacy Zone 等能力在真实 route export/share 出现前再推进。
-
 ---
 
-## 8. v0.4 Local First Sync Foundation
+## 8. v0.4 - Local First Sync & Catalog
 
-Phase A 已完成：
+### 8.1 Sync Phase A
+
+已完成:
 
 - Vehicle `syncId` + `updatedAtEpochMillis`
 - ChargingRecord `syncId` + `updatedAtEpochMillis`
 - ChargingRecord tombstone
 - explicit Room migration / old identity generation
-- Backup / Restore 保留 sync metadata
-- active UI / analytics 排除 tombstone
+- Backup / Restore sync metadata
+- active UI/analytics 排除 tombstone
 - pure JVM identity tests
 
-Issue #28 已完成关闭；父 Issue #27 继续承担 Phase B / Phase C。
+后续由 #27 继续:
 
-`SYNC_PROTOCOL.md` 保留第一版 payload / idempotency / tombstone / conflict / cursor 边界。
+- protocol/schema runtime
+- Vehicle / ChargingRecord envelope
+- push/pull cursor
+- idempotent upsert
+- tombstone propagation
+- simple conflict rule
+- smallest HTTPS + Spring Boot monolith + PostgreSQL slice
 
-下一步仍坚持最小方案：Vehicle + ChargingRecord 的 envelope、push/pull cursor、幂等 upsert、tombstone propagation、简单 conflict policy，然后才是 HTTPS + Spring Boot monolith + PostgreSQL。
+第一批不做 TripSession / TripPoint cloud sync、CRDT、微服务、MQ。
 
-当前不做：TripSession / TripPoint cloud sync、CRDT、微服务、Kafka/MQ、云端成为唯一备份。
+### 8.2 Catalog
 
----
-
-## 9. v0.5 Local Experience / VehicleState 状态: Code Baseline Implemented / Physical Closeout
-
-### 9.1 UI
-
-已合并 Dark First 基线与核心页面重构（#71），并继续补齐：
-
-- Dashboard dynamic Vehicle Hero（#96）
-- Dashboard recent Trip card（#100）
-- current SOC / current mileage VehicleState presentation
-- release updater Dashboard dark/green visual alignment（#126）
-
-#70/#94/#95/#42/#22 仍保留真机视觉 / accessibility / large-font / small-screen closeout，不从 CI 推导视觉验收。
-
-### 9.2 Trip SOC / mileage / energy -> VehicleState
-
-PR #87 等当前基线已经实现：
-
-- Trip start snapshot 当前 VehicleState SOC / mileage
-- completion 要求 explicit end SOC
-- end mileage 默认按 start mileage + GPS distance 预填并允许修正
-- TripSession 保存 start/end SOC + mileage
-- 只有正向可信 SOC drop 才估算 consumed energy
-- required inputs 足够时才估算 kWh / 100km
-- Trip completion 后 end SOC / mileage 回写 VehicleState
-- 删除完成 Trip 后重新构建 VehicleState
-- 后发生的 Charge / manual VehicleState 保持 authority，不被更老 Trip 回滚
-
-Issue #124 专门负责真机数据闭环验收，不再创建重复实现 PR。
-
-### 9.3 Location / address optionality
-
-当前原则已经落地：coordinates 是事实，address 是派生展示。
-
-- Add Charge 有权限时自动请求当前位置
-- Geocoder failure 不阻塞坐标事实
-- 可继续手填地点
-- `LocationProvider` / `AddressResolver` 分离
-- successful geocode 使用 bounded process-local cache
-- failed / blank result 不缓存，下次用户 retry 会重新调用 Geocoder
-
-Issue #66 已完成；真实权限 / Geocoder / backup-restore 继续由 #14 真机验收。
-
-### 9.4 Lock-screen / background Trip UX
-
-PR #130/#131/#132 已形成当前必要代码基线：
-
-- ongoing notification 显示 Trip elapsed time + trusted persisted distance
-- notification tap / `打开行程` 直接进入 active Trip
-- 锁屏文本不泄露精确坐标 / 地址
-- runtime Location permission loss -> `INTERRUPTED` + one-shot repair notification
-- no usable location provider -> `INTERRUPTED` + system Location repair action
-- repair 后不会自动恢复 tracking；用户回 Trip 明确 resume
-- stale repair warning 在 resume/start 后清除
-- Android 13+ Trip notification permission 在 tracking 已开始/恢复后请求
-- notification denial 不阻塞、不回滚 Trip
-- Trip 场景只做一次 notification permission prompt，避免重复打扰
-- 通知不能直接 complete Trip，结束仍进入 App 输入 end SOC
-
-Issue #26 现在只保留真机 acceptance，以及 trusted current speed / battery optimization guidance 两项 evidence-driven optional。
-
-### 9.5 Production APK updater
-
-当前已实现：
-
-- release manifest `latest.json`
-- higher version discovery
-- DownloadManager
-- SHA-256 verification
-- unknown-source permission flow
-- Android system installer handoff
-- root app composition wiring（#103）
-- Dashboard-style non-modal updater UI（#126）
-
-Issue #102 保留 old-production APK -> newer-production APK 的真实覆盖升级验收。不能只凭 Debug CI 关闭。
+managed catalog runtime + Android offline-first refresh 已实现。#20 剩余是 source provenance、bulk import/validation、normalization、coverage quality。
 
 ---
 
-## 10. P3 Optional Vehicle Data / OBD-II
+## 9. v0.5 / v0.6 - Local Experience & Trip UI
 
-OBD-II 是未来可选数据源，不是当前产品依赖。
+状态: **Code Baseline Implemented / Physical Closeout**
 
-```text
-VehicleSpeedSource
-├── GnssSpeedSource      当前默认
-├── DerivedSpeedSource   分段派生/校验
-└── ObdSpeedSource       P3 optional
-```
+### 9.1 Global UI
 
-第一个 PoC 只验证：
+已实现:
 
-- 外接 Bluetooth / BLE / Wi-Fi OBD-II adapter
-- 查询标准 Vehicle Speed 支持
-- 读取标准 OBD Vehicle Speed
-- 与 GNSS speed 对照
+- Dark First + persisted Light mode
+- Dashboard / Records / Stats / Trip / Vehicle 五一级页面
+- low-elevation / restrained-outline surface language
+- responsive metric grids
+- Dashboard dynamic Vehicle Hero
+- Dashboard recent Trip card
+- Records v0.6 dense ledger
+- Stats v0.6 compact analytics hierarchy
 
-当前明确不做：厂商私有 CAN ID 逆向、私有 BMS PID 逆向、单车型复杂协议维护、让 OBD 成为 Trip 必需依赖。
+#70/#94/#95/#159/#164/#165/#42/#22 保留真实设备视觉/可访问性 closeout。
 
-只有 Vehicle Speed PoC 稳定且有产品价值后，才评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
+### 9.2 Trip v0.6 information architecture
+
+Trip v0.6 代码侧已完成，不再需要 broad redesign。
+
+当前页面/状态:
+
+1. Trip home/history
+2. READY preparation
+3. active/interrupted cockpit
+4. completion form
+5. completed detail `概览`
+6. completed detail `轨迹`
+7. completed detail `数据`
+
+已落地:
+
+- Trip home/history 与 READY 分离（PR #176）
+- dense truthful history rows
+- READY vehicle/SOC/mileage/GPS truth
+- restrained slide-to-start
+- active distance + trusted current speed hierarchy
+- active real route + speed/altitude trends
+- active primary metrics 去除重复 diagnostic facts
+- slide-to-end 直接进入唯一 compact completion form（PR #174）
+- completed overview + one endpoint card
+- completed detail `概览 / 轨迹 / 数据` split（#178 / PR #179）
+- completed start = green start/play
+- completed end = small red flag
+- active latest point = green current point
+- LONG_GAP route/trends 不插值
+- raw GPS diagnostics collapsed by default
+- unavailable route/altitude 使用 truthful empty state
+- 不加入 unsupported `充电` / `备注` / destination / fake basemap tabs
+
+Trip UI implementation authority:
+
+- `TRIP_V0.6_APPROVED_UI_BASELINE.md`
+- #145 parent
+- #168 device-fidelity corrections
+- #178 detail-section split
+
+当前 main 的 Trip UI behavior baseline 包含 PR #179；Android CI run `33198331727` Green。代码完成不能替代 #145/#168/#178 的真机 design-device comparison。
+
+### 9.3 Trip SOC / mileage / energy -> VehicleState
+
+当前代码已经实现:
+
+- start snapshot current SOC / mileage
+- explicit end SOC
+- optional validated end mileage
+- TripSession start/end SOC + mileage
+- positive trustworthy SOC drop 才估算 consumed energy
+- required inputs 足够才估算 kWh/100km
+- completion 更新 VehicleState
+- 删除 completed Trip 后 rebuild VehicleState
+- 后发生 Charge/manual VehicleState 继续保持 authority
+
+#124 负责真机数据闭环。
+
+### 9.4 Location / address
+
+已实现:
+
+- coordinates-first
+- Geocoder optional
+- AddressResolver 分离
+- successful geocode bounded cache
+- failed/blank geocode 不缓存
+
+#14 保留真机 permission / Geocoder / restore acceptance。
+
+### 9.5 Lock-screen / background Trip UX
+
+当前代码:
+
+- ongoing notification = elapsed + trusted persisted distance
+- notification tap / action -> active Trip
+- permission/provider loss -> `INTERRUPTED`
+- one-shot repair notification
+- repair 后用户显式 resume
+- Android 13+ notification permission 在 tracking 已开始后请求
+- notification denial 不回滚 Trip
+- lock screen 不显示精确坐标 / HOME / WORK
+- notification 不直接 complete Trip
+
+#26 保留真机 round-trip；#77 独立负责 callback/stationary reliability。
+
+### 9.6 Production updater
+
+已实现 discovery / DownloadManager / SHA-256 / unknown-source permission / Android installer / root wiring / Dashboard-style non-modal UI。
+
+#102 保留 old-production -> newer-production 真实覆盖升级验收。
+
+---
+
+## 10. Map / destination / OBD 边界
+
+### Map
+
+当前真实 WGS84 route preview 已满足 Trip v0.6 数据可信展示。MapLibre 是 future optional renderer，不是当前完成门槛。
+
+### Destination
+
+#152 是 future capability。当前 Trip v0.6 不显示 destination selector / ETA / navigation preview / fake endpoint。
+
+### OBD-II
+
+OBD 仅作为 future optional adapter。首个 PoC 只验证标准 Vehicle Speed；不进入私有 CAN/BMS 逆向，不成为 Trip 必需依赖。
 
 ---
 
@@ -324,53 +371,50 @@ VehicleSpeedSource
 - Local JSON Backup 长期保留
 - Cloud Sync 不是唯一恢复路径
 - restore 失败不得破坏当前数据
-- 持续定位必须可见；通知权限被拒绝也不得阻止 Trip 本身记录
-- ongoing notification 不显示精确经纬度 / HOME / WORK 地址
-- 路线公开分享 / 导出之前实现 Privacy Zone
-- 云同步轨迹需要明确产品同意与隐私说明
+- 持续定位必须可见
+- notification permission denial 不阻止 Trip tracking
+- ongoing notification 不显示精确坐标 / HOME / WORK
+- route share/export 前需要 Privacy Zone
+- future cloud Trip sync 需要明确产品与隐私设计
 
 ---
 
-## 12. 发布 / CI / APK 自动升级基线
+## 12. CI / Release
+
+基线:
 
 - JDK 17
 - Android SDK 36
 - Build Tools 36.0.0
 - repository Gradle Wrapper
 - Android CI 与 Production Release 分离
-- signed APK
-- Actions Artifact
-- 普通 Android Build 使用 dev 版本，不生成正式版本号
-- 只有手动 Production Release 才生成正式 `versionCode/versionName`
-- Production Release 最后原子发布 `release-meta/latest.json`
-- release App 自动检查更高 `versionCode`
-- DownloadManager 下载 immutable APK
-- 下载后 SHA-256 校验
-- 最终由 Android 系统安装器完成覆盖安装
+- 普通业务提交不生成新的正式版本号
+- Production Release 才生成正式 `versionCode/versionName`
+- release 最后原子发布 `release-meta/latest.json`
 
-近期 current-head evidence：
+近期关键 Trip/UI evidence:
 
-- #123 Android Build #408 Green：extreme Trip max-speed trust
-- #127 Android Build #414 Green：Trip elevation analytics
-- #128 Android Build #417 Green：Trip validity / cleanup
-- #129 Android Build #419 Green：geocode cache / retry
-- #130 Android Build #422 Green：lock-screen Trip progress / active-Trip deep link
-- #131 Android Build #424 Green：provider / permission repair notifications
-- #132 Android Build #426 Green：Android 13+ non-blocking Trip notification permission
+- PR #80 Android CI run `33083631555` Green: stationary callback implementation slice
+- PR #170 Build #482 Green: slider/trends/history/insets/endpoint corrections
+- PR #172 Build #485 Green: READY/active density
+- PR #174 Build #489 Green: compact completion flow
+- PR #176 Build #490 Green: home vs READY split
+- PR #179 Android CI run `33198331727` Green: completed detail sections
 
-这些 CI 只证明自动化 build/test；#77/#124/#26/#14/#70/#94/#95/#42/#22/#102 的真机 acceptance 仍独立存在。
+这些证据只证明 automated build/test；physical acceptance 独立存在。
 
 ---
 
 ## 13. 架构约束
 
-Android 保持：
+Android 保持简单单体:
 
 ```text
-Compose -> MainViewModel -> ChargingRepository -> Room DAO -> Room
+Compose -> MainViewModel -> Repository/domain -> Room DAO -> Room
+TripTrackingService -> LocationManager -> sampling/trust -> Room
 ```
 
-未来 v0.4 云端第一版保持：
+future sync 第一版:
 
 ```text
 Android Room
@@ -379,9 +423,7 @@ Spring Boot Monolith
    -> PostgreSQL
 ```
 
-不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ、第二套 Trip tracking service、为了通知增加 WorkManager 或其他当前没有收益的基础设施。
-
-OBD 未来也必须是 optional adapter，不允许反向污染核心 Trip 架构。
+不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ、第二套 Trip service 或为了 notification 增加 WorkManager。
 
 ---
 
@@ -389,43 +431,40 @@ OBD 未来也必须是 optional adapter，不允许反向污染核心 Trip 架�
 
 ```text
 v0.5 physical acceptance bundle
+  -> #145 / #168 / #178 Trip v0.6 design-device comparison
   -> #77 background / stationary Trip reliability
-  -> #124 Trip SOC -> VehicleState data closure
-  -> #26 lock-screen / repair notification round-trip
-  -> #14 Location / Geocoder device behavior
-  -> #70 / #94 / #95 / #42 / #22 UI-device checks
-  -> #102 old-production -> new-production updater flow
+  -> #124 Trip SOC -> VehicleState
+  -> #26 lock-screen + repair notification
+  -> #14 Location / Geocoder
+  -> #70 / #94 / #95 / #159 / #164 / #165 / #42 / #22 UI-device checks
+  -> #102 old-production -> new-production updater
   -> only fix concrete device regressions
-  -> resume #27 minimal sync protocol/runtime
-  -> advance #20 catalog pipeline when data-source/coverage work is justified
-  -> P3 OBD-II Vehicle Speed PoC only when justified
+  -> resume #27 minimal Local First sync
+  -> advance #20 catalog pipeline when justified
+  -> optional MapLibre / destination / OBD only when product evidence exists
 ```
-
-APK 自动升级属于发布基础设施；它随 Production Release 验收独立推进。
-
-MapLibre 继续保持低优先级；已有真实 WGS84 route preview，不为了路线“看起来完整”提前引入地图 SDK。
 
 ---
 
 ## 15. 开发验收规则
 
-每轮业务代码必须：
+每轮业务代码必须:
 
 - Android Gradle test/build
-- GitHub CI Green
-- 更新 owning Issue / PR
-- 阶段变化同步 ROADMAP / PROJECT_MASTER
-- schema 改动必须显式 Migration
+- current-head GitHub CI Green
+- owning Issue / PR 同步
+- execution-stage 变化同步 ROADMAP / PROJECT_MASTER
+- schema change 必须 explicit Migration
 - 不把“代码已写”标成“CI Accepted”
-- 不把 CI 通过标成“真机已验收”
-- GPS `COMPLETED` 不等同于 continuity accepted
-- notification available 不等同于 tracking data accepted
-- Open Issue 不等同于“代码还没写”；先检查 owning PR / current `main`
+- 不把 CI Green 标成“真机已验收”
+- GPS `COMPLETED` 不等于 continuity accepted
+- notification available 不等于 tracking data accepted
+- Open Issue 不等于“代码还没写”
 
-正式 APK 版本规则：
+正式 APK:
 
-- 不发布 APK -> 不触发 Android Release -> 不升级正式版本
-- 需要下发 APK -> current-head Android CI Green -> 手动 Android Release -> 自动生成正式版本
+- 不发布 -> 不升级正式版本
+- 需要下发 -> current-head CI Green -> manual Production Release
 
 ---
 
@@ -438,59 +477,71 @@ MapLibre 继续保持低优先级；已有真实 WGS84 route preview，不为了
 - #26 background / lock-screen / repair notification
 - #42 accessibility / large font / small screen / state safety
 - #67 trajectory presentation device check
-- #70 v0.5 core UI physical closeout
+- #70 core UI physical closeout
 - #77 background callback / stationary hold
 - #94 Dashboard dynamic Hero
 - #95 recent Trip card
 - #102 Production APK auto-update
 - #124 Trip SOC -> VehicleState
+- #145 Trip v0.6 parent design-device matrix
+- #146 Trip history density
+- #147 READY slide interaction
+- #148 active Trip cockpit live update
+- #149 completed overview
+- #150 route surface
+- #151 diagnostics/trends
+- #168 Trip device-fidelity corrections
+- #171 READY/active density
+- #173 completion form
+- #175 home vs READY
+- #178 completed detail tabs
+- #159/#164/#165 Records/Stats v0.6 physical closeout
 
-### 后续真正业务扩展
+### Future / expansion
 
 - #27 Local First Sync Phase B / smallest cloud slice
 - #20 scalable Vehicle Catalog pipeline
+- #152 destination selection / pre-trip planning
 
 ### Repository / maintenance
 
 - #6 authoritative docs ongoing maintenance
-- #75 main branch protection / required CI，需要 repository administration 权限；不通过代码 PR 伪实现
+- #75 main branch protection / required CI; requires repository administration, not a code PR
 
 ---
 
 ## 17. 决策记录
 
+### v2.4.0
+
+- added Trip v0.6 approved UI baseline and implementation breakdown to authority set
+- reconciled master with current Trip home/READY/active/completion/detail architecture
+- recorded #178 / PR #179 `概览 / 轨迹 / 数据` detail split
+- recorded PR #80 stationary callback implementation as code-complete with #77 physical-only acceptance
+- aligned execution order with ROADMAP v2.8.0: Trip design-device closeout before feature expansion
+- clarified MapLibre / destination / OBD remain optional/future and are not Trip v0.6 blockers
+
 ### v2.3.0
 
-- reconciled PROJECT_MASTER with current `main` after reliability/data-quality work through #123/#127/#128/#129
-- recorded Trip SOC/mileage/energy -> VehicleState authority and #124 physical acceptance boundary
-- recorded dynamic Dashboard Hero / recent Trip baseline (#96/#100)
-- recorded updater wiring/UI baseline (#103/#126) while retaining #102 Production APK acceptance
-- recorded lock-screen Trip progress and direct active-Trip navigation (#130)
-- recorded explicit provider/permission interruption repair flow (#131)
-- recorded Android 13+ non-blocking Trip notification permission semantics (#132)
-- changed current execution from “implement Trip P0 slices” to “physical acceptance bundle, then resume minimal Local First sync”
-- retained simple architecture boundaries; no WorkManager/second tracking service/MapLibre requirement introduced
+- reconciled reliability/data-quality work through #123/#127/#128/#129
+- recorded Trip SOC/mileage/energy -> VehicleState authority and #124
+- recorded Dashboard Hero / recent Trip (#96/#100)
+- recorded updater wiring/UI (#103/#126)
+- recorded lock-screen Trip progress, repair flow and notification permission semantics (#130/#131/#132)
+- moved execution to physical acceptance bundle before sync expansion
 
 ### v2.2.0
 
-- `APK_AUTO_UPDATE.md` 纳入权威文档体系
-- 正式 APK 版本改为 Production Release-only generation
-- Android Release 增加 `release_series`
-- release server 新增 per-version JSON + `latest.json`
-- `latest.json` 成为 App 更新发现的最后原子指针
-- release App 增加自动检查、一键下载、SHA-256 校验和系统安装器流程
-- APK 更新基础设施不改变 Trip reliability 当前 P0
+- added `APK_AUTO_UPDATE.md` to authority
+- formalized Production Release-only version generation and atomic `latest.json`
 
 ### v2.1.0
 
-- 基于真实 Trip #7 将 GPS continuity 提升为当前 P0
-- PR #36 第一阶段通过 Build Run #184
-- 明确 Location.speed / derived speed / average speed 的不同来源与可信度
-- 明确 long gap distance correction 与 GPS/Network dedupe 先于彩色轨迹
-- OBD-II 作为 P3 optional VehicleSpeedSource，仅从标准 Vehicle Speed PoC 开始
-- v0.4 sync foundation 保留，但 feature expansion 暂缓到 Trip reliability 真机复验之后
+- promoted GPS continuity to P0 based on real Trip evidence
+- separated Location.speed / derived speed / average speed semantics
+- established OBD-II as optional future source
 
 ### v2.0.1
 
-- `SYNC_PROTOCOL.md` 纳入权威文档体系
-- 固定第一版 payload / idempotency / tombstone / conflict / cursor 边界
+- added `SYNC_PROTOCOL.md` to authority
+- fixed first sync payload / idempotency / tombstone / conflict / cursor boundaries

--- a/docs/UIUX.md
+++ b/docs/UIUX.md
@@ -1,221 +1,287 @@
 # EV Charge Book UI/UX 设计
 
-版本: v1.2.0
-更新时间: 2026-08-26
+版本: v1.3.0
+更新时间: 2026-08-29
+状态: Authority Document
 
 ## 1. 设计目标
 
 关键词: 简洁、清晰、低录入成本、数据可信、长期可用。
 
-v0.1 目标仍是 10-20 秒完成一次充电记录；v0.2 在不破坏这个体验的前提下增加多车辆、定位和行程记录。
+当前 UI 已从早期 v0.1/v0.2 原型推进到 Dark First 的 v0.5/v0.6 产品形态。页面密度通过层级和间距提升，不通过缩小字体或堆叠装饰卡片实现。
+
+全局规则:
+
+- Dark First，Light mode 可切换并持久化
+- 主强调色使用 `EVDesignTokens.Energy.green` (`#32F080`)
+- 不使用蓝色作为主要动作色，不做霓虹 bloom / 大 halo / 广告式发光
+- 原始事实、派生值、估算值必须明确区分
+- 无数据时宁可显示不可用，也不伪造 SOC、路线、地址、速度、能耗或海拔
+- 关键可点击区域尽量保持 >=48dp；320-360dp 与 fontScale 1.3 需要真机可用
+
+详细 Trip v0.6 视觉/交互 authority 见 `TRIP_V0.6_APPROVED_UI_BASELINE.md`。
 
 ---
 
-## 2. 信息架构
+## 2. 当前一级信息架构
 
-### v0.1
-
-- 首页
-- 记录
-- 统计
-- 车辆
-
-### v0.2
-
-保持一级导航简单，不为每种数据增加底部 Tab。新增能力通过当前车辆上下文和二级页面进入:
+底部一级导航保持五个稳定入口:
 
 ```text
-首页
-├── 当前车辆切换器
-├── 开始行程
-└── 最近充电 / 最近行程
-
-记录
-├── 充电记录
-└── 行程记录
-
-车辆
-├── 我的车辆列表
-└── 添加车辆 / 车型选择
+首页 Dashboard
+记录 Records
+统计 Stats
+行程 Trip
+车辆 Vehicle
 ```
 
----
+不要再把 Trip 隐藏在 Records 二级入口中。Trip 已是一级产品能力。
 
-## 3. Dashboard 与多车辆
-
-顶部使用明确的当前车辆切换器:
-
-```text
-[ 零跑 C16 ▼ ]
-```
-
-切换车辆后，Dashboard、Records、Stats 同步切换数据范围。
-
-允许后续增加“全部车辆”汇总，但必须显示 `全部车辆` 标签，不能把多车数据静默相加后让用户误认为单车数据。
-
-首页新增行程入口时使用明显动作:
-
-`开始行程`
-
-记录中状态:
-
-`正在记录 · 00:36:12 · 32.4 km`
-
-用户必须明确知道定位正在工作。
+当前车辆上下文会影响 Dashboard、Records、Stats、Trip 与新建记录目标；用户明确选择车辆后，不允许静默把不同车辆的数据混为单车数据。
 
 ---
 
-## 4. 新增车辆
+## 3. Dashboard
 
-推荐流程:
+Dashboard 当前重点是“车辆当前状态 + 最近发生了什么”，而不是展示静态规格表。
 
-```text
-搜索品牌/车型
- -> 品牌
- -> 车系
- -> 年款/配置
- -> 参数确认
- -> 保存
-```
+### Vehicle Hero
 
-必须始终有:
+- 生成完成的车型 Hero 资产直接展示，不在 Compose 内重建极光/反射特效
+- 当前 SOC 是主要动态事实；未知时显示 `--`
+- 当前里程为次要动态事实
+- 最近完成 Trip 的距离/可信平均能耗可作为辅助事实
+- 不在 Hero 中重复电池容量、标称续航、`ACTIVE` 等静态或装饰信息
 
-`没有找到？自定义添加车辆`
+### Recent Trip
 
-目录字段只是建议值，用户可以修改电池容量/续航等关键参数。
-
----
-
-## 5. 我的车辆
-
-多车辆采用列表而不是横向无限卡片:
-
-```text
-我的车辆
-
-[当前] 零跑 C16
-       67.7 kWh · 520 km
-
-       小米 SU7
-       73.6 kWh · 700 km
-
-[ + 添加车辆 ]
-```
-
-单车菜单:
-
-- 设为当前车辆
-- 编辑
-- 归档
-
-有历史数据时优先归档，不鼓励直接删除。
+- 使用最新有效完成 Trip
+- 时间/日期优先可见
+- 起点、终点分行表达，保留语义图标/标签，不只靠颜色
+- 距离、耗时、可信平均能耗/SOC/里程仅在有数据时显示
+- 地址不可用时保留真实坐标或不可用状态，不编造地点
 
 ---
 
-## 6. 充电记录
+## 4. Records
 
-继续支持时间、SOC、电量、费用、类型、地点、备注。
+Records 是充电账本，不是卡片画廊。
 
-v0.2 表单增加:
+当前 v0.6 层级:
 
-- 顶部车辆选择（默认当前车辆）
-- `使用当前位置` 按钮
+1. 紧凑累计账本摘要
+2. 连续时间线式充电记录
+3. 点击整行进入 Edit
+4. 独立删除动作 + destructive confirmation
 
-定位失败不能阻塞保存，用户仍可手工填写地点。
+保留时间、SOC、电量、费用、类型、里程、地点、备注等真实记录事实。长地点/备注必须可预测截断；缺失地点明确显示未记录。
 
 ---
 
-## 7. 行程记录 UX
+## 5. Stats
 
-### 开始前
+Stats 当前 v0.6 层级:
 
-显示当前车辆，避免把轨迹记录到错误车辆。
+1. 本月支出 / 补能摘要
+2. 上月比较
+3. Trip SOC-derived 能耗估算
+4. 月趋势 / charger mix / 常用地点
+5. lifetime / interval evidence
 
-### 记录中
+Trip 能耗必须继续标记为估算/非 BMS；previous-month 为 0 时不制造百分比增长。
 
-实时页面只保留驾驶时有价值且可信的信息:
+---
 
-- 记录耗时
+## 6. Trip v0.6
+
+Trip 是当前最重要的驾驶数据页面之一。现有实现分为明确状态/阅读面，而不是一个超长页面。
+
+### 6.1 Trip home / history
+
+进入 Trip 且没有 active Trip 时，默认落到历史/概览，不直接暴露 READY 表单。
+
+优先级:
+
+1. 紧凑 `开始行程` 动作
+2. 最新完成 Trip 摘要
+3. 最近 Trip 历史列表
+4. 日期/状态、起终点、距离/耗时、可信平均能耗
+
+目标是普通手机可舒适浏览 5+ 条历史记录；长地址可预测截断。
+
+### 6.2 READY / preparation
+
+用户从 Trip home 明确进入 READY。
+
+显示:
+
+- 当前车辆
+- 当前 SOC / 里程（已知时）
+- 紧凑 GPS 实录说明
+- restrained slide-to-start
+
+规则:
+
+- READY back 返回 Trip home，不创建空 Trip
+- 未获得真实定位样本前不伪造 GPS accuracy/readiness
+- slide progress 与 thumb 保持胶囊圆角
+- partial drag 自然回弹
+- accessibility 仍需存在等价语义动作
+
+### 6.3 Active Trip cockpit
+
+驾驶中只保留 glanceable、可信的信息:
+
+主要事实:
+
 - 已记录距离
-- 当前速度（可选）
-- GPS 状态/精度提示
-- 结束记录按钮
+- 当前/最近可信速度
 
-不鼓励驾驶中复杂交互。
+辅助事实:
 
-### 结束后
+- 已记录时间
+- 行驶均速
+- 最高已记录可信速度
+- 起始 SOC
 
-行程详情:
+支持面:
 
-- 地图轨迹
-- 开始 / 结束时间
-- 距离
-- 总耗时
-- 平均 / 最高速度
-- 起终点 GPS 海拔 / 海拔范围（数据可靠时）
-- 关联车辆
+- 真实轨迹预览
+- 可信 speed trend
+- 有可信样本时 altitude trend
+- interrupted 状态及显式恢复
 
-GPS 海拔必须明确标注来源，不包装成高精度地形数据。
+Point count / altitude sample count 属于诊断，不重复占据主指标区。
 
----
+结束使用 restrained slide-to-end；滑动后直接进入唯一的 Trip completion form，不再叠加一个通用“是否结束”AlertDialog。
 
-## 8. 地图交互
+### 6.4 Completion
 
-地图是轨迹可视化，不是记录引擎。
+完成表单先展示证据，再收集输入:
 
-基础能力:
+1. GPS 距离
+2. 起始 SOC / 起始里程
+3. 结束 SOC（必填 0..100）
+4. 结束里程（可选、非负、不得低于起始里程）
+5. 可计算时显示 SOC-derived energy estimate，并明确非 BMS
 
-- 当前定位
-- 轨迹线
-- 起点 / 终点
-- 自动缩放到完整路线
+`继续行驶` / dismiss 不结束 Trip；只有合法 `保存并结束` 才真正 stop。
 
-v0.2 不做导航、路线规划、复杂 POI 搜索。
+### 6.5 Completed detail
 
----
+完成/选中的 Trip detail 已分为三个支持的阅读 section:
 
-## 9. 权限与隐私 UX
+- `概览`: summary + 紧凑起终点卡
+- `轨迹`: 真实 route + speed/altitude trends
+- `数据`: altitude/reliability summary + raw point progressive disclosure
 
-定位权限只在用户使用相关功能时请求。
+默认打开 `概览`。切换 section 不修改 Trip 数据。
 
-开始持续记录前说明:
+不加入当前产品没有能力支撑的 `充电`、`备注`、目的地选择、导航预览或假地图。
 
-- 记录内容
-- 持续定位原因
-- 锁屏后仍记录
-- 如何停止
+### 6.6 Route / endpoint semantics
 
-持续定位必须伴随前台服务通知。
+- 起点: 紧凑绿色 start/play 语义
+- completed 终点: 小型红旗，无大 ring/halo
+- active latest point: 绿色 `当前点`
+- interrupted/non-final latest point: `最后记录点`，不得伪装成 completed endpoint
+- LONG_GAP 保持断开，不把缺失路线补成可信连续实线
+- 速度颜色仅代表本车可信 GPS speed，不代表道路拥堵
 
----
+### 6.7 Diagnostics
 
-## 10. 状态设计
+默认不展开 raw GPS log。
 
-必须覆盖:
+可见摘要可以包含:
 
-- 无车辆
-- 无充电记录
-- 无行程记录
-- 定位权限拒绝
-- GPS 暂不可用
-- 地图加载失败但行程数据可正常查看
-- 车型库找不到车型 -> 自定义车辆
+- continuity/reliability
+- point count
+- accuracy context
+- long-gap summary
+- altitude start/end/min/max/ascent/descent
+- speed / altitude trends
 
----
-
-## 11. v0.1 验收不变
-
-- 创建/编辑车辆
-- Dashboard
-- 新增/编辑/删除充电记录
-- 历史列表
-- 基础统计
-
-新地图/行程/多车辆需求不得阻塞 v0.1 发布。
+raw points 通过 `查看轨迹点` 显式展开。
 
 ---
 
-## 12. 变更记录
+## 7. Location / permission / background UX
+
+坐标是事实，地址是派生展示。Geocoder 失败不能阻塞记录。
+
+Trip 需要用户明确启动；持续记录必须有 foreground notification。
+
+当前通知/中断 UX:
+
+- ongoing notification 显示已记录时间 + 可信累计距离
+- notification 可直接回 active Trip
+- runtime Location permission/provider loss -> Trip `INTERRUPTED`
+- repair notification 提供系统设置入口
+- 修复后由用户明确恢复，不自动后台 resume
+- Android 13+ 通知权限拒绝不能阻塞 Trip 本身
+- 锁屏通知不展示精确坐标 / HOME / WORK 地址
+
+后台 callback / stationary hold 的最终可靠性仍由 #77 真机验收，不能从 CI 推导。
+
+---
+
+## 8. Map 边界
+
+地图/route renderer 只消费已有 TripPoint，不参与记录事实生成。
+
+当前已经拥有无底图真实 WGS84 route preview；MapLibre 仍是可选未来 renderer，不是当前 Trip v0.6 完整性的前置条件。
+
+不为了“像地图”而道路吸附、补线或制造假 destination。
+
+---
+
+## 9. Vehicle
+
+车辆页当前采用 garage/list + switcher，而不是无限横向卡片。
+
+支持:
+
+- 当前车辆切换
+- 编辑车辆
+- catalog 选择/搜索
+- custom vehicle fallback
+- 归档
+- Bluetooth vehicle prompt 配置
+- Backup / CSV 等工具入口
+
+当前车辆切换不改变已开始 Trip 的 `vehicleId`。
+
+---
+
+## 10. 当前验收边界
+
+代码侧 Trip v0.6 已实现；以下仍必须真机完成:
+
+- Trip home 5+ rows 信息密度
+- READY slide 手感/误触
+- active route / live telemetry update
+- completion + IME
+- completed `概览 / 轨迹 / 数据`
+- LONG_GAP / endpoint semantics
+- 320-360dp
+- fontScale 1.3
+- Dark/Light readability
+- #77 background/stationary callback reliability
+
+不得用 Android CI Green 直接关闭这些 physical acceptance owners。
+
+---
+
+## 11. 变更记录
+
+### v1.3.0
+
+- 对齐当前五一级导航与 Dark First v0.5/v0.6 页面层级
+- 同步 Trip home / READY / active / completion / completed detail 三 section 信息架构
+- 同步 slide-to-end 直接进入唯一 completion form 的当前交互
+- 同步真实 route / LONG_GAP / endpoint / diagnostics 语义
+- 明确 MapLibre 仍为可选 renderer，不是当前 Trip 完整性前置条件
+- 明确 Trip v0.6 代码完成与真机验收的边界
 
 ### v1.2.0
 


### PR DESCRIPTION
## Summary

Reconciles the remaining Trip-related authority drift after the v0.6 implementation and device-fidelity series landed.

### Why

The dedicated Trip v0.6 baseline and Roadmap were current, but several higher-level authority documents still described the 2026-08-26 prototype state:

- `UIUX.md` still placed Trip under Records and described a generic start/stop page
- `FRONTEND.md` still described MapLibre as if it were the current v0.2 implementation target and did not document the actual v0.6 screen/service boundaries
- `FEATURE_MATRIX.md` still showed core Trip/location/multi-vehicle features as unchecked
- `PROJECT_MASTER.md` did not include the Trip v0.6 authority docs or #145/#168/#178 in the current physical closeout

### Updates

- align the five primary pages with current Dark First UI
- document Trip home -> READY -> active/interrupted -> completion -> completed `概览 / 轨迹 / 数据`
- document slide-to-end -> single completion form semantics
- document `TripTrackingService` time-based callback liveness and app-level stationary throttling
- keep LONG_GAP / route / endpoint / data-truth rules explicit
- keep MapLibre, destination planning and OBD optional/future rather than current Trip blockers
- separate code completion / CI / physical acceptance throughout the authority set

Issue state cleanup completed in the same reconciliation pass:
- #77 now records PR #80 / CI as code-complete and physical-only remaining
- #148 now reflects the post-#174 direct completion-form flow

Docs only; no Android/runtime behavior change.

Related: #6 #77 #145 #148 #168 #178