### PR TITLE
docs: reconcile Trip reliability and speed visualization baseline

### DIFF
--- a/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
+++ b/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
@@ -1,32 +1,42 @@
-# Trip GPS Reliability & Speed Visualization Plan
+# Trip GPS Reliability & Speed Visualization
 
-版本: v1.1.0
-更新时间: 2026-08-27
-状态: Partially Implemented / Physical Acceptance Pending
+版本: v1.2.0
+更新时间: 2026-08-29
+状态: Code Baseline Complete / Physical Acceptance Pending
 
-## 1. 背景
+## 1. 文档定位
 
-2026-08-27 的真实 Trip 数据连续暴露出两个核心方向：
+本文档是 EV Charge Book 行程模块中 **GPS 可信度、轨迹连续性、速度可信度与轨迹可视化** 的实现/验收说明。
 
-1. 单一全程平均速度无法表达高速、城市道路、停车/低速等不同区段的驾驶特征。
-2. `COMPLETED` 不能证明中间 GPS 连续；后台 callback、provider fallback、业务过滤与真实 GPS loss 必须可区分。
+当前阶段不再是“等待实现方案”。核心代码已经进入 `main`，剩余主要是 Android 真机上的后台定位、轨迹可读性与无障碍/窄屏验收。
 
-本文档最初基于 Trip #7 建立 P0 GPS reliability + P1 speed visualization 方案。第二轮真机 Trip 又确认：
+相关 authority：
 
