### PR TITLE
docs: sync Trip completion authority after PR 189

### DIFF
--- a/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
+++ b/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
@@ -129,7 +129,7 @@ Add:
 
 # Trip v0.6 Approved Follow-up
 
-The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are tracked as correction slices instead of starting another redesign. A final code/design comparison also found that completed Trip detail was still one long scroll while the approved board used separate reading surfaces; #178 / PR #179 closes that information-architecture gap.
+The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are tracked as correction slices instead of starting another redesign. Completed Trip detail was subsequently split into separate reading surfaces by #178 / PR #179, and later device/static review produced two focused corrections: PR #184 for endpoint/reliability fidelity and #187 / PR #189 for completion narrow-width/IME accessibility.
 
 Authority: `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
 Owning issue: #145
@@ -152,8 +152,10 @@ Documentation owner: #6
 - [x] #173 — compact Trip completion form + remove redundant intermediate confirmation — PR #174
 - [x] #175 — split Trip home/history from READY preparation — PR #176
 - [x] #178 — split completed Trip detail into `概览` / `轨迹` / `数据` supported sections — PR #179, merged as `88e1e2b`, Android CI run `33198331727` Green
+- [x] PR #184 — completed route endpoint converged on the compact four-corner red flag; redundant long SOC/energy helper copy removed; delayed callback reliability fix kept separate from UI acceptance — merged as `bae3a21`, Android CI run `33229162800` Green
+- [x] #187 / PR #189 — completion dialog responsive evidence layout, IME/large-text scrollability and >=48dp continue/save actions — merged as `536fc80`, Android CI run `33236915039` Green
 
-Code-side Trip v0.6 work above is in `main`. These Issues remain open only where their explicit physical-device checks are still pending.
+Current Trip code baseline is in `main` through `536fc80`. These Issues remain open only where their explicit physical-device checks are still pending.
 
 ## Completed Trip detail section ownership
 
@@ -178,8 +180,12 @@ The selected/completed Trip no longer stacks all supporting evidence into one lo
 - do not invent GPS readiness/accuracy before a real sample exists
 - slide progress keeps a rounded capsule edge at every drag position
 - slide-to-end goes directly to one explicit completion form; do not stack a redundant generic alert
+- completion validation / `TripEnergyCalculator` remain business-authority behavior, not UI-derived logic
+- completion width <380dp or fontScale >=1.3 uses a compact evidence layout instead of squeezing three facts into one row
+- completion compact mode stacks `继续行驶` / `保存并结束`; both keep >=48dp height
+- completion body remains vertically scrollable under keyboard/IME or large-text pressure
 - start marker uses a compact green start/play shape
-- completed end marker uses a compact red flag without outer ring
+- completed end marker uses the same compact four-corner red-flag visual language in endpoint card and route
 - active latest point stays green and is not described as a completed endpoint
 - raw GPS point lists are secondary troubleshooting UI, not default detail content
 - speed and altitude trends include sparse axis context and omit unavailable/untrustworthy data
@@ -193,11 +199,12 @@ Remaining work is physical, not another broad code rewrite:
 1. Trip home/history — latest summary, 5+ rows, address truncation
 2. READY — back/start behavior, compact GPS truth, slide gesture
 3. Active — live route, current speed, trends, interrupted state
-4. Completion — keyboard/IME, 320–360dp, fontScale 1.3, continue/save safety
+4. Completion — normal-width visual hierarchy plus 320–360dp / fontScale 1.3+ / keyboard-IME reachability; `继续行驶` must not end the Trip and only valid `保存并结束` may stop it
 5. Completed detail `概览` — endpoint card and metric hierarchy
-6. Route `轨迹` — real geometry, start/end/current marker semantics, LONG_GAP discontinuity, trusted trends
+6. Route `轨迹` — real geometry, unified four-corner completed endpoint, start/current marker semantics, LONG_GAP discontinuity, trusted trends
 7. Data `数据` — altitude/reliability evidence, collapsed diagnostics, `查看轨迹点` explicit
 8. Detail tabs — switching remains readable and stable on 320–360dp / fontScale 1.3
 9. Dark/Light — shared-theme contrast/readability where supported
+10. #77 separately revalidates post-#184 lock-screen/background callback reliability; CI or UI acceptance must not close it
 
-Do not close #145 from CI alone. Use the latest Debug APK from `main` for the final physical comparison against the approved v0.6 board.
+Do not close #145 from CI alone. Use the latest Debug APK from current `main` for the final physical comparison against the approved v0.6 board.

--- a/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
+++ b/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
@@ -1,6 +1,6 @@
 # EV Charge Book Trip v0.6 Approved UI Baseline
 
-Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison, completed-detail information-architecture correction, and post-lock-screen endpoint fidelity cleanup.
+Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison, completed-detail information-architecture correction, post-lock-screen endpoint fidelity cleanup, and narrow-width/IME completion hardening.
 
 Owning issue: #145
 
@@ -17,8 +17,10 @@ Current Trip UI/runtime baseline in `main` includes:
 - PR #179 / `88e1e2b`: completed detail split into `概览` / `轨迹` / `数据`
 - PR #184 / `bae3a21`: delayed lock-screen callback handling, completed endpoint route flag changed to the compact four-corner red flag, and redundant long SOC/energy helper copy removed while `估算能耗` remains explicit
 - PR #185 / `5e27203`: post-#184 reliability/Roadmap documentation synchronization
+- PR #186 / `3433492`: Trip v0.6 UI authority synchronized after #184
+- PR #189 / `536fc80`: completion dialog narrow-width/fontScale/IME hardening
 
-Android CI run `33229162800` was Green for PR #184.
+Android CI run `33229162800` was Green for PR #184. Android CI run `33236915039` was Green for PR #189.
 
 The runtime reliability change in PR #184 is accepted only at code/CI level. Real-device lock-screen/background revalidation remains owned by #77 and must not be inferred from UI completion.
 
@@ -227,7 +229,7 @@ Rules:
 
 Physical comparison against approved detail-board screens remains required before final UI acceptance.
 
-## Completion flow — #173
+## Completion flow — #173 / #187
 
 The final completion form is part of the Trip interaction language even though it is not one of the six browsing surfaces.
 
@@ -246,6 +248,13 @@ Rules:
 - existing start-mileage + GPS-distance prefill may remain, but is editable
 - estimate remains clearly non-BMS
 - dismiss / continue never ends the Trip
+- width <380dp or fontScale >=1.3 switches to the compact evidence layout: GPS distance + start SOC on the first row, start mileage on its own row
+- normal-width layout keeps the established three-fact evidence hierarchy
+- compact mode stacks `继续行驶` and `保存并结束` instead of squeezing the labels side-by-side
+- both actions retain >=48dp height
+- dialog content is vertically scrollable so IME or large text cannot permanently hide actions
+
+PR #189 implements the responsive/IME hardening above without changing completion validation, `TripEnergyCalculator`, persistence or tracking behavior.
 
 ## System inset ownership
 
@@ -324,6 +333,8 @@ Physical-device corrections:
 - #178 / PR #179 — split completed Trip detail into `概览` / `轨迹` / `数据` supported surfaces; Android CI Green
 - #77 / PR #184 — delayed lock-screen callback grace plus completed-route four-corner endpoint flag and removal of redundant SOC/energy helper copy; Android CI `33229162800` Green; merged as `bae3a21`
 - PR #185 — synchronize post-#184 reliability boundary and Roadmap; merged as `5e27203`
+- PR #186 — synchronize post-#184 Trip UI authority; merged as `3433492`
+- #187 / PR #189 — narrow-width/fontScale/IME completion hardening; Android CI `33236915039` Green; merged as `536fc80`
 
 #152 remains the future destination-selection capability and is not part of v0.6.
 
@@ -343,7 +354,7 @@ Final closure of #145 requires one physical-device pass across:
 1. Trip home/history
 2. READY preparation
 3. active cockpit
-4. completion form
+4. completion form at normal width and 320–360dp/fontScale 1.3+, including keyboard/IME action reachability
 5. completed overview / `概览`
 6. route / `轨迹`, including unified compact four-corner completed red flag
 7. speed + altitude trends
@@ -351,6 +362,6 @@ Final closure of #145 requires one physical-device pass across:
 9. detail-section switching and truthful unavailable states
 10. Dark / Light readability where the shared theme supports both
 
-Also verify 320–360dp width and fontScale 1.3 before declaring UI acceptance complete.
+Also verify 320–360dp width and fontScale 1.3 across the rest of Trip before declaring UI acceptance complete.
 
 Separately, #77 must pass a post-#184 real-device drive covering lock screen, another app in foreground for 5–10 minutes, 2–3 minutes stationary, resumed driving, real LONG_GAP behavior and stationary write throttling.


### PR DESCRIPTION
## Summary

Synchronize the two Trip UI authority documents with the latest `main` completion baseline from #187 / PR #189.

- record `536fc80` as the latest Trip code baseline
- record Android CI run `33236915039` Green
- document `<380dp` / fontScale >=1.3 responsive evidence layout
- document vertical scrolling under IME/large-text pressure
- document stacked compact actions and >=48dp action height
- preserve existing completion validation, `TripEnergyCalculator`, non-BMS estimate semantics and physical-only acceptance boundary

Docs only; no runtime behavior changes.

Related: #6 #42 #145 #173 #187