### PR TITLE
ui: harden Trip home summary and completion helper copy

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -1,6 +1,7 @@
 package com.evchargebook.ui.trip
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -37,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
@@ -263,20 +265,33 @@ private fun LatestTripSummaryV06(trip: TripSessionEntity, onClick: () -> Unit) {
                 Text("已完成", style = MaterialTheme.typography.labelSmall, color = accent)
             }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-            ) {
-                HomeMetricV06("距离", formatHomeDistance(trip.distanceMeters), Modifier.weight(1f))
-                HomeMetricV06("耗时", formatHomeDuration(trip.elapsedSeconds), Modifier.weight(1f))
-                HomeMetricV06(
-                    "能耗",
-                    trip.averageConsumptionKwhPer100Km
-                        ?.takeIf { it.isFinite() && it >= 0.0 }
-                        ?.let { String.format(Locale.US, "%.1f", it) }
-                        ?: "--",
-                    Modifier.weight(1f)
-                )
+            val energyText = trip.averageConsumptionKwhPer100Km
+                ?.takeIf { it.isFinite() && it >= 0.0 }
+                ?.let { String.format(Locale.US, "%.1f", it) }
+                ?: "--"
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val compact = maxWidth < 360.dp || LocalConfiguration.current.fontScale >= 1.3f
+                if (compact) {
+                    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                        ) {
+                            HomeMetricV06("距离", formatHomeDistance(trip.distanceMeters), Modifier.weight(1f))
+                            HomeMetricV06("耗时", formatHomeDuration(trip.elapsedSeconds), Modifier.weight(1f))
+                        }
+                        HomeMetricV06("能耗", energyText, Modifier.fillMaxWidth())
+                    }
+                } else {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                    ) {
+                        HomeMetricV06("距离", formatHomeDistance(trip.distanceMeters), Modifier.weight(1f))
+                        HomeMetricV06("耗时", formatHomeDuration(trip.elapsedSeconds), Modifier.weight(1f))
+                        HomeMetricV06("能耗", energyText, Modifier.weight(1f))
+                    }
+                }
             }
 
             val socText = when {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -226,7 +226,7 @@ fun TripScreen(
                     releaseLabel = "松开结束"
                 )
                 Text(
-                    "滑动后确认结束状态；取消时行程继续记录。",
+                    "滑动后直接进入结束信息填写；选择继续行驶时保持记录。",
                     modifier = Modifier.padding(top = 6.dp),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
## Summary

Implements #194 as a small Trip v0.6 hardening slice found during accessibility/narrow-width audit.

- make the Trip home `最近一次` metric group responsive at <360dp or fontScale >=1.3
- keep distance + duration first and move energy to its own row in compact mode
- keep the existing three-column layout on normal widths
- replace stale active helper copy that could imply a second generic confirmation step
- preserve all Trip persistence, tracking, validation and energy-calculation behavior

## Acceptance

- [x] no typography shrinking
- [x] no schema/repository/tracking changes
- [x] current single completion-form semantics reflected in copy
- [ ] Android CI Green
- [ ] physical 320–360dp / fontScale confirmation remains under #145/#42

Related: #42 #145 #173 #187 #194