-- 切换其他 App 时仍可能出现移动中长时间轨迹空洞；
-- 2-3 分钟红灯可能因 callback/accepted point 间隔被误解为长 gap；
-- Network provider 的粗定位 speed 可以制造 122+ km/h 假峰值；
-- 海拔、地址、起终点标记和速度颜色需要真正落到 Trip 详情。
+- `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
+- `docs/LOCATION_TRIP.md`
+- `docs/ROADMAP.md`
+- #145 Trip v0.6 总体验收
+- #168 Trip v0.6 device-fidelity correction
+- #77 后台 callback / stationary hold 真机验收
+- #67 trajectory / speed-colored route 真机验收
 
-当前多项代码已经进入 `main`，但后台连续性、最高速度实际一致性与彩色轨迹视觉仍需下一轮真机验收。CI 不能代替这些物理设备结论。
+设计原则保持不变：
+
+1. GPS / Room 中保存的原始事实优先于视觉效果。
+2. 不跨真实 GPS gap 伪造路线、距离或速度。
+3. Network/coarse provider 可以作为诊断证据，但不能污染可信最高速度或彩色轨迹。
+4. UI 的速度颜色只表达“本车可信 GPS 速度分布”，不代表道路拥堵、限速或交通状态。
+5. 地图 SDK、road snapping、云端轨迹处理都不是当前可靠性成立的前提。
 
 ---
 
-## 2. 真实数据证据
+## 2. 历史真实数据证据
 
-### 2.1 第一轮：Trip #7
+这些数据保留作为当前 trust rules 的来源，不代表当前代码仍存在相同缺陷。
 
-Trip #7：
+### 2.1 Trip #7：十分钟级 GPS 空洞
+
+历史 Trip #7：
 
 - distanceMeters: 42643.19 m
 - elapsedSeconds: 4137 s
@@ -36,212 +46,171 @@ Trip #7：
 - maxSpeedMps: 25.92 m/s（约 93.3 km/h）
 - status: COMPLETED
 
-TripPoint 中存在多段长时间缺口，例如：
+曾出现：
 
-- Point 64 -> 65 约 749 秒（12 分 29 秒）
-- Point 70 -> 71 约 917 秒（15 分 17 秒）
+- Point 64 -> 65：约 749 秒
+- Point 70 -> 71：约 917 秒
 
-由此确认：
+由此确定：
 
-- `COMPLETED` 只能说明 Trip 最终正常收口，不代表中间 GPS 连续。
-- 需要独立的 GPS health / continuity 指标。
-- 长 gap 两端不能被画成可信连续路线。
+- `COMPLETED` 只代表行程最终收口，不代表中间 GPS 连续。
+- 大 gap 两端不得画成可信连续路线。
+- gap 期间不得补造可信距离、移动时间或速度。
 
-### 2.2 第二轮：2026-08-27 Trip #2
+### 2.2 2026-08-27 Trip #2：后台空洞、停车误判和假最高速
 
-第二轮实机导出进一步暴露：
+历史实机证据：
 
 - distanceMeters: 约 24.20 km
 - elapsed: 约 83 分 45 秒
 - moving: 约 51 分 25 秒
-- stoppedSeconds: 仅 15 秒，明显不符合城市道路红灯实际
-- maxSpeed: 约 122.4 km/h，但车辆实际返程没有该速度
-- Session 已保存 start/end/min/max altitude，但 UI 当时未展示
+- stoppedSeconds: 仅 15 秒
+- UI 曾出现约 122.4 km/h 的最高速度
 
 典型 continuity 证据：
 
-- Point 42 -> 43：约 643 秒（10 分 43 秒），坐标发生公里级变化，属于真实移动期间记录空洞。
-- Point 109 -> 110：约 465 秒（7 分 45 秒），恢复时先出现 coarse network fallback。
-- 一组红灯样本约 140 秒间隔，起始点 speed=0，符合“车辆静止但系统/业务没有保留足够 heartbeat”的误分类风险。
+- Point 42 -> 43：约 643 秒移动空洞
+- Point 109 -> 110：约 465 秒，恢复时出现 coarse network fallback
+- 约 140 秒的红灯样本暴露旧 `8m` LocationManager gate 与 15 秒 stationary heartbeat 的冲突
 
-典型假速度证据：
+典型假速度点：
 
 - provider: `network`
 - horizontal accuracy: 约 100m
 - speed accuracy: null
 - reported speed: 34.005 m/s（约 122.4 km/h）
 
-另有类似 network point 报出约 142.6 km/h，说明不能把 Network `Location.speed` 与高质量 GPS 速度视为同等统计事实。
+上述证据推动了 PR #80、#82、#85 等后续修复。
 
 ---
 
-## 3. P0 - GPS 后台可靠性与可诊断性
+## 3. 当前 GPS callback / stationary reliability baseline
 
-### 3.1 目标
+### 3.1 PR #80：callback liveness 与停车 heartbeat
 
-下一次出现断点时，必须能区分：
+PR #80 `fix(android): keep Trip callbacks alive while stationary` 已进入 `main`。
 
-- Foreground Service 被系统杀/重启
-- LocationManager 长时间没有 callback
-- GPS provider 不可用
-- network provider fallback
-- Location 被业务过滤
-- 权限或系统定位状态异常
-- 车辆实际静止但 tracking callback 仍健康
+当前实现：
 
-### 3.2 运行时状态
+- LocationManager `minDistance = 0m`，不再使用旧 8m displacement gate
+- 保留约 4 秒 callback request interval
+- callback 与数据库写入分层：系统回调可以频繁，Room 写入仍由 domain sampling rules 降频
+- stationary heartbeat 约 15 秒持久化一次，而不是每个 callback 都写 TripPoint
+- stationary heartbeat 增加 `stoppedSeconds`，不增加 `movingSeconds`
+- `START_REDELIVER_INTENT` 保留
+- provider / permission / service lifecycle 诊断保留
 
-当前运行时已经覆盖主要 health 信息：
+这解决了代码层“系统 8m gate 阻止业务 15s heartbeat”的冲突。
+
+### 3.2 仍需 #77 真机验证
+
+CI 无法证明不同 Android ROM 在后台时一定持续交付定位 callback。
+
+因此 #77 保持 open，仅用于验证：
+
+- [ ] 切换其他 App 并保持其前台 5–10 分钟时，可信距离仍持续增长
+- [ ] 2–3 分钟真实停车会增加合理 `stoppedSeconds`
+- [ ] 健康 stationary callback 不产生 false LONG_GAP
+- [ ] 真正 provider/callback loss 仍产生 LOST/LONG_GAP
+- [ ] stationary TripPoint 写入仍保持节流
+
+没有新的真机证据前，不再重新实现第二套 tracking service / WorkManager / 云端 tracking。
+
+---
+
+## 4. GPS health 与诊断
+
+当前运行时已经区分：
 
 - `lastLocationCallbackAt`
 - `lastAcceptedPointAt`
 - recent accepted provider
-- rejected point count
-- foreground service lifecycle diagnostic events
-
-仍建议继续补充 Trip 级持久摘要：
-
-- lastGpsPointAt / lastNetworkPointAt
-- acceptedPointCount
-- rejectedByAccuracyCount
-- rejectedByJumpCount
-- providerSwitchCount
-- longestLocationGapSeconds
-- cumulative gap summary
-
-### 3.3 GPS Health 状态
-
-UI / Notification 使用统一派生状态：
-
-- GOOD：最近有效定位 <= 10s
-- DEGRADED：10-30s
-- LOST：> 30s
-- LONG_GAP：> 120s
-
-阈值仍属于可调 reliability 参数，必须通过真实设备继续验证。
-
-### 3.4 Notification
-
-Foreground notification 已实现：
-
-- 正在记录行程
-- GPS health
-- 最近有效定位时间
-- recent accepted provider
-- rejected point count
-- 结束行程动作
-- LOST / LONG_GAP 使用同一条 ongoing notification 更新，不刷屏
-
-后续 #26 继续补：
-
-- 已记录时长
-- 已记录可信距离
-- 点击通知进入当前 Trip
-- provider/permission/background restriction 修复入口
-
-### 3.5 Service 生命周期
-
-当前服务继续使用 location foreground service + `START_REDELIVER_INTENT`。
-
-已记录的关键诊断事件包含：
-
-- service start
-- START_REDELIVER_INTENT redelivery
-- service destroy
+- rejected point evidence / sampled diagnostics
+- foreground service start / destroy / redelivery
 - provider disabled
 - permission missing
-- location registration failed
-- sampled rejected location event
+- location registration failure
 
-这些事件用于解释断点，不用于长期堆积无界日志。
+UI / notification 使用的核心 health 语义仍是：
 
-### 3.6 callback 与 stationary heartbeat
+- GOOD：最近有效定位约 <=10s
+- DEGRADED：约 10–30s
+- LOST：约 >30s
+- LONG_GAP：约 >=120s 的真实 continuity break
 
-第二轮真机发现了一个明确冲突：
+这些阈值是产品 reliability 参数，可根据真机数据做小幅调整，但不能通过放宽阈值来隐藏真实 gap。
 
-```text
-LocationManager minDistance = 8m
-        +
-TripSamplingRules stationary heartbeat = 15s
-```
+### 可选的未来摘要
 
-车辆停在红灯时，如果系统层因为没有移动 8m 而不产生 callback，业务层就无法执行 15s stationary heartbeat。下一次 accepted point 若超过 120s，可能被当成 LONG_GAP。
+以下属于 future / evidence-driven，不是当前 blocker：
 
-PR #80 已进入 `main`：
+- Trip 级 longest gap
+- GPS / Network provider counters
+- rejected reason 汇总
+- provider switch count
 
-- LocationManager `minDistance` 从 8m 调整为 0m；
-- 保持约 4 秒 callback request interval；
-- Room 写入仍由 `TripSamplingRules` 负责降频；
-- stationary heartbeat 继续约 15 秒一条；
-- JVM test 覆盖 stationary heartbeat 增加 `stoppedSeconds` 而不增加 `movingSeconds`。
-
-该改动解决“代码层两套门槛互相打架”，但仍必须通过 #77 的真机流程验证：切到其他 App 后 callback/距离是否真的持续。
-
-### 3.7 GPS / Network provider 融合
-
-当前允许 GPS + Network provider 进入原始 TripPoint，但统计权限分层：
-
-- GPS 高质量点优先作为主轨迹/速度事实。
-- Network point 保留为 fallback / continuity / diagnostic evidence。
-- 时间非常接近的 GPS / Network point 使用 continuity rule 去重/择优。
-- Network 粗速度不能制造最高速度。
-- Network 粗速度不能给速度彩色轨迹上色。
-- 原始数据不因为统计过滤而被删除或改写。
+只有当诊断成本明显影响真实问题定位时再增加，不为了“指标齐全”扩展 schema。
 
 ---
 
-## 4. P0 - 最高速度可信度
+## 5. Notification / interruption 状态
 
-### 4.1 问题
+早期文档曾把 #26 写成后续代码工作；该描述已经过期。
 
-第二轮实机的 122.4 km/h 最高速来自 coarse `network` point，而非可信 GPS 峰值。
+当前必要代码已经通过 PR #130 / #131 / #132 进入 `main`：
 
-因此“原始 Location.speed 存在”不等于“允许进入 maxSpeedMps”。
+- ongoing notification 显示真实已记录时长
+- ongoing notification 显示已持久化可信累计距离
+- 点击 ongoing notification / `打开行程` 可回当前 Trip
+- provider 不可用或 Location 权限丢失时进入 `INTERRUPTED`
+- repair notification 可进入对应设置修复
+- 修复后必须由用户明确恢复，不自动偷偷 resume
+- Android 13+ notification permission 拒绝不会回滚或阻止 Trip
+- 锁屏通知默认不暴露精确经纬度 / HOME / WORK 地址
 
-### 4.2 已实现质量门
+#26 目前属于 **physical acceptance owner**，不是待实现代码清单。
 
-PR #82 已进入 `main`，新增独立 max-speed trust gate。
+---
 
-最高速度 candidate 必须同时满足：
+## 6. 最高速度可信度
 
-- existing aggregate continuity/distance corroboration；
-- provider = `gps`；
-- horizontal accuracy <= 25m；
-- speedAccuracy 存在时 <= 3 m/s；
-- speed 为 finite 且非负。
+### 6.1 PR #82 / #78 已完成
 
-Network / coarse point 的原始速度仍保留在 TripPoint，只是不再污染派生最高速度。
+历史 122.4 km/h 假峰值来自 coarse `network` point。
+
+PR #82 已建立独立 max-speed trust gate，#78 已按 completed 关闭。
+
+当前最高速度 candidate 必须满足：
+
+- existing aggregate continuity / distance corroboration
+- provider = `gps`
+- horizontal accuracy <= 25m
+- speedAccuracy 存在时 <= 3 m/s
+- speed finite 且非负
+
+Network/coarse point 的原始 `speedMps` 仍可保留在 TripPoint 作为诊断事实，但不能刷新可信 `maxSpeedMps`。
 
 JVM regression 已覆盖：
 
-- 122.4 km/h network + 100m accuracy 被拒绝；
-- 合理 GPS highway peak 可以通过；
-- coarse GPS peak 被拒绝。
+- 122.4 km/h network + 100m accuracy 被拒绝
+- 合理 GPS highway peak 可以通过
+- coarse GPS peak 被拒绝
 
-### 4.3 仍需真机确认
+因此不要再把 #78 写成当前 open blocker。
 
-#78 继续保持 open，下一轮需要把 App 的“最高已记录速度”与车辆实际峰值进行对照。
-
-产品文案仍应理解为“最高已记录可信 GNSS 速度”，不是车辆真实最高速度的绝对证明，因为短时峰值可能恰好没有被采到。
+产品语义仍应理解为“最高已记录可信 GNSS 速度”，不是车辆真实物理最高速度的绝对证明。
 
 ---
 
-## 5. P1 - 分段速度模型
+## 7. 可信速度彩色轨迹
 
-### 5.1 三种速度必须区分
+### 7.1 PR #85 已实现
 
-Trip UI 至少区分：
+PR #85 `feat(android): color Trip route by trusted vehicle speed` 已合并为 `482b6e9`。
 
-1. 全程平均速度：总可信距离 / elapsed time
-2. 行驶平均速度：总可信距离 / moving time
-3. 分段/轨迹速度：可信 segment 的显示或分析派生
-4. 最高已记录速度：经异常过滤的可信 GNSS `Location.speed` 峰值
+Android CI run `33086126816` 在 PR head `8337d81` 上成功。
 
-当前 UI 已明确显示全程均速 / 行驶均速 / 最高速度 / 移动时间。
-
-### 5.2 第一版 route speed visualization 已实现
-
-PR #85 已实现轻量第一版，不新增 Room 表：
+数据路径：
 
 ```text
 TripPoint[]
