### PR TITLE
feat(android): add Trip trajectory playback controls

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -35,38 +35,45 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
         }
     }
 
-    Surface(
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("趋势", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(
-                    "横轴为行程时间，纵轴为可信样本值；超过 2 分钟的缺口保持断开。",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+        TripPlaybackRouteCardV06(points = points)
 
-            BoxWithConstraints(Modifier.fillMaxWidth()) {
-                val compact = maxWidth < 360.dp
-                if (compact) {
-                    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                        DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.fillMaxWidth(), "暂无可信速度样本")
-                        DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.fillMaxWidth(), "暂无可信海拔样本")
-                    }
-                } else {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-                    ) {
-                        DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.weight(1f), "暂无可信速度样本")
-                        DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.weight(1f), "暂无可信海拔样本")
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surfaceContainerLow
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text("趋势", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        "横轴为行程时间，纵轴为可信样本值；超过 2 分钟的缺口保持断开。",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                BoxWithConstraints(Modifier.fillMaxWidth()) {
+                    val compact = maxWidth < 360.dp
+                    if (compact) {
+                        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                            DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.fillMaxWidth(), "暂无可信速度样本")
+                            DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.fillMaxWidth(), "暂无可信海拔样本")
+                        }
+                    } else {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+                        ) {
+                            DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.weight(1f), "暂无可信速度样本")
+                            DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.weight(1f), "暂无可信海拔样本")
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
@@ -52,8 +52,6 @@ import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import kotlinx.coroutines.delay
 import java.util.Locale
