### PR TITLE
docs: sync Trip authority after PR 195

### DIFF
--- a/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
+++ b/docs/EVChargeBook_UI_Redesign_Task_Breakdown.md
@@ -63,12 +63,12 @@ Main v0.5 differentiating page
 
 Requirements:
 
-- Route map card
-- Start and destination
+- truthful recorded route surface
+- recorded start and completed end/current-point semantics; no pre-trip destination assumption
 - Distance
 - Duration
 - Average speed
-- Energy consumption
+- Energy consumption estimate when trustworthy
 - Recent trips list
 
 ## Phase P1 - Information Enhancement
@@ -129,7 +129,7 @@ Add:
 
 # Trip v0.6 Approved Follow-up
 
-The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are tracked as correction slices instead of starting another redesign. Completed Trip detail was subsequently split into separate reading surfaces by #178 / PR #179, and later device/static review produced two focused corrections: PR #184 for endpoint/reliability fidelity and #187 / PR #189 for completion narrow-width/IME accessibility.
+The 2026-08-28 Trip design review approved a denser Trip-specific refinement of the v0.5 Dark First system. The 2026-08-29 device comparison then exposed concrete fidelity regressions; those are tracked as correction slices instead of starting another redesign. Completed Trip detail was subsequently split into separate reading surfaces by #178 / PR #179. Later device/static review produced focused corrections: PR #184 for endpoint/reliability fidelity, #187 / PR #189 for completion narrow-width/IME accessibility, and #194 / PR #195 for the Trip-home latest-summary narrow-width layout plus stale completion helper copy.
 
 Authority: `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
 Owning issue: #145
@@ -154,8 +154,9 @@ Documentation owner: #6
 - [x] #178 — split completed Trip detail into `概览` / `轨迹` / `数据` supported sections — PR #179, merged as `88e1e2b`, Android CI run `33198331727` Green
 - [x] PR #184 — completed route endpoint converged on the compact four-corner red flag; redundant long SOC/energy helper copy removed; delayed callback reliability fix kept separate from UI acceptance — merged as `bae3a21`, Android CI run `33229162800` Green
 - [x] #187 / PR #189 — completion dialog responsive evidence layout, IME/large-text scrollability and >=48dp continue/save actions — merged as `536fc80`, Android CI run `33236915039` Green
+- [x] #194 / PR #195 — Trip-home `最近一次` summary becomes responsive at width <360dp or fontScale >=1.3; active helper copy now reflects the single completion-form flow — merged as `8a895bc`, Android Build run `33240198841` Green
 
-Current Trip code baseline is in `main` through `536fc80`. These Issues remain open only where their explicit physical-device checks are still pending.
+Current Trip code baseline is in `main` through `8a895bc`. These Issues remain open only where their explicit physical-device checks are still pending; #194 is closed because its physical checks are shared by #145/#146/#42.
 
 ## Completed Trip detail section ownership
 
@@ -178,8 +179,10 @@ The selected/completed Trip no longer stacks all supporting evidence into one lo
 - no destination selector until the product actually owns destination planning
 - Trip home/history and READY preparation are separate interaction states
 - do not invent GPS readiness/accuracy before a real sample exists
+- Trip-home latest summary uses a compact two-primary-facts + energy row layout at width <360dp or fontScale >=1.3; normal width keeps the established three-column hierarchy
 - slide progress keeps a rounded capsule edge at every drag position
 - slide-to-end goes directly to one explicit completion form; do not stack a redundant generic alert
+- helper copy must describe the direct completion-form flow and must not imply a second confirmation dialog
 - completion validation / `TripEnergyCalculator` remain business-authority behavior, not UI-derived logic
 - completion width <380dp or fontScale >=1.3 uses a compact evidence layout instead of squeezing three facts into one row
 - completion compact mode stacks `继续行驶` / `保存并结束`; both keep >=48dp height
@@ -192,13 +195,20 @@ The selected/completed Trip no longer stacks all supporting evidence into one lo
 - long GPS gaps remain disconnected
 - nested Trip Scaffolds must not double-apply the root system-bar inset
 
+## Post-v0.6 enhancements — not current blockers
+
+- #192 — optional interactive map context / pan / zoom / road-name provider work
+- #193 — truthful trajectory playback
+
+These are future presentation enhancements. They must not delay #145 closure, #77 reliability revalidation, or turn the current v0.6 closeout into a MapLibre/playback project.
+
 ## Current acceptance gate
 
 Remaining work is physical, not another broad code rewrite:
 
-1. Trip home/history — latest summary, 5+ rows, address truncation
+1. Trip home/history — latest summary responsive behavior, 5+ rows, address truncation
 2. READY — back/start behavior, compact GPS truth, slide gesture
-3. Active — live route, current speed, trends, interrupted state
+3. Active — live route, current speed, trends, interrupted state, direct completion helper wording
 4. Completion — normal-width visual hierarchy plus 320–360dp / fontScale 1.3+ / keyboard-IME reachability; `继续行驶` must not end the Trip and only valid `保存并结束` may stop it
 5. Completed detail `概览` — endpoint card and metric hierarchy
 6. Route `轨迹` — real geometry, unified four-corner completed endpoint, start/current marker semantics, LONG_GAP discontinuity, trusted trends

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # EV Charge Book Roadmap
 
-版本: v2.8.1
+版本: v2.8.2
 更新时间: 2026-08-29
 
 ## 0. 路线原则
@@ -178,7 +178,9 @@ Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
 - [x] READY / active / completion density and interaction corrections（PR #170 / #172 / #174）
 - [x] completed Trip detail 分为 `概览` / `轨迹` / `数据`（#178 / PR #179，Android CI run `33198331727` Green）
 - [x] completed route endpoint red-flag visual language further unified by PR #184
-- [x] Trip v0.6 authority docs synchronized through PR #180
+- [x] completion narrow-width/fontScale/IME hardening merged by #187 / PR #189（Android CI run `33236915039` Green）
+- [x] Trip-home latest-summary narrow-width/fontScale hardening + completion helper copy alignment merged by #194 / PR #195 as `8a895bc`（Android Build run `33240198841` Green）
+- [x] Trip v0.6 authority docs synchronized through PR #191; post-#195 authority synchronization is part of the current documentation closeout
 
 ### VehicleState / SOC / mileage
 
@@ -202,7 +204,7 @@ Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
 - [x] successful geocode process-local bounded cache
 - [x] failed / blank geocode 不缓存，允许真实 retry（#129）
 
-真机权限 / Geocoder / restore 验收仍由 #14 保留。
+#14 已收窄为 Location / Geocoder / backup restore 真机验收；交互地图增强由 #192 独立跟踪，不再作为 #14 或 #145 blocker。
 
 ### Lock-screen / background notification
 
@@ -229,17 +231,21 @@ Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
 
 - #145 Trip v0.6 parent physical matrix
 - #168 Trip device-fidelity correction acceptance
+- #146 Trip home/history + latest-summary narrow-width acceptance
+- #173/#187 completion normal width / 320–360dp / fontScale / IME acceptance
 - #178 completed-detail tabs / 320–360dp / fontScale 1.3 / Dark-Light comparison
 - #70 五个一级页面 + Light mode
 - #94 Dashboard Hero
 - #95 recent Trip card
 - #42 accessibility / large font / small screen / active-Trip state safety
 - #22 top spacing / density
-- #14 Location / Geocoder
+- #14 Location / Geocoder / backup restore
 - #77 post-#184 lock-screen / delayed callback / stationary hold
 - #124 Trip SOC -> VehicleState
 - #26 lock-screen / repair notifications
 - #102 release APK updater
+
+#192 interactive map context and #193 truthful trajectory playback are post-v0.6 enhancements. They do not block this physical closeout.
 
 ---
 
@@ -270,24 +276,34 @@ Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
 
 ```text
 v0.5 physical acceptance bundle