@@ -253,252 +222,275 @@ TripPoint[]
 
 规则：
 
-- 只有相邻两端都拥有可信 GPS speed，该线段才有速度颜色；
-- 任一端 speed 不可信/缺失，该线段保持中性灰色；
-- 不能把未知速度当作 0 km/h；
-- 长 GPS gap 在 geometry 层仍保持断开；
-- downsample/normalize 后保留可信 speed metadata。
+- 只有相邻两端都拥有可信 GPS speed，线段才使用速度颜色
+- 任一端 speed 不可信/缺失，线段保持中性灰色
+- 未知速度不能被当作 0 km/h
+- downsample / normalize 后保留可信 speed metadata
+- LONG_GAP segmentation 优先于颜色；gap 不会因为上色而重新连起来
 
-### 5.3 完整 TripSpeedSegment 仍是 future
+### 7.2 当前颜色语义
 
-原计划的更长窗口派生模型仍有价值：
+连续映射：
 
-```text
-TripPoint[]
-  -> TripSpeedSegmentBuilder
-  -> TripSpeedSegment[]
-  -> analytics / UI
-```
-
-推荐继续研究：
-
-- 20-30 秒，或
-- 200-300 米
-
-每个 segment 可包含：
-
-- start/end timestamp
-- distance
-- duration
-- averageSpeedKmh
-- min/max speed（可选）
-- GPS quality / gap flag
-
-注意：PR #85 的“相邻可信 GPS speed 颜色”不是完整的 `TripSpeedSegmentBuilder`。文档必须保持两者边界。
-
----
-
-## 6. P1 - 速度颜色映射
-
-### 6.1 当前视觉语义
-
-在未接道路类型/限速/交通数据前，不使用“严重拥堵 / 畅通”等交通事实词。
-
-当前使用本车速度语义：
-
-- 深红：极低速
-- 红：低速
-- 黄：较慢
-- 绿：正常/快速
-- 蓝：高速
-- 灰：速度数据不足 / 不可信
-
-### 6.2 连续颜色
-
-PR #85 已按以下连续映射实现：
-
-- 0-5 km/h：深红
-- 5-15 km/h：红
-- 15-30 km/h：红 -> 黄
-- 30-50 km/h：黄 -> 绿
-- 50-70 km/h：绿
-- 70-90 km/h：绿 -> 蓝
+- 0–5 km/h：深红
+- 5–15 km/h：红
+- 15–30 km/h：红 -> 黄
+- 30–50 km/h：黄 -> 绿
+- 50–70 km/h：绿
+- 70–90 km/h：绿 -> 蓝
 - 90+ km/h：蓝 / 深蓝