-import kotlin.math.cos
-import kotlin.math.sin
 
 /**
  * Completed-Trip playback surface for the current no-basemap renderer.
@@ -67,8 +65,11 @@ internal fun TripPlaybackRouteCardV06(
     modifier: Modifier = Modifier
 ) {
     val accent = EVDesignTokens.Energy.green
-    val samples = remember(points) {
-        points.map {
+    val playbackPoints = remember(points) {
+        points.filter { it.latitude.isFinite() && it.longitude.isFinite() }
+    }
+    val samples = remember(playbackPoints) {
+        playbackPoints.map {
             TripPlaybackSample(
                 capturedAtEpochMillis = it.capturedAtEpochMillis,
                 latitude = it.latitude,
@@ -77,9 +78,9 @@ internal fun TripPlaybackRouteCardV06(
             )
         }
     }
-    val geometry = remember(points) {
+    val geometry = remember(playbackPoints) {
         TripRouteGeometryBuilder.build(
-            points.map {
+            playbackPoints.map {
                 TripGeoPoint(
                     latitude = it.latitude,
                     longitude = it.longitude,
@@ -92,10 +93,10 @@ internal fun TripPlaybackRouteCardV06(
     val totalMillis = remember(samples) { TripPlaybackTimeline.durationMillis(samples) }
     val playable = geometry?.isDrawable == true && totalMillis > 0L && TripPlaybackTimeline.isChronological(samples)
 
-    var playbackMode by remember(points.firstOrNull()?.tripId) { mutableStateOf(false) }
-    var playing by remember(points.firstOrNull()?.tripId) { mutableStateOf(false) }
-    var elapsedMillis by remember(points.firstOrNull()?.tripId) { mutableLongStateOf(0L) }
-    var speed by remember(points.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
+    var playbackMode by remember(playbackPoints.firstOrNull()?.tripId) { mutableStateOf(false) }
+    var playing by remember(playbackPoints.firstOrNull()?.tripId) { mutableStateOf(false) }
+    var elapsedMillis by remember(playbackPoints.firstOrNull()?.tripId) { mutableLongStateOf(0L) }
+    var speed by remember(playbackPoints.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
 
     val frame = remember(samples, elapsedMillis) {
         TripPlaybackTimeline.frameAt(samples, elapsedMillis)
@@ -115,9 +116,7 @@ internal fun TripPlaybackRouteCardV06(
                 speedMultiplier = speed,
                 totalMillis = totalMillis
             )
-            if (elapsedMillis >= totalMillis) {
-                playing = false
-            }
+            if (elapsedMillis >= totalMillis) playing = false
         }
     }
 
@@ -135,16 +134,16 @@ internal fun TripPlaybackRouteCardV06(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-                    Text("轨迹", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text("轨迹回放", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                     Text(
                         when {
                             !playable -> "当前轨迹不足以进行可信回放"
-                            frame?.isLongGap == true -> "回放暂停于 GPS 缺口"
+                            playbackMode && frame?.isLongGap == true -> "GPS 缺口 · 保持最后真实定位点"
                             playbackMode -> "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)} · ${formatPlaybackSpeed(speed)}"
-                            else -> "${points.size} 个 GPS 点 · 可按真实时间回放"
+                            else -> "${playbackPoints.size} 个 GPS 点 · 按真实时间推进"
                         },
                         style = MaterialTheme.typography.labelSmall,
-                        color = if (frame?.isLongGap == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                        color = if (playbackMode && frame?.isLongGap == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
                 TextButton(
@@ -156,28 +155,26 @@ internal fun TripPlaybackRouteCardV06(
                     enabled = playable,
                     modifier = Modifier.heightIn(min = 48.dp)
                 ) {
-                    Text(if (playbackMode) "退出回放" else "回放")
+                    Text(if (playbackMode) "退出" else "回放")
                 }
             }
 
-            geometry?.takeIf { it.isDrawable }?.let { routeGeometry ->
-                PlaybackCanvasV06(
-                    points = points,
-                    frame = if (playbackMode) frame else null,
-                    elapsedMillis = if (playbackMode) elapsedMillis else totalMillis,
-                    totalMillis = totalMillis,
-                    minLatitude = routeGeometry.minLatitude,
-                    maxLatitude = routeGeometry.maxLatitude,
-                    minLongitude = routeGeometry.minLongitude,
-                    maxLongitude = routeGeometry.maxLongitude,
-                    accent = accent
-                )
-            }
-
             if (playbackMode && playable) {
-                val sliderValue = if (totalMillis > 0L) elapsedMillis.toFloat().coerceIn(0f, totalMillis.toFloat()) else 0f
+                geometry?.takeIf { it.isDrawable }?.let { routeGeometry ->
+                    PlaybackCanvasV06(
+                        points = playbackPoints,
+                        frame = frame,
+                        elapsedMillis = elapsedMillis,
+                        minLatitude = routeGeometry.minLatitude,
+                        maxLatitude = routeGeometry.maxLatitude,
+                        minLongitude = routeGeometry.minLongitude,
+                        maxLongitude = routeGeometry.maxLongitude,
+                        accent = accent
+                    )
+                }
+
                 Slider(
-                    value = sliderValue,
+                    value = elapsedMillis.toFloat().coerceIn(0f, totalMillis.toFloat()),
                     onValueChange = {
                         playing = false
                         elapsedMillis = it.toLong().coerceIn(0L, totalMillis)
@@ -268,7 +265,6 @@ private fun PlaybackCanvasV06(
     points: List<TripPointEntity>,
     frame: TripPlaybackFrame?,
     elapsedMillis: Long,
-    totalMillis: Long,
     minLatitude: Double,
     maxLatitude: Double,
     minLongitude: Double,
@@ -281,9 +277,7 @@ private fun PlaybackCanvasV06(
             .fillMaxWidth()
             .height(170.dp)
             .semantics {
-                contentDescription = if (frame == null) {
-                    "已完成真实行程轨迹；绿色起点和红色终点旗"
-                } else if (frame.isLongGap) {
+                contentDescription = if (frame?.isLongGap == true) {
                     "行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
                 } else {
                     "行程轨迹回放；移动标记沿真实定位时间推进"
@@ -393,7 +387,7 @@ private fun formatPlaybackSpeed(value: Float): String =
     if (value % 1f == 0f) "${value.toInt()}×" else String.format(Locale.US, "%.1f×", value)
 
 private fun formatPlaybackTime(valueMillis: Long): String {
-    val totalSeconds = (valueMillis.coerceAtLeast(0L) / 1_000L)
+    val totalSeconds = valueMillis.coerceAtLeast(0L) / 1_000L
     val hours = totalSeconds / 3_600L
     val minutes = (totalSeconds % 3_600L) / 60L
     val seconds = totalSeconds % 60L

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
@@ -1,0 +1,405 @@
+package com.evchargebook.ui.trip
+
+import android.os.SystemClock
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripPointEntity
+import com.evchargebook.domain.TripContinuityRules
+import com.evchargebook.domain.TripPlaybackFrame
+import com.evchargebook.domain.TripPlaybackSample
+import com.evchargebook.domain.TripPlaybackTimeline
+import com.evchargebook.domain.trip.TripGeoPoint
+import com.evchargebook.domain.trip.TripRouteGeometryBuilder
+import com.evchargebook.ui.theme.EVDesignTokens
+import com.evchargebook.ui.theme.spacing
+import kotlinx.coroutines.delay
+import java.util.Locale
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Completed-Trip playback surface for the current no-basemap renderer.
+ *
+ * Playback is presentation-only. It reads persisted TripPoint chronology and delegates seek/gap
+ * semantics to TripPlaybackTimeline; no TripPoint or TripSession is ever changed here.
+ */
+@Composable
+internal fun TripPlaybackRouteCardV06(
+    points: List<TripPointEntity>,
+    modifier: Modifier = Modifier
+) {
+    val accent = EVDesignTokens.Energy.green
+    val samples = remember(points) {
+        points.map {
+            TripPlaybackSample(
+                capturedAtEpochMillis = it.capturedAtEpochMillis,
+                latitude = it.latitude,
+                longitude = it.longitude,
+                bearingDegrees = it.bearingDegrees
+            )
+        }
+    }
+    val geometry = remember(points) {
+        TripRouteGeometryBuilder.build(
+            points.map {
+                TripGeoPoint(
+                    latitude = it.latitude,
+                    longitude = it.longitude,
+                    capturedAtEpochMillis = it.capturedAtEpochMillis,
+                    speedMps = it.speedMps
+                )
+            }
+        )
+    }
+    val totalMillis = remember(samples) { TripPlaybackTimeline.durationMillis(samples) }
+    val playable = geometry?.isDrawable == true && totalMillis > 0L && TripPlaybackTimeline.isChronological(samples)
+
+    var playbackMode by remember(points.firstOrNull()?.tripId) { mutableStateOf(false) }
+    var playing by remember(points.firstOrNull()?.tripId) { mutableStateOf(false) }
+    var elapsedMillis by remember(points.firstOrNull()?.tripId) { mutableLongStateOf(0L) }
+    var speed by remember(points.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
+
+    val frame = remember(samples, elapsedMillis) {
+        TripPlaybackTimeline.frameAt(samples, elapsedMillis)
+    }
+
+    LaunchedEffect(playing, speed, totalMillis) {
+        if (!playing || totalMillis <= 0L) return@LaunchedEffect
+        var previousRealtime = SystemClock.elapsedRealtime()
+        while (playing) {
+            delay(50L)
+            val now = SystemClock.elapsedRealtime()
+            val realDelta = (now - previousRealtime).coerceAtLeast(0L)
+            previousRealtime = now
+            elapsedMillis = TripPlaybackTimeline.advanceElapsed(
+                currentElapsedMillis = elapsedMillis,
+                realDeltaMillis = realDelta,
+                speedMultiplier = speed,
+                totalMillis = totalMillis
+            )
+            if (elapsedMillis >= totalMillis) {
+                playing = false
+            }
+        }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                    Text("轨迹", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(
+                        when {
+                            !playable -> "当前轨迹不足以进行可信回放"
+                            frame?.isLongGap == true -> "回放暂停于 GPS 缺口"
+                            playbackMode -> "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)} · ${formatPlaybackSpeed(speed)}"
+                            else -> "${points.size} 个 GPS 点 · 可按真实时间回放"
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (frame?.isLongGap == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                TextButton(
+                    onClick = {
+                        playbackMode = !playbackMode
+                        playing = false
+                        if (!playbackMode) elapsedMillis = 0L
+                    },
+                    enabled = playable,
+                    modifier = Modifier.heightIn(min = 48.dp)
+                ) {
+                    Text(if (playbackMode) "退出回放" else "回放")
+                }
+            }
+
+            geometry?.takeIf { it.isDrawable }?.let { routeGeometry ->
+                PlaybackCanvasV06(
+                    points = points,
+                    frame = if (playbackMode) frame else null,
+                    elapsedMillis = if (playbackMode) elapsedMillis else totalMillis,
+                    totalMillis = totalMillis,
+                    minLatitude = routeGeometry.minLatitude,
+                    maxLatitude = routeGeometry.maxLatitude,
+                    minLongitude = routeGeometry.minLongitude,
+                    maxLongitude = routeGeometry.maxLongitude,
+                    accent = accent
+                )
+            }
+
+            if (playbackMode && playable) {
+                val sliderValue = if (totalMillis > 0L) elapsedMillis.toFloat().coerceIn(0f, totalMillis.toFloat()) else 0f
+                Slider(
+                    value = sliderValue,
+                    onValueChange = {
+                        playing = false
+                        elapsedMillis = it.toLong().coerceIn(0L, totalMillis)
+                    },
+                    valueRange = 0f..totalMillis.toFloat().coerceAtLeast(1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = "行程回放进度" }
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(
+                        onClick = {
+                            elapsedMillis = 0L
+                            playing = false
+                        },
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(Icons.Default.Replay, contentDescription = "重新开始回放")
+                    }
+                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                    IconButton(
+                        onClick = {
+                            if (elapsedMillis >= totalMillis) elapsedMillis = 0L
+                            playing = !playing
+                        },
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            contentDescription = if (playing) "暂停回放" else "开始回放"
+                        )
+                    }
+                    Spacer(Modifier.width(MaterialTheme.spacing.sm))
+                    Text(
+                        "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)
+                ) {
+                    TripPlaybackTimeline.speedPresets.forEach { preset ->
+                        val selected = speed == preset
+                        Surface(
+                            onClick = { speed = preset },
+                            modifier = Modifier.weight(1f).heightIn(min = 48.dp),
+                            shape = MaterialTheme.shapes.medium,
+                            color = if (selected) accent.copy(alpha = .12f) else MaterialTheme.colorScheme.surfaceContainerHigh
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    formatPlaybackSpeed(preset),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                                    color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (frame?.isLongGap == true) {
+                    Text(
+                        "GPS 缺口 · ${formatPlaybackTime(frame.longGapStartElapsedMillis ?: 0L)} → ${formatPlaybackTime(frame.longGapEndElapsedMillis ?: elapsedMillis)}。缺失区间不会插值成连续驾驶。",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaybackCanvasV06(
+    points: List<TripPointEntity>,
+    frame: TripPlaybackFrame?,
+    elapsedMillis: Long,
+    totalMillis: Long,
+    minLatitude: Double,
+    maxLatitude: Double,
+    minLongitude: Double,
+    maxLongitude: Double,
+    accent: androidx.compose.ui.graphics.Color
+) {
+    val endColor = MaterialTheme.colorScheme.error
+    Canvas(
+        Modifier
+            .fillMaxWidth()
+            .height(170.dp)
+            .semantics {
+                contentDescription = if (frame == null) {
+                    "已完成真实行程轨迹；绿色起点和红色终点旗"
+                } else if (frame.isLongGap) {
+                    "行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
+                } else {
+                    "行程轨迹回放；移动标记沿真实定位时间推进"
+                }
+            }
+    ) {
+        if (points.isEmpty()) return@Canvas
+        val pad = 12.dp.toPx()
+        val width = (size.width - pad * 2).coerceAtLeast(1f)
+        val height = (size.height - pad * 2).coerceAtLeast(1f)
+        val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.0 } ?: 1.0
+        val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.0 } ?: 1.0
+        val startTime = points.first().capturedAtEpochMillis
+        val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+
+        fun project(latitude: Double, longitude: Double): Offset {
+            val x = ((longitude - minLongitude) / lonSpan).toFloat().coerceIn(0f, 1f)
+            val y = (1.0 - (latitude - minLatitude) / latSpan).toFloat().coerceIn(0f, 1f)
+            return Offset(pad + x * width, pad + y * height)
+        }
+
+        points.zipWithNext().forEach { (from, to) ->
+            val delta = to.capturedAtEpochMillis - from.capturedAtEpochMillis
+            if (delta <= 0L || delta >= longGapMillis) return@forEach
+            val start = project(from.latitude, from.longitude)
+            val end = project(to.latitude, to.longitude)
+            drawLine(
+                color = accent.copy(alpha = .18f),
+                start = start,
+                end = end,
+                strokeWidth = 3.dp.toPx(),
+                cap = StrokeCap.Round
+            )
+
+            val fromElapsed = (from.capturedAtEpochMillis - startTime).coerceAtLeast(0L)
+            val toElapsed = (to.capturedAtEpochMillis - startTime).coerceAtLeast(fromElapsed)
+            when {
+                elapsedMillis >= toElapsed -> drawLine(
+                    color = accent.copy(alpha = .82f),
+                    start = start,
+                    end = end,
+                    strokeWidth = 3.dp.toPx(),
+                    cap = StrokeCap.Round
+                )
+
+                elapsedMillis > fromElapsed && toElapsed > fromElapsed -> {
+                    val fraction = ((elapsedMillis - fromElapsed).toDouble() / (toElapsed - fromElapsed).toDouble())
+                        .coerceIn(0.0, 1.0)
+                    val partial = Offset(
+                        x = start.x + (end.x - start.x) * fraction.toFloat(),
+                        y = start.y + (end.y - start.y) * fraction.toFloat()
+                    )
+                    drawLine(
+                        color = accent.copy(alpha = .82f),
+                        start = start,
+                        end = partial,
+                        strokeWidth = 3.dp.toPx(),
+                        cap = StrokeCap.Round
+                    )
+                }
+            }
+        }
+
+        val startPoint = project(points.first().latitude, points.first().longitude)
+        val endPoint = project(points.last().latitude, points.last().longitude)
+        val markerSize = 6.dp.toPx()
+        val startTriangle = Path().apply {
+            moveTo(startPoint.x - markerSize * .45f, startPoint.y - markerSize)
+            lineTo(startPoint.x + markerSize, startPoint.y)
+            lineTo(startPoint.x - markerSize * .45f, startPoint.y + markerSize)
+            close()
+        }
+        drawPath(startTriangle, accent)
+
+        val poleHeight = 13.dp.toPx()
+        val flagWidth = 9.dp.toPx()
+        val flagHeight = 6.dp.toPx()
+        drawLine(endColor, endPoint, Offset(endPoint.x, endPoint.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
+        val flag = Path().apply {
+            moveTo(endPoint.x, endPoint.y - poleHeight)
+            lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight)
+            lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight + flagHeight)
+            lineTo(endPoint.x, endPoint.y - poleHeight + flagHeight)
+            close()
+        }
+        drawPath(flag, endColor)
+
+        frame?.let { current ->
+            val currentOffset = project(current.latitude, current.longitude)
+            val direction = current.bearingDegrees?.takeIf { it.isFinite() }?.toFloat() ?: 0f
+            val vehicleSize = 7.dp.toPx()
+            val vehicle = Path().apply {
+                moveTo(currentOffset.x, currentOffset.y - vehicleSize)
+                lineTo(currentOffset.x + vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                lineTo(currentOffset.x, currentOffset.y + vehicleSize * .30f)
+                lineTo(currentOffset.x - vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                close()
+            }
+            rotate(degrees = direction, pivot = currentOffset) {
+                drawPath(vehicle, accent)
+            }
+        }
+    }
+}
+
+private fun formatPlaybackSpeed(value: Float): String =
+    if (value % 1f == 0f) "${value.toInt()}×" else String.format(Locale.US, "%.1f×", value)
+
+private fun formatPlaybackTime(valueMillis: Long): String {
+    val totalSeconds = (valueMillis.coerceAtLeast(0L) / 1_000L)
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    val seconds = totalSeconds % 60L
+    return if (hours > 0L) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+}


### PR DESCRIPTION
## Summary

Implements #200 under parent #193 on top of the merged playback timeline engine from #197 / PR #198.

### Completed Trip playback
- adds a compact `轨迹回放` entry to the existing `轨迹` section; collapsed by default so normal detail stays dense
- play / pause / restart
- elapsed / total time and seek slider
- compact 1x / 2x / 4x / 8x speed controls
- moving directional marker driven only by `TripPlaybackTimeline`
- played route uses restrained app green; future route remains low-alpha context
- existing green start + compact red completed flag remain visible

### GPS truth
- uses persisted chronological TripPoints only
- real `LONG_GAP_SECONDS` intervals are never drawn as continuous route segments
- while playback time crosses a real long gap, marker stays on the prior real point and UI shows `GPS 缺口`; it jumps only when the next real timestamp is reached
- no synthetic TripPoints, road snapping, distance or speed creation

### Interaction / accessibility
- scrubbing pauses playback and seeks immediately
- reaching the end pauses at 100%
- replay returns to the first real sample
- play/pause/replay controls keep 48dp targets and content descriptions
- timeline has an accessibility description
- playback is foreground presentation state only

## Scope

No MapLibre/provider dependency in this PR. #192/#199 remain independent map work. No Room/schema/tracking-service changes.

## Acceptance
- [x] playback controls wired to current no-basemap Trip route flow
- [x] moving marker and played route derive from real chronology
- [x] LONG_GAP not bridged
- [x] no Trip data mutation
- [x] Android Build #503 Green — build, tests and Debug APK upload
- [x] Squash merged to `main` as `d9e180e`
- [ ] physical-device playback acceptance remains under #193

Refs #200
Parent #193
Related #192 #199