-  -> #145 / #168 / #178 Trip v0.6 design-device comparison
+  -> #145 / #168 / #146 / #173 / #187 / #178 Trip v0.6 design-device comparison
   -> #77 post-#184 lock-screen / delayed callback / stationary reliability revalidation
   -> #124 Trip SOC -> VehicleState
   -> #26 lock-screen + repair notification
-  -> #14 Location / Geocoder
+  -> #14 Location / Geocoder / backup restore
   -> #70 / #94 / #95 / #42 / #22 remaining UI-device checks
   -> #102 old-production -> new-production updater flow
   -> only fix concrete device regressions
   -> resume #27 minimal Local First sync protocol/runtime
   -> advance #20 catalog pipeline when source/coverage work is justified
+  -> evaluate #192 / #193 only after current Trip closeout and only when map/playback product value is justified
   -> P3 OBD-II optional PoC only when product value justifies it
 ```
 
-MapLibre 继续保持低优先级；当前已有真实 WGS84 route preview，不为了“看起来完整”提前引入地图 SDK。
+当前已有真实 WGS84 no-basemap route preview。#192 可探索交互地图/道路上下文，#193 可探索真实轨迹回放，但两者都保持 post-v0.6、非 blocker；不为了“看起来完整”提前绑定地图 SDK 或回放架构。
 
 ---
 
 ## 变更记录
+
+### v2.8.2
+
+- recorded #187 / PR #189 completion narrow-width/fontScale/IME hardening and Android CI `33236915039` Green
+- recorded #194 / PR #195 Trip-home latest-summary responsive layout and completion helper-copy alignment; Android Build `33240198841` Green; merged as `8a895bc`
+- moved #14 to Location / Geocoder / backup-restore physical acceptance only; map rendering ownership moved to #192
+- classified #192 interactive map context and #193 trajectory playback as post-v0.6, non-blocking enhancements
+- updated Trip physical closeout owners to include #146 and #173/#187 explicitly
+- synchronized direct Trip UI authority to the post-#195 code baseline
 
 ### v2.8.1
 

--- a/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
+++ b/docs/TRIP_V0.6_APPROVED_UI_BASELINE.md
@@ -1,6 +1,6 @@
 # EV Charge Book Trip v0.6 Approved UI Baseline
 
-Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison, completed-detail information-architecture correction, post-lock-screen endpoint fidelity cleanup, and narrow-width/IME completion hardening.
+Status: approved visual / interaction baseline from 2026-08-28 review, refined by the 2026-08-29 physical-device comparison, completed-detail information-architecture correction, post-lock-screen endpoint fidelity cleanup, completion narrow-width/IME hardening, and Trip-home narrow-width hardening.
 
 Owning issue: #145
 
@@ -19,8 +19,10 @@ Current Trip UI/runtime baseline in `main` includes:
 - PR #185 / `5e27203`: post-#184 reliability/Roadmap documentation synchronization
 - PR #186 / `3433492`: Trip v0.6 UI authority synchronized after #184
 - PR #189 / `536fc80`: completion dialog narrow-width/fontScale/IME hardening
+- PR #191 / `8d2d828`: Trip UI authority synchronized after #189
+- PR #195 / `8a895bc`: Trip-home latest-summary narrow-width/fontScale hardening + completion helper copy aligned with the single completion-form flow
 
-Android CI run `33229162800` was Green for PR #184. Android CI run `33236915039` was Green for PR #189.
+Android CI run `33229162800` was Green for PR #184. Android CI run `33236915039` was Green for PR #189. Android Build run `33240198841` was Green for PR #195, including tests and Debug APK upload.
 
 The runtime reliability change in PR #184 is accepted only at code/CI level. Real-device lock-screen/background revalidation remains owned by #77 and must not be inferred from UI completion.
 
@@ -61,7 +63,7 @@ Completed Trips may show the recorded end address when available. Coordinate fal
 
 ## Six implementation surfaces
 
-### 1. Trip home / history — #146, #175
+### 1. Trip home / history — #146, #175, #194
 
 Goal: make the Trip landing page compact and immediately useful.
 
@@ -84,6 +86,11 @@ Rules:
 - avoid decorative status cards
 - do not expose raw GPS diagnostics in the list
 - use only persisted completed-Trip facts in the latest summary
+- when width is <360dp or fontScale >=1.3, the latest-summary metric group keeps distance + duration on the first row and moves energy to its own row
+- normal-width latest summary keeps the established three-column layout
+- do not shrink typography merely to keep three metrics on one row
+
+PR #195 implements the latest-summary responsive rule above without changing Trip persistence or calculations.
 
 ### 2. READY / preparation — #147, #171, #175
 
@@ -140,8 +147,12 @@ Interaction:
 
 - restrained slide-to-end control
 - the slide opens the final completion surface directly; do not stack a redundant generic confirmation alert in between
-- preserve existing interrupted / pause / resume semantics
+- helper copy must describe that direct completion-form flow and must not imply that a second generic confirmation appears after the slide
+- `继续行驶` keeps the Trip active; only valid save/finish ends it
+- preserve existing interrupted / resume semantics
 - no selected-destination implication while the Trip is active
+
+PR #195 aligns the active helper copy with this existing interaction behavior; it does not alter stop/validation semantics.
 
 ### 4. Completed Trip overview — #149
 
@@ -314,6 +325,16 @@ Post-PR #184 reliability boundary:
 
 The post-#184 physical drive remains tracked by #77; CI Green does not close that acceptance.
 
+## Post-v0.6 enhancements — not blockers
+
+The following are intentionally outside current v0.6 closeout:
+
+- #152 — destination selection / pre-trip endpoint planning
+- #192 — interactive map context, pan/zoom and optional road-name/basemap provider work
+- #193 — truthful trajectory playback
+
+They must not delay #145 closure or #77 reliability revalidation. Current v0.6 remains valid with the truthful no-basemap route renderer.
+
 ## Implementation history
 
 Original slices:
@@ -324,7 +345,7 @@ Original slices:
 4. #149/#150 / PR #158 — completed overview + route markers
 5. #151 / PR #161 — diagnostics + trends
 
-Physical-device corrections:
+Physical-device / static-review corrections:
 
 - #168 / PR #170 — rounded slider progress, labeled trends, history density, inset ownership, recording endpoint semantics
 - #171 / PR #172 — compact READY information group + active metric de-duplication
@@ -335,8 +356,8 @@ Physical-device corrections:
 - PR #185 — synchronize post-#184 reliability boundary and Roadmap; merged as `5e27203`
 - PR #186 — synchronize post-#184 Trip UI authority; merged as `3433492`
 - #187 / PR #189 — narrow-width/fontScale/IME completion hardening; Android CI `33236915039` Green; merged as `536fc80`
-
-#152 remains the future destination-selection capability and is not part of v0.6.
+- PR #191 — synchronize Trip authority after #189; merged as `8d2d828`
+- #194 / PR #195 — Trip-home latest-summary responsive layout + active completion helper copy alignment; Android Build `33240198841` Green; merged as `8a895bc`
 
 ## Acceptance gate
 
@@ -351,9 +372,9 @@ Every implementation PR requires:
 
 Final closure of #145 requires one physical-device pass across:
 
-1. Trip home/history
+1. Trip home/history, including latest-summary compact layout on 320–360dp/fontScale 1.3+
 2. READY preparation
-3. active cockpit
+3. active cockpit, including direct completion helper wording
 4. completion form at normal width and 320–360dp/fontScale 1.3+, including keyboard/IME action reachability
 5. completed overview / `概览`
 6. route / `轨迹`, including unified compact four-corner completed red flag


### PR DESCRIPTION
## Summary

Synchronize Trip authority after #194 / PR #195 and reconcile the new map/playback follow-ups with the current v0.6 closeout boundary.

- record PR #195 / `8a895bc` and Android Build `33240198841` Green
- document the Trip-home `<360dp` / fontScale >=1.3 latest-summary layout
- align active completion helper wording with the existing single completion-form flow
- remove the stale generic `Start and destination` assumption from the old Trip task summary
- advance Roadmap to v2.8.2
- move #14 to Location/Geocoder physical acceptance only
- classify #192 interactive map context and #193 trajectory playback as post-v0.6, non-blocking enhancements
- keep #77 reliability revalidation separate from UI acceptance

Docs only; no runtime behavior changes.

Related: #6 #14 #42 #145 #146 #168 #173 #178 #187 #192 #193 #194