+- 未知 / 不可信：灰色
 
-最终颜色只属于 UI 派生，不写回原始 TripPoint。
+颜色仅属于 UI 派生，不写回原始 TripPoint。
 
-### 6.3 交通语义边界
+### 7.3 不允许的交通语义
 
-在没有道路类型 / 限速 / map matching / 实时交通数据前：
+没有道路类型、限速、map matching、实时交通数据时：
 
 - 8 km/h 可能只是停车场
 - 15 km/h 可能只是小区道路
-- 40 km/h 在城市道路可能畅通，在高速可能拥堵
+- 40 km/h 在不同道路上意义完全不同
 
-因此彩色轨迹代表“本车可信 GPS 速度分布”，不是“道路拥堵等级”。
-
-UI 已明确说明该边界。
+因此 UI 必须继续说明：颜色代表本车可信 GPS 速度分布，不代表道路拥堵等级。
 
 ---
 
-## 7. P1 - Trip detail facts
+## 8. GPS gap 与轨迹连续性
 
-第二轮真机同时暴露了三个展示缺口，PR #83 已进入 `main`：
+当前核心规则：
 
-### 7.1 海拔
-
-当前 Trip detail 可展示已持久化的：
-
-- 起点海拔
-- 终点海拔
-- 最低海拔
-- 最高海拔
-
-当前不计算累计爬升/下降；raw altitude 需要经过 vertical accuracy / smoothing 后再做高程分析。
-
-### 7.2 起终点地址
-
-- WGS84 坐标继续作为权威事实。
-- 已完成/中断 Trip 使用现有 `AndroidGeocoderAddressResolver` 做展示层 reverse geocoding。
-- 地址作为主阅读文本，坐标保留为技术参数。
-- geocoder 失败显示“地址暂不可用”，不阻止 Trip 完成。
-- RECORDING 状态不反复解析实时 endpoint。
-
-### 7.3 起终点 marker
-
-原先两端仅使用两个同形状、不同颜色的小点，真机不易辨认。
-
-当前改为：
-
-- 起点：圆形 + `起点 · 圆形`
-- 终点：方形 + `终点 · 方形`
-- Canvas accessibility semantics 明确两者含义
-
-因此不再只依赖红/绿颜色区分。
-
----
-
-## 8. GPS Gap 可视化与统计
-
-禁止把长时间缺失的两端 GPS 点直接连成实线路线。
-
-当前规则：
-
-- `>=120s` gap 后 renderer 拆成 disconnected segment；
-- gap 两端不累计可信直线距离；
-- gap duration 不进入 moving/stopped 统计；
-- gap 不允许刷新 aggregate/max speed；
-- speed-colored route 同样不会跨 gap 画线。
+- `>=120s` 的真实 gap 拆成 disconnected segments
+- gap 两端不累计可信直线距离
+- gap duration 不进入可信 moving/stopped 统计
+- gap 不允许刷新 aggregate / max speed
+- speed-colored route 不跨 gap 画线
 
 ```text
 已知轨迹 ━━━━━     ━━━━━ 已知轨迹
              GPS 缺失
 ```
 
