### PR TITLE
fix(android): harden lock-screen trip GPS and unify endpoint flag

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripContinuityRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripContinuityRules.kt
@@ -11,7 +11,12 @@ data class TripContinuityDecision(
 object TripContinuityRules {
     const val LONG_GAP_SECONDS = 120L
     const val PROVIDER_DEDUP_SECONDS = 8L
-    const val MAX_LOCATION_AGE_MILLIS = 15_000L
+
+    // Some Android/OEM builds batch otherwise valid foreground-location callbacks while the screen
+    // is locked or the device enters a light idle state. Keep callback delivery tolerance wider
+    // than route continuity: the original capture timestamps still decide whether a segment can
+    // contribute distance/duration, and >= LONG_GAP_SECONDS remains a hard route break.
+    const val MAX_LOCATION_AGE_MILLIS = 10 * 60_000L
 
     fun isFreshLocation(ageMillis: Long): Boolean = ageMillis in 0..MAX_LOCATION_AGE_MILLIS
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -106,14 +106,6 @@ internal fun TripDetailScreenV06(
         null
     }
     val displayAverageSpeed = trip.averageSpeedMps ?: wholeTripAverageMps
-    val hasVehicleState = listOf(
-        trip.startSoc,
-        trip.endSoc,
-        trip.startMileageKm,
-        trip.endMileageKm,
-        trip.consumedEnergyKwh,
-        trip.averageConsumptionKwhPer100Km
-    ).any { it != null }
     val hasAltitude = elevationSummary != null || listOf(
         trip.startAltitudeMeters,
         trip.endAltitudeMeters,
@@ -171,8 +163,7 @@ internal fun TripDetailScreenV06(
                         CompletedTripSummaryCardV06(
                             trip = trip,
                             vehicle = vehicle,
-                            averageSpeedMps = displayAverageSpeed,
-                            hasVehicleState = hasVehicleState
+                            averageSpeedMps = displayAverageSpeed
                         )
                     }
                     item {
@@ -296,8 +287,7 @@ private fun DetailUnavailableCardV06(title: String, detail: String) {
 private fun CompletedTripSummaryCardV06(
     trip: TripSessionEntity,
     vehicle: VehicleEntity?,
-    averageSpeedMps: Double?,
-    hasVehicleState: Boolean
+    averageSpeedMps: Double?
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -352,14 +342,6 @@ private fun CompletedTripSummaryCardV06(
                     SummaryMetricV06("移动时间", trip.movingSeconds?.let(::formatV06Duration) ?: "--")
                 )
             )
-
-            if (hasVehicleState) {
-                Text(
-                    "SOC / 能耗沿用现有估算口径，非 BMS 实测；缺失、SOC 回升或无法可信计算时保持 --。",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         }
     }
 }
@@ -588,11 +570,14 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEnd
 
                 if (finalEndpoint) {
                     val poleHeight = 13.dp.toPx()
+                    val flagWidth = 9.dp.toPx()
+                    val flagHeight = 6.dp.toPx()
                     drawLine(endColor, end, Offset(end.x, end.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
                     val flag = Path().apply {
                         moveTo(end.x, end.y - poleHeight)
-                        lineTo(end.x + 9.dp.toPx(), end.y - poleHeight + 3.dp.toPx())
-                        lineTo(end.x, end.y - poleHeight + 6.dp.toPx())
+                        lineTo(end.x + flagWidth, end.y - poleHeight)
+                        lineTo(end.x + flagWidth, end.y - poleHeight + flagHeight)
+                        lineTo(end.x, end.y - poleHeight + flagHeight)
                         close()
                     }
                     drawPath(flag, endColor)

--- a/android/app/src/test/java/com/evchargebook/domain/TripContinuityRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripContinuityRulesTest.kt
@@ -48,8 +48,8 @@ class TripContinuityRulesTest {
     }
 
     @Test
-    fun `stale location age is rejected`() {
-        assertFalse(TripContinuityRules.isFreshLocation(15_001))
-        assertTrue(TripContinuityRules.isFreshLocation(15_000))
+    fun `lock screen delayed callback remains eligible within delivery grace`() {
+        assertTrue(TripContinuityRules.isFreshLocation(10 * 60_000L))
+        assertFalse(TripContinuityRules.isFreshLocation(10 * 60_000L + 1L))
     }
 }


### PR DESCRIPTION
## What changed

- tolerate delayed foreground-location callbacks for up to 10 minutes so screen-off / light-idle / OEM batching does not immediately discard otherwise valid historical GPS fixes
- keep the existing 120s continuity rule unchanged: delayed delivery does **not** make long gaps trustworthy or draw fake distance across them
- add regression coverage for the lock-screen callback delivery grace
- remove the verbose `SOC / 能耗沿用现有估算口径...` explanatory copy from Trip detail
- unify the completed Trip endpoint marker: endpoint card keeps the Material red flag and route Canvas now draws the same four-corner rectangular red flag instead of a triangular pennant

## Evidence

The 2026-08-29 physical-device screenshot still shows `2 个长缺口` after lock-screen use, which is new evidence for open issue #77. Current `main` already uses a 0m displacement gate, so this PR targets the remaining 15s callback-age rejection path rather than reverting to another sampling redesign.

## Safety boundary

- `LONG_GAP_SECONDS = 120` remains unchanged
- route gaps remain visually disconnected
- no synthetic GPS points are introduced
- no WorkManager / second tracking service / cloud tracking added

Refs #77 #26