### PR TITLE
feat(android): add truthful Trip playback timeline engine

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripPlaybackTimeline.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripPlaybackTimeline.kt
@@ -1,0 +1,165 @@
+package com.evchargebook.domain
+
+import kotlin.math.max
+
+/**
+ * Renderer-independent playback sample built from persisted TripPoint timestamps.
+ *
+ * The playback layer may interpolate only inside a short real interval. A real
+ * LONG_GAP remains a hard discontinuity and is never bridged as continuous movement.
+ */
+data class TripPlaybackSample(
+    val capturedAtEpochMillis: Long,
+    val latitude: Double,
+    val longitude: Double,
+    val bearingDegrees: Double? = null
+)
+
+data class TripPlaybackFrame(
+    val elapsedMillis: Long,
+    val totalMillis: Long,
+    val currentSampleIndex: Int,
+    val nextSampleIndex: Int?,
+    val latitude: Double,
+    val longitude: Double,
+    val bearingDegrees: Double?,
+    val segmentFraction: Double,
+    val isLongGap: Boolean,
+    val longGapStartElapsedMillis: Long? = null,
+    val longGapEndElapsedMillis: Long? = null
+)
+
+object TripPlaybackTimeline {
+    val speedPresets: List<Float> = listOf(1f, 2f, 4f, 8f)
+
+    fun durationMillis(samples: List<TripPlaybackSample>): Long {
+        if (!isChronological(samples) || samples.size < 2) return 0L
+        return max(0L, samples.last().capturedAtEpochMillis - samples.first().capturedAtEpochMillis)
+    }
+
+    fun frameAt(
+        samples: List<TripPlaybackSample>,
+        requestedElapsedMillis: Long
+    ): TripPlaybackFrame? {
+        if (samples.isEmpty() || !isChronological(samples)) return null
+
+        val startTime = samples.first().capturedAtEpochMillis
+        val totalMillis = durationMillis(samples)
+        val elapsedMillis = requestedElapsedMillis.coerceIn(0L, totalMillis)
+        val targetTime = startTime + elapsedMillis
+
+        if (samples.size == 1 || elapsedMillis == 0L) {
+            return frameAtSample(samples, 0, elapsedMillis, totalMillis)
+        }
+
+        if (elapsedMillis >= totalMillis) {
+            return frameAtSample(samples, samples.lastIndex, totalMillis, totalMillis)
+        }
+
+        for (index in 0 until samples.lastIndex) {
+            val current = samples[index]
+            val next = samples[index + 1]
+
+            if (targetTime == next.capturedAtEpochMillis) {
+                return frameAtSample(samples, index + 1, elapsedMillis, totalMillis)
+            }
+            if (targetTime > next.capturedAtEpochMillis) continue
+
+            val deltaMillis = next.capturedAtEpochMillis - current.capturedAtEpochMillis
+            if (deltaMillis <= 0L) {
+                return frameAtSample(samples, index, elapsedMillis, totalMillis)
+            }
+
+            val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+            if (deltaMillis >= longGapMillis) {
+                return TripPlaybackFrame(
+                    elapsedMillis = elapsedMillis,
+                    totalMillis = totalMillis,
+                    currentSampleIndex = index,
+                    nextSampleIndex = index + 1,
+                    latitude = current.latitude,
+                    longitude = current.longitude,
+                    bearingDegrees = current.bearingDegrees,
+                    segmentFraction = 0.0,
+                    isLongGap = true,
+                    longGapStartElapsedMillis = current.capturedAtEpochMillis - startTime,
+                    longGapEndElapsedMillis = next.capturedAtEpochMillis - startTime
+                )
+            }
+
+            val fraction = ((targetTime - current.capturedAtEpochMillis).toDouble() / deltaMillis.toDouble())
+                .coerceIn(0.0, 1.0)
+            return TripPlaybackFrame(
+                elapsedMillis = elapsedMillis,
+                totalMillis = totalMillis,
+                currentSampleIndex = index,
+                nextSampleIndex = index + 1,
+                latitude = lerp(current.latitude, next.latitude, fraction),
+                longitude = lerp(current.longitude, next.longitude, fraction),
+                bearingDegrees = interpolateBearing(current.bearingDegrees, next.bearingDegrees, fraction),
+                segmentFraction = fraction,
+                isLongGap = false
+            )
+        }
+
+        return frameAtSample(samples, samples.lastIndex, elapsedMillis, totalMillis)
+    }
+
+    fun advanceElapsed(
+        currentElapsedMillis: Long,
+        realDeltaMillis: Long,
+        speedMultiplier: Float,
+        totalMillis: Long
+    ): Long {
+        if (totalMillis <= 0L) return 0L
+        val safeSpeed = speedMultiplier.takeIf { it.isFinite() && it > 0f } ?: 1f
+        val safeDelta = realDeltaMillis.coerceAtLeast(0L)
+        val advanced = currentElapsedMillis.toDouble() + safeDelta.toDouble() * safeSpeed.toDouble()
+        return advanced.toLong().coerceIn(0L, totalMillis)
+    }
+
+    fun isChronological(samples: List<TripPlaybackSample>): Boolean =
+        samples.zipWithNext().all { (current, next) ->
+            next.capturedAtEpochMillis >= current.capturedAtEpochMillis
+        }
+
+    private fun frameAtSample(
+        samples: List<TripPlaybackSample>,
+        index: Int,
+        elapsedMillis: Long,
+        totalMillis: Long
+    ): TripPlaybackFrame {
+        val sample = samples[index]
+        return TripPlaybackFrame(
+            elapsedMillis = elapsedMillis,
+            totalMillis = totalMillis,
+            currentSampleIndex = index,
+            nextSampleIndex = samples.getOrNull(index + 1)?.let { index + 1 },
+            latitude = sample.latitude,
+            longitude = sample.longitude,
+            bearingDegrees = sample.bearingDegrees,
+            segmentFraction = 0.0,
+            isLongGap = false
+        )
+    }
+
+    private fun lerp(start: Double, end: Double, fraction: Double): Double =
+        start + (end - start) * fraction
+
+    private fun interpolateBearing(start: Double?, end: Double?, fraction: Double): Double? {
+        if (start == null && end == null) return null
+        if (start == null) return end
+        if (end == null) return start
+        if (!start.isFinite() || !end.isFinite()) return start.takeIf { it.isFinite() } ?: end.takeIf { it.isFinite() }
+
+        val normalizedStart = normalizeDegrees(start)
+        val normalizedEnd = normalizeDegrees(end)
+        val delta = ((normalizedEnd - normalizedStart + 540.0) % 360.0) - 180.0
+        return normalizeDegrees(normalizedStart + delta * fraction)
+    }
+
+    private fun normalizeDegrees(value: Double): Double {
+        val normalized = value % 360.0
+        return if (normalized < 0.0) normalized + 360.0 else normalized
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripPlaybackTimelineTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripPlaybackTimelineTest.kt
@@ -1,0 +1,145 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripPlaybackTimelineTest {
+    @Test
+    fun `short interval interpolates between real samples`() {
+        val samples = listOf(
+            sample(time = 1_000L, latitude = 30.0, longitude = 120.0, bearing = 350.0),
+            sample(time = 11_000L, latitude = 31.0, longitude = 121.0, bearing = 10.0)
+        )
+
+        val frame = TripPlaybackTimeline.frameAt(samples, 5_000L)!!
+
+        assertFalse(frame.isLongGap)
+        assertEquals(0, frame.currentSampleIndex)
+        assertEquals(1, frame.nextSampleIndex)
+        assertEquals(30.5, frame.latitude, 0.000001)
+        assertEquals(120.5, frame.longitude, 0.000001)
+        assertEquals(0.5, frame.segmentFraction, 0.000001)
+        assertEquals(0.0, frame.bearingDegrees!!, 0.000001)
+    }
+
+    @Test
+    fun `elapsed time clamps to start and end`() {
+        val samples = listOf(
+            sample(time = 1_000L, latitude = 30.0, longitude = 120.0),
+            sample(time = 6_000L, latitude = 31.0, longitude = 121.0)
+        )
+
+        val before = TripPlaybackTimeline.frameAt(samples, -500L)!!
+        val after = TripPlaybackTimeline.frameAt(samples, 50_000L)!!
+
+        assertEquals(0L, before.elapsedMillis)
+        assertEquals(30.0, before.latitude, 0.0)
+        assertEquals(5_000L, after.elapsedMillis)
+        assertEquals(31.0, after.latitude, 0.0)
+        assertEquals(1, after.currentSampleIndex)
+    }
+
+    @Test
+    fun `long gap never interpolates across missing interval`() {
+        val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+        val samples = listOf(
+            sample(time = 10_000L, latitude = 30.0, longitude = 120.0),
+            sample(time = 10_000L + longGapMillis + 30_000L, latitude = 31.0, longitude = 121.0)
+        )
+
+        val frame = TripPlaybackTimeline.frameAt(samples, 60_000L)!!
+
+        assertTrue(frame.isLongGap)
+        assertEquals(30.0, frame.latitude, 0.0)
+        assertEquals(120.0, frame.longitude, 0.0)
+        assertEquals(0.0, frame.segmentFraction, 0.0)
+        assertEquals(0L, frame.longGapStartElapsedMillis)
+        assertEquals(longGapMillis + 30_000L, frame.longGapEndElapsedMillis)
+    }
+
+    @Test
+    fun `exact next timestamp after long gap jumps to real sample`() {
+        val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+        val samples = listOf(
+            sample(time = 10_000L, latitude = 30.0, longitude = 120.0),
+            sample(time = 10_000L + longGapMillis, latitude = 31.0, longitude = 121.0)
+        )
+
+        val frame = TripPlaybackTimeline.frameAt(samples, longGapMillis)!!
+
+        assertFalse(frame.isLongGap)
+        assertEquals(1, frame.currentSampleIndex)
+        assertEquals(31.0, frame.latitude, 0.0)
+        assertEquals(121.0, frame.longitude, 0.0)
+    }
+
+    @Test
+    fun `non chronological history is rejected instead of reordered`() {
+        val samples = listOf(
+            sample(time = 2_000L, latitude = 30.0, longitude = 120.0),
+            sample(time = 1_000L, latitude = 31.0, longitude = 121.0)
+        )
+
+        assertFalse(TripPlaybackTimeline.isChronological(samples))
+        assertEquals(0L, TripPlaybackTimeline.durationMillis(samples))
+        assertNull(TripPlaybackTimeline.frameAt(samples, 500L))
+    }
+
+    @Test
+    fun `playback advancement applies speed and clamps to duration`() {
+        assertEquals(
+            9_000L,
+            TripPlaybackTimeline.advanceElapsed(
+                currentElapsedMillis = 1_000L,
+                realDeltaMillis = 2_000L,
+                speedMultiplier = 4f,
+                totalMillis = 20_000L
+            )
+        )
+        assertEquals(
+            20_000L,
+            TripPlaybackTimeline.advanceElapsed(
+                currentElapsedMillis = 19_000L,
+                realDeltaMillis = 2_000L,
+                speedMultiplier = 8f,
+                totalMillis = 20_000L
+            )
+        )
+        assertEquals(
+            2_000L,
+            TripPlaybackTimeline.advanceElapsed(
+                currentElapsedMillis = 1_000L,
+                realDeltaMillis = 1_000L,
+                speedMultiplier = Float.NaN,
+                totalMillis = 20_000L
+            )
+        )
+    }
+
+    @Test
+    fun `single sample stays at zero duration`() {
+        val samples = listOf(sample(time = 1_000L, latitude = 30.0, longitude = 120.0))
+
+        val frame = TripPlaybackTimeline.frameAt(samples, 10_000L)!!
+
+        assertEquals(0L, TripPlaybackTimeline.durationMillis(samples))
+        assertEquals(0L, frame.elapsedMillis)
+        assertEquals(0L, frame.totalMillis)
+        assertEquals(30.0, frame.latitude, 0.0)
+    }
+
+    private fun sample(
+        time: Long,
+        latitude: Double,
+        longitude: Double,
+        bearing: Double? = null
+    ) = TripPlaybackSample(
+        capturedAtEpochMillis = time,
+        latitude = latitude,
+        longitude = longitude,
+        bearingDegrees = bearing
+    )
+}


### PR DESCRIPTION
## Summary

Implements the first code slice of #193 through child Issue #197.

### Playback timeline engine
- renderer/provider independent; no MapLibre dependency
- derives duration and frames from real recorded timestamps
- clamps elapsed time at start/end
- bounded interpolation is allowed only inside short real intervals
- `TripContinuityRules.LONG_GAP_SECONDS` is reused as the hard playback discontinuity
- playback time inside a LONG_GAP remains at the previous real sample and reports the gap explicitly
- at the next real timestamp playback jumps to that real sample; no missing points are invented
- non-monotonic sample order is rejected rather than silently reordered
- playback advancement supports compact 1x / 2x / 4x / 8x presets
- shortest-path bearing interpolation is provided for later marker rendering

### Tests
Covers short-interval interpolation, start/end clamping, LONG_GAP non-interpolation, exact post-gap jump, non-monotonic input rejection, speed advancement/clamping and single-sample behavior.

## Scope boundary

This PR intentionally does **not** add the UI playback controls or moving marker yet. Those remain follow-up slices under #193.

No schema, Room, tracking service, persisted TripPoint, route-truth or map-provider changes.

## Acceptance
- [x] playback domain is renderer independent
- [x] no interpolation across LONG_GAP
- [x] no Trip data mutation
- [x] Android Build #501 Green — build, tests and Debug APK upload
- [x] Squash merged to `main` as `382fd91`

Refs #197
Parent #193
Related #67 #77 #192