-无 basemap 阶段继续使用断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+无 basemap 阶段使用断开表达已经足够真实。
+
+MapLibre 如果未来接入，只负责更好的 renderer，不负责补造道路或缺失路线。
 
 ---
 
-## 9. 当前验收状态
+## 9. 海拔 / 高程分析
+
+早期版本写着“当前不计算累计爬升/下降”，该描述已经过期。
+
+PR #127 `feat(android): add trusted Trip elevation analysis` 已实现 #69 并进入 `main`：
+
+- start / end altitude
+- min / max altitude
+- cumulative ascent / descent
+- vertical-accuracy quality filtering
+- jitter suppression
+- LONG_GAP isolation
+- Trip detail UI
+- JVM regression coverage
+
+#69 已完成关闭。
+
+v0.6 详情中：
+
+- `轨迹`：速度 / 海拔趋势作为 route supporting evidence
+- `数据`：海拔摘要与 reliability / raw-point diagnostics
+- 无可信海拔时显示 truthful unavailable state，不生成合成高程
+
+---
+
+## 10. 地址与 endpoint 语义
+
+### 10.1 Coordinate-first
+
+#66 的 coordinate-first / geocode cache-retry code 已完成关闭。
+
+当前原则：
+
+- WGS84 latitude / longitude 是原始权威事实
+- 地址只是展示层派生数据
+- geocoder 失败不阻止 Trip 保存/完成
+- 无法解析时保留坐标或明确 unavailable，不虚构地点
+
+真实设备 Location / Geocoder 行为继续由 #14 验收，而不是重新打开 #66。
+
+### 10.2 v0.6 endpoint semantics
+
+当前 v0.6 authority 已替代早期“圆形起点 / 方形终点”视觉：
+
+- start：compact primary-green play/start icon
+- completed end：small red flag，无 ring / halo
+- active latest point：green `当前点`
+- interrupted/non-final latest point：`最后记录点`，不能冒充 completed endpoint
+
+同时保留 accessibility semantics，不能只靠红/绿颜色区分状态。
+
+---
+
+## 11. v0.6 详情信息架构
+
+PR #179 已将 completed Trip detail 从一个长页面拆成：
+
+- `概览`：summary + start/end card
+- `轨迹`：真实 route + trusted speed/altitude trends
+- `数据`：altitude/reliability summary + raw-point progressive disclosure
+
+因此本文件描述的 reliability / route / speed visualization 必须服从 `TRIP_V0.6_APPROVED_UI_BASELINE.md` 的当前信息架构，不再把所有诊断内容堆在默认详情页。
+
+Raw GPS point list 默认折叠，只在用户明确点击 `查看轨迹点` 时展开。
+
+---
+
+## 12. 当前验收状态
 
 ### P0 GPS Reliability
 
-- [x] 显示最近有效定位时间
-- [x] 识别 >30s GPS gap，并提供 LOST / LONG_GAP health
-- [x] 区分 GPS / Network provider 基线
-- [x] rejected point 运行时计数 / sampled diagnostic
-- [x] service start / destroy / redelivery 等生命周期诊断事件
-- [x] GPS 长时间丢失时 ongoing notification 明确提示
-- [x] `>=120s` 长 gap 路线断开且不累计可信距离/时长
-- [x] LocationManager 8m callback gate 移除，stationary heartbeat 可在业务层执行
-- [ ] longest gap / provider counters / rejected reason 的 Trip 级持久摘要
-- [ ] 切换其他 App 5-10 分钟仍持续 callback / 距离更新真机复验（#77）
-- [ ] 2-3 分钟红灯不产生 false LONG_GAP，且 stoppedSeconds 合理真机复验（#77）
+- [x] 最近有效定位 / provider / rejected evidence
+- [x] service lifecycle diagnostics
+- [x] LOST / LONG_GAP health
+- [x] `>=120s` route gap 断开，不累计伪造可信距离
+- [x] old LocationManager 8m callback gate 已移除
+- [x] stationary heartbeat 可以在 domain layer 执行并保持写入节流
+- [ ] 另一 App 前台 5–10 分钟仍持续 callback / 距离更新（#77）
+- [ ] 2–3 分钟停车不产生 false LONG_GAP，stoppedSeconds 合理（#77）
+- [ ] 真正 provider/callback loss 仍可复现 LOST/LONG_GAP（#77）
 
 ### P0 Speed Trust
 
-- [x] Network/coarse speed 不得刷新 maxSpeedMps
-- [x] max-speed quality gate 有 JVM regression
-- [ ] 下一次真实行程与车辆仪表峰值对照（#78）
+- [x] Network/coarse speed 不刷新 maxSpeedMps
+- [x] GPS quality gate + JVM regression
+- [x] #78 completed；不再作为当前 open blocker
 
 ### P1 Speed Visualization
 
-- [x] UI 区分全程平均 / 行驶平均 / 最高速度
-- [x] 可信 GPS route 支持连续颜色映射
-- [x] 不可信/未知 speed segment 使用中性灰色
-- [x] 长 GPS gap 不画成可信实线
-- [x] 未接交通数据前不宣称“真实拥堵等级”
-- [x] trusted speed metadata 经过 geometry normalize/gap segmentation 有 JVM test
-- [ ] `TripSpeedSegmentBuilder` 长窗口派生模型
-- [ ] 分段平均速度综合模型 JVM tests
-- [ ] 彩色路线 dark/light 真机视觉复验（#67）
+- [x] 可信 GPS route 连续颜色映射
+- [x] unknown/untrusted speed 使用 neutral color
+- [x] LONG_GAP 不跨 gap 上色/连线
+- [x] 不宣称真实拥堵等级
+- [x] geometry metadata JVM coverage
+- [ ] real-device route / legend Dark-Light 可读性（#67/#145/#168）
+- [ ] 320–360dp + fontScale 1.3（#67/#145/#42）
 
-### P1 Trip detail
+### P1 Elevation / detail
 
-- [x] 起/终/最低/最高海拔展示
-- [x] 起终点地址展示，坐标保持技术参数
-- [x] 起点圆形 / 终点方形 + 文本语义
-- [ ] 地址 Geocoder 真实设备成功/失败路径复验（#66）
-- [ ] 海拔与 marker dark/light 真机视觉复验（#69/#42）
+- [x] start/end/min/max altitude
+- [x] cumulative ascent/descent
+- [x] quality/jitter/gap filtering
+- [x] v0.6 `轨迹` / `数据` section ownership
+- [ ] Location/Geocoder real-device pass（#14）
+- [ ] detail/trend/diagnostic Dark-Light + narrow-screen pass（#145/#168/#178/#42）
 
 ---
 
-## 10. 下一轮真机验收脚本
+## 13. 推荐一次性真机验收脚本
 
-一次 20-30 分钟测试即可覆盖当前主要 blocker：
+一次 20–30 分钟 session 可覆盖主要剩余 blocker：
 
-1. 前台开始 Trip，正常行驶 3-5 分钟。
-2. 锁屏一段时间，确认 foreground notification 仍存在。
-3. 解锁后切换到抖音/其他 App，保持该 App 前台 5-10 分钟并继续行驶。
-4. 找一次约 2-3 分钟停车/红灯场景。
-5. 恢复行驶，再返回 EV Charge Book 结束 Trip。
-6. 对照车辆仪表记住本次大致最高速度。
+1. 前台开始 Trip，正常行驶 3–5 分钟。
+2. 锁屏一段时间，确认 foreground notification 存在并刷新真实时长/距离。
+3. 解锁后切换到其他 App，保持其前台 5–10 分钟并继续行驶。
+4. 找一次约 2–3 分钟停车/红灯场景。
+5. 如果安全且方便，可测试一次系统定位/provider 中断，再明确手工恢复。
+6. 恢复行驶并返回 EV Charge Book。
+7. 通过 slide-to-end 打开 compact completion form，填写 end SOC / mileage 并结束。
+8. 检查 completed `概览` / `轨迹` / `数据`。
 
 必须检查：
 
-- [ ] 切其他 App 时累计距离继续增长，没有新的公里级移动空洞
-- [ ] 红灯期间产生合理 stoppedSeconds，不被误判成 LONG_GAP
-- [ ] 真正 GPS/callback 丢失仍会显示 LOST/LONG_GAP
-- [ ] 最高已记录速度与车辆实际峰值合理接近，不再出现 network 122+ km/h 假峰值
-- [ ] 起/终/最低/最高海拔可见
-- [ ] 起终点优先展示地址，地址失败时仍显示坐标且不虚构地点
-- [ ] 起点圆形 / 终点方形一眼可分
-- [ ] route 能看到低/中/高速度的红黄绿蓝变化
-- [ ] 灰色只用于不可信/缺失速度区间
-- [ ] 长 GPS gap 仍保持断开
-- [ ] Dark / Light 下轨迹和图例都可读
+- [ ] 后台/另一 App 前台期间可信距离继续增长
+- [ ] 停车期间 stoppedSeconds 合理且无 false LONG_GAP
+- [ ] 真正 GPS/callback loss 仍显示 LOST/LONG_GAP
+- [ ] route 能看到可信低/中/高速度差异，不可信段保持 neutral
+- [ ] LONG_GAP 清晰断开
+- [ ] completed end 只在真实完成后显示 red flag
+- [ ] speed/altitude trends 有可读 X/Y context
+- [ ] altitude / ascent / descent truthfully available or unavailable
+- [ ] raw diagnostics 默认折叠
+- [ ] Dark / Light、320–360dp、fontScale 1.3 可用
 
-只有真机通过后，才可以关闭 #77/#78/#67 对应 acceptance；不能用 Android CI 直接替代。
+CI 不能替代上述物理设备结论。
 
 ---
 
-## 11. 实施顺序
+## 14. Future / evidence-driven only
 
-当前已完成代码主线：
+以下不属于当前 Trip v0.6 closeout blocker：
+
+### TripSpeedSegmentBuilder
+
+如果以后需要更稳定的区间分析，可研究 20–30 秒或 200–300 米窗口的 segment model：
+
+- start/end timestamp
+- distance
+- duration
+- averageSpeedKmh
+- optional min/max speed
+- quality / gap flag
+
+PR #85 的“相邻可信 GPS speed 上色”不是完整 segment analytics；两者边界必须继续保持。
+
+### Persistent reliability summary
+
+只有在真实故障分析证明需要时再考虑：
+
+- longest gap
+- provider switch count
+- rejected reason counters
+
+### MapLibre
+
+MapLibre 继续是可选 renderer：
+
+- 不阻塞当前 reliability
+- 不负责 road snapping
+- 不允许跨缺失数据补造路线
+
+---
+
+## 15. 实施历史
+
+当前主要代码链：
 
 ```text
-PR #36 GPS health / diagnostics / gap route split
+PR #36  GPS health / diagnostics / gap route split
   -> PR #80 callback liveness + stationary heartbeat enablement
   -> PR #82 trusted max-speed gate
-  -> PR #83 altitude / address / endpoint semantics
+  -> PR #83 altitude/address/endpoint foundation
   -> PR #85 trusted speed-colored route preview
+  -> PR #127 trusted elevation analysis
+  -> PR #158 / #170 v0.6 route/endpoint fidelity
+  -> PR #179 completed detail `概览` / `轨迹` / `数据`
 ```
 
-下一步：
+后台通知 / repair flow：
 
 ```text
-Physical acceptance #77/#78/#67/#66/#69/#42
-  -> longest gap/provider summary（必要时）
-  -> TripSpeedSegmentBuilder 长窗口分析（P1）
-  -> MapLibre renderer（P2，可选，不阻塞 reliability）
+PR #130 elapsed + trusted distance + Trip deep link
+  -> PR #131 provider/permission interruption repair
+  -> PR #132 Android 13+ non-blocking notification permission
 ```
-
-MapLibre 仍为低优先级，不应阻塞 P0 GPS reliability 和当前本地 Trip 体验收口。
 
 ---
 
-## 12. 变更记录
+## 16. 变更记录
+
+### v1.2.0
+
+- 将文档状态从 `Partially Implemented` 更新为 `Code Baseline Complete / Physical Acceptance Pending`。
+- 同步 #77 / PR #80：旧 8m callback gate 已不存在，剩余 ROM/background 真机验证。
+- 修正 #78 状态：max-speed trust gate 已完成，#78 已关闭，不再是 open acceptance owner。
+- 同步 #26：必要 notification / interruption / permission code 已由 #130/#131/#132 完成，剩余真机验收。
+- 同步 #66：coordinate-first / geocode cache-retry 已完成关闭，Location/Geocoder 真机验收归 #14。
+- 同步 #69 / PR #127：trusted cumulative ascent/descent 已实现，不再写成 future。
+- 同步 #67 / PR #85 Android CI `33086126816` Green，明确代码侧已完成、仅余 physical route fidelity。
+- 同步 Trip v0.6 `概览` / `轨迹` / `数据` 详情信息架构和 endpoint semantics。
 
 ### v1.1.0
 
-- 保留 Trip #7 第一轮十分钟级 GPS gap 历史证据。
-- 新增 2026-08-27 Trip #2 第二轮真机证据：后台切 App 空洞、红灯 stationary gap 风险、122.4 km/h network 假峰值、海拔/地址/marker/速度色轨反馈。
-- 同步 PR #80 callback-liveness 修复，并保留 #77 真机验收门。
-- 同步 PR #82 max-speed trusted GPS quality gate，并保留 #78 仪表对照验收门。
-- 同步 PR #83 Trip altitude/address/endpoint marker 实现。
-- 同步 PR #85 trusted GPS speed-colored route；两端都可信才上色，未知段灰色。
-- 明确完整 `TripSpeedSegmentBuilder` 尚未实现，不能把第一版 route visualization 写成完整 segment analytics。
-- 状态从 `Design / Future Implementation` 更新为 `Partially Implemented / Physical Acceptance Pending`。
+- 保留 Trip #7 与 2026-08-27 Trip #2 的历史可靠性证据。
+- 加入 callback/stationary、max-speed gate、altitude/address/marker、speed-colored route 第一轮实现状态。
 
 ### v1.0.0
 


### PR DESCRIPTION
## Summary

Reconcile `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` with the current Trip implementation and owning Issue states.

### Fix stale status
- mark the core reliability/speed code baseline as implemented with physical acceptance remaining
- record #77 / PR #80 callback + stationary heartbeat reality
- remove stale claim that #78 is still open; #78 is completed
- record #26 notification/interruption code as implemented, physical-only remaining
- record #66 coordinate-first/geocode code as completed; real-device Location/Geocoder remains #14
- record #69 / PR #127 trusted ascent/descent implementation
- record #67 / PR #85 trusted speed-colored route + Android CI run `33086126816`
- align endpoint and completed-detail semantics with Trip v0.6 / PR #179

### Scope
Docs only. No Android runtime, schema, tracking or analytics behavior changes.

Related: #6 #14 #26 #42 #67 #77 #145 #168 #178