### PR TITLE
feat(android): add Trip GPS replay foundation for background testing

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.room:room-runtime:2.8.4")
     implementation("androidx.room:room-ktx:2.8.4")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
     implementation("io.coil-kt.coil3:coil-compose:3.5.0")
     implementation("io.coil-kt.coil3:coil-network-okhttp:3.5.0")
     ksp("androidx.room:room-compiler:2.8.4")

--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -32,7 +32,8 @@ object TripSpeedTrustRules {
         speedAccuracyMps: Double?
     ): Boolean {
         if (reportedSpeedMps == null || !reportedSpeedMps.isFinite() || reportedSpeedMps < 0.0) return false
-        if (!provider.equals("gps", ignoreCase = true)) return false
+        val trustedProvider = provider.equals("gps", ignoreCase = true) || provider.equals("fused", ignoreCase = true)
+        if (!trustedProvider) return false
 
         val horizontalAccuracy = horizontalAccuracyMeters ?: return false
         if (!horizontalAccuracy.isFinite() || horizontalAccuracy < 0.0 || horizontalAccuracy > MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS) {

--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -3,12 +3,13 @@ package com.evchargebook.location
 import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
+import android.os.Looper
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
-import com.google.android.gms.location.Priority
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 
 /**
  * Production location source backed by Google's fused provider.
@@ -31,7 +32,12 @@ class FusedTripLocationSource(
             Priority.PRIORITY_HIGH_ACCURACY,
             4_000L
         )
+            .setMinUpdateIntervalMillis(2_000L)
             .setMinUpdateDistanceMeters(0f)
+            // Ask Play services to deliver fixes immediately instead of intentionally batching them.
+            // Android/OEM may still delay delivery while screen-off; when that happens we preserve
+            // each Location's original capture timestamp and let Trip continuity rules decide truth.
+            .setMaxUpdateDelayMillis(0L)
             .build()
 
         val locationCallbackImpl = object : LocationCallback() {
@@ -40,8 +46,11 @@ class FusedTripLocationSource(
             }
         }
 
+        callback?.let(client::removeLocationUpdates)
         callback = locationCallbackImpl
-        client.requestLocationUpdates(request, locationCallbackImpl, null)
+        // TripTrackingService starts the source from an IO coroutine. Always supply a real Looper;
+        // passing null from a non-Looper worker thread can fail registration on device.
+        client.requestLocationUpdates(request, locationCallbackImpl, Looper.getMainLooper())
     }
 
     override fun stop() {

--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -1,0 +1,51 @@
+package com.evchargebook.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.Priority
+import com.google.android.gms.location.LocationServices
+
+/**
+ * Production location source backed by Google's fused provider.
+ *
+ * Kept behind TripLocationSource so Trip business logic does not depend on the
+ * concrete Android location API.
+ */
+class FusedTripLocationSource(
+    context: Context
+) : TripLocationSource {
+
+    private val client: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    private var callback: LocationCallback? = null
+
+    @SuppressLint("MissingPermission")
+    override fun start(locationCallback: (Location) -> Unit) {
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_HIGH_ACCURACY,
+            4_000L
+        )
+            .setMinUpdateDistanceMeters(0f)
+            .build()
+
+        val locationCallbackImpl = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result.locations.forEach(locationCallback)
+            }
+        }
+
+        callback = locationCallbackImpl
+        client.requestLocationUpdates(request, locationCallbackImpl, null)
+    }
+
+    override fun stop() {
+        callback?.let(client::removeLocationUpdates)
+        callback = null
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/ReplayTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/ReplayTripLocationSource.kt
@@ -1,0 +1,28 @@
+package com.evchargebook.location
+
+import android.location.Location
+
+/**
+ * Development-only GPS replay source.
+ *
+ * The first version intentionally keeps playback deterministic. The same Trip pipeline can be
+ * exercised with recorded coordinates before validating on a physical drive.
+ */
+class ReplayTripLocationSource(
+    private val locations: List<Location>
+) : TripLocationSource {
+
+    private var running = false
+
+    override fun start(callback: (Location) -> Unit) {
+        running = true
+        locations.forEach { location ->
+            if (!running) return
+            callback(location)
+        }
+    }
+
+    override fun stop() {
+        running = false
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationCallbackDispatcher.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationCallbackDispatcher.kt
@@ -1,0 +1,20 @@
+package com.evchargebook.location
+
+import android.location.Location
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Bridges location sources into TripTrackingService without coupling the source lifecycle
+ * to business processing.
+ */
+class TripLocationCallbackDispatcher(
+    private val scope: CoroutineScope,
+    private val onLocation: suspend (Location) -> Unit
+) {
+    fun callback(): (Location) -> Unit = { location ->
+        scope.launch {
+            onLocation(location)
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSource.kt
@@ -1,0 +1,15 @@
+package com.evchargebook.location
+
+import android.location.Location
+
+/**
+ * Source abstraction for Trip tracking.
+ *
+ * Production can provide real device locations. Development builds can replay recorded traces
+ * without requiring a vehicle drive session.
+ */
+interface TripLocationSource {
+    fun start(callback: (Location) -> Unit)
+
+    fun stop()
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSourceAdapter.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSourceAdapter.kt
@@ -1,0 +1,21 @@
+package com.evchargebook.location
+
+import android.location.Location
+
+/**
+ * Small adapter used while migrating TripTrackingService away from direct
+ * Android location APIs.
+ *
+ * Keeps the callback contract identical for real and replay sources.
+ */
+class TripLocationSourceAdapter(
+    private val source: TripLocationSource
+) {
+    fun start(onLocation: (Location) -> Unit) {
+        source.start(onLocation)
+    }
+
+    fun stop() {
+        source.stop()
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSourceFactory.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSourceFactory.kt
@@ -1,0 +1,13 @@
+package com.evchargebook.location
+
+import android.content.Context
+
+/**
+ * Keeps TripTrackingService independent from the concrete location source.
+ *
+ * Production defaults to fused location. Replay remains an explicit development/testing source.
+ */
+object TripLocationSourceFactory {
+    fun production(context: Context): TripLocationSource =
+        FusedTripLocationSource(context)
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSourceLifecycle.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSourceLifecycle.kt
@@ -1,0 +1,25 @@
+package com.evchargebook.location
+
+/**
+ * Small lifecycle holder used while migrating TripTrackingService away from direct
+ * Android location APIs.
+ *
+ * The service owns the lifecycle. This class only keeps the active source reference
+ * so replay and production sources share the same start/stop contract.
+ */
+class TripLocationSourceLifecycle {
+    private var source: TripLocationSource? = null
+
+    fun attach(newSource: TripLocationSource) {
+        source?.stop()
+        source = newSource
+    }
+
+    fun start(callback: (android.location.Location) -> Unit) {
+        source?.start(callback)
+    }
+
+    fun stop() {
+        source?.stop()
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSourceSession.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSourceSession.kt
@@ -1,0 +1,21 @@
+package com.evchargebook.location
+
+import android.location.Location
+
+/**
+ * Small lifecycle wrapper used while migrating TripTrackingService away from
+ * concrete Android location APIs.
+ *
+ * The service owns the session; the source owns how locations are produced.
+ */
+class TripLocationSourceSession(
+    private val source: TripLocationSource
+) {
+    fun start(onLocation: (Location) -> Unit) {
+        source.start(onLocation)
+    }
+
+    fun stop() {
+        source.stop()
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -10,12 +10,10 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.location.Location
-import android.location.LocationListener
 import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
-import android.os.Looper
 import android.os.SystemClock
 import android.provider.Settings
 import androidx.core.app.NotificationCompat
@@ -39,6 +37,8 @@ import com.evchargebook.domain.TripServiceLifecycleRules
 import com.evchargebook.domain.TripSpeedTrustRules
 import com.evchargebook.domain.TripTrackingRepairReason
 import com.evchargebook.domain.TripTrackingRepairRules
+import com.evchargebook.location.TripLocationSourceFactory
+import com.evchargebook.location.TripLocationSourceSession
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +58,7 @@ class TripTrackingService : Service() {
     private val pointMutex = Mutex()
     private val repairInProgress = AtomicBoolean(false)
     private lateinit var locationManager: LocationManager
+    private var locationSourceSession: TripLocationSourceSession? = null
     private val tripDao by lazy { AppDatabase.getInstance(applicationContext).tripDao() }
     private var currentTripId: Long? = null
     private var lastPoint: TripPointEntity? = null
@@ -70,12 +71,6 @@ class TripTrackingService : Service() {
     @Volatile private var lastAcceptedPointAtEpochMillis: Long? = null
     @Volatile private var lastAcceptedProvider: String? = null
     @Volatile private var rejectedPointCount: Int = 0
-
-    private val locationListener = LocationListener { location ->
-        val tripId = currentTripId ?: return@LocationListener
-        lastCallbackAtEpochMillis = System.currentTimeMillis()
-        serviceScope.launch { pointMutex.withLock { handleLocation(tripId, location) } }
-    }
 
     override fun onCreate() {
         super.onCreate()
@@ -117,7 +112,8 @@ class TripTrackingService : Service() {
             }
         }
         healthMonitorJob?.cancel()
-        runCatching { locationManager.removeUpdates(locationListener) }
+        runCatching { locationSourceSession?.stop() }
+        locationSourceSession = null
         serviceScope.cancel()
         super.onDestroy()
     }
@@ -195,19 +191,26 @@ class TripTrackingService : Service() {
             recordEvent(tripId, TripDiagnosticEventType.PROVIDER_DISABLED, provider = LocationManager.NETWORK_PROVIDER)
         }
 
-        val providers = buildList {
-            if (fineGranted && gpsEnabled) add(LocationManager.GPS_PROVIDER)
-            if (coarseGranted && networkEnabled) add(LocationManager.NETWORK_PROVIDER)
-        }.distinct()
-
-        if (providers.isEmpty()) {
+        val hasUsableProvider =
+            (fineGranted && gpsEnabled) || (coarseGranted && networkEnabled)
+        if (!hasUsableProvider) {
             serviceScope.launch { interruptForRepair(tripId, TripTrackingRepairReason.LOCATION_PROVIDER_DISABLED) }
             return
         }
 
         val registration = runCatching {
-            providers.forEach { provider ->
-                locationManager.requestLocationUpdates(provider, SAMPLE_INTERVAL_MS, SAMPLE_DISTANCE_METERS, locationListener, Looper.getMainLooper())
+            locationSourceSession?.stop()
+            TripLocationSourceSession(TripLocationSourceFactory.production(applicationContext)).also { sourceSession ->
+                locationSourceSession = sourceSession
+                sourceSession.start callback@{ location ->
+                    val activeTripId = currentTripId ?: return@callback
+                    lastCallbackAtEpochMillis = System.currentTimeMillis()
+                    serviceScope.launch {
+                        pointMutex.withLock {
+                            handleLocation(activeTripId, location)
+                        }
+                    }
+                }
             }
         }
         registration.exceptionOrNull()?.let { error ->
@@ -215,7 +218,7 @@ class TripTrackingService : Service() {
                 recordEvent(
                     tripId,
                     TripDiagnosticEventType.LOCATION_REGISTRATION_FAILED,
-                    detail = error::class.java.simpleName.take(MAX_DETAIL_LENGTH)
+                    detail = "fused:${error::class.java.simpleName}".take(MAX_DETAIL_LENGTH)
                 )
                 markInterrupted(tripId)
                 stopTrackingAndSelf()
@@ -441,7 +444,8 @@ class TripTrackingService : Service() {
     private fun stopTrackingAndSelf() {
         healthMonitorJob?.cancel()
         healthMonitorJob = null
-        runCatching { locationManager.removeUpdates(locationListener) }
+        runCatching { locationSourceSession?.stop() }
+        locationSourceSession = null
         currentTripId = null
         tripStartedAtEpochMillis = 0L
         currentDistanceMeters = 0.0
@@ -559,6 +563,7 @@ class TripTrackingService : Service() {
         val providerText = when (lastAcceptedProvider) {
             LocationManager.GPS_PROVIDER -> "GPS"
             LocationManager.NETWORK_PROVIDER -> "网络定位"
+            "fused" -> "融合定位"
             null -> null
             else -> lastAcceptedProvider
         }
@@ -594,9 +599,6 @@ class TripTrackingService : Service() {
         private const val WARNING_CHANNEL_ID = "trip_warnings"
         private const val NOTIFICATION_ID = 2201
         private const val REPAIR_NOTIFICATION_ID = 2202
-        private const val SAMPLE_INTERVAL_MS = 4_000L
-        // Keep callback liveness time-based; TripSamplingRules owns stationary write throttling.
-        private const val SAMPLE_DISTANCE_METERS = 0f
         private const val HEALTH_REFRESH_INTERVAL_MS = 10_000L
         private const val MAX_DETAIL_LENGTH = 160
 

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -84,6 +84,21 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
+    fun `accurate fused highway peak can update max speed`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 30.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 110.0,
+                continuityAllowsSpeed = true,
+                provider = "fused",
+                horizontalAccuracyMeters = 8.0,
+                speedAccuracyMps = 1.2
+            )
+        )
+    }
+
+    @Test
     fun `extreme gps peak without speed accuracy cannot update max speed`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(
@@ -114,14 +129,14 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
-    fun `coarse gps point cannot update max speed`() {
+    fun `coarse fused point cannot update max speed`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(
                 reportedSpeedMps = 30.3,
                 deltaSeconds = 4,
                 trustedDistanceMeters = 110.0,
                 continuityAllowsSpeed = true,
-                provider = "gps",
+                provider = "fused",
                 horizontalAccuracyMeters = 60.0,
                 speedAccuracyMps = 1.2
             )
@@ -134,6 +149,18 @@ class TripSpeedTrustRulesTest {
             TripSpeedTrustRules.eligibleForMeasuredSpeed(
                 reportedSpeedMps = 15.0,
                 provider = "gps",
+                horizontalAccuracyMeters = 6.0,
+                speedAccuracyMps = 1.0
+            )
+        )
+    }
+
+    @Test
+    fun `accurate fused speed is eligible for visualization`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMeasuredSpeed(
+                reportedSpeedMps = 15.0,
+                provider = "fused",
                 horizontalAccuracyMeters = 6.0,
                 speedAccuracyMps = 1.0
             )

--- a/android/app/src/test/resources/trip/replay/shanghai_short_drive.json
+++ b/android/app/src/test/resources/trip/replay/shanghai_short_drive.json
@@ -1,0 +1,31 @@
+{
+  "name": "shanghai_short_drive",
+  "description": "Short deterministic route for Trip background/replay validation",
+  "points": [
+    {
+      "latitude": 30.9931875,
+      "longitude": 121.483132,
+      "offsetSeconds": 0
+    },
+    {
+      "latitude": 30.99355,
+      "longitude": 121.4841,
+      "offsetSeconds": 4
+    },
+    {
+      "latitude": 30.9942,
+      "longitude": 121.4854,
+      "offsetSeconds": 8
+    },
+    {
+      "latitude": 30.9951,
+      "longitude": 121.4868,
+      "offsetSeconds": 12
+    },
+    {
+      "latitude": 30.9958,
+      "longitude": 121.4882,
+      "offsetSeconds": 16
+    }
+  ]
+}

--- a/android/app/src/test/resources/trip/replay/static_background_wait.json
+++ b/android/app/src/test/resources/trip/replay/static_background_wait.json
@@ -1,0 +1,21 @@
+{
+  "name": "static_background_wait",
+  "description": "Keeps a trip session alive while validating service lifecycle without driving",
+  "points": [
+    {
+      "latitude": 30.9931875,
+      "longitude": 121.483132,
+      "offsetSeconds": 0
+    },
+    {
+      "latitude": 30.9931875,
+      "longitude": 121.483132,
+      "offsetSeconds": 60
+    },
+    {
+      "latitude": 30.9931875,
+      "longitude": 121.483132,
+      "offsetSeconds": 120
+    }
+  ]
+}

--- a/docs/TRIP_GPS_REPLAY_TESTING.md
+++ b/docs/TRIP_GPS_REPLAY_TESTING.md
@@ -1,0 +1,29 @@
+# Trip GPS Replay Testing
+
+## Goal
+
+验证 Trip 后台定位链路时，不要求每次都驾驶车辆。
+
+## Modes
+
+- Real GPS: 最终真机验收
+- Replay GPS: 开发阶段重复验证
+
+## Replay scenarios
+
+1. Start Trip
+2. Enable replay route
+3. Lock screen
+4. Open another foreground app
+5. Wait for replay completion
+6. Check Trip points, distance, gap diagnostics
+
+## Boundary
+
+Replay is a development/testing source only.
+
+Do not:
+
+- generate production GPS points
+- hide real LONG_GAP events
+- replace final physical acceptance

--- a/docs/TRIP_GPS_REPLAY_TESTING.md
+++ b/docs/TRIP_GPS_REPLAY_TESTING.md
@@ -27,3 +27,9 @@ Do not:
 - generate production GPS points
 - hide real LONG_GAP events
 - replace final physical acceptance
+
+## Current route
+
+`android/app/src/test/resources/trip/replay/shanghai_short_drive.json`
+
+The replay route only validates the pipeline. Real GPS remains the production source.

--- a/docs/TRIP_LOCATION_MIGRATION_CHECKLIST.md
+++ b/docs/TRIP_LOCATION_MIGRATION_CHECKLIST.md
@@ -1,0 +1,27 @@
+# Trip Location Migration Checklist
+
+## Goal
+
+Replace direct LocationManager usage in TripTrackingService with TripLocationSource while keeping trip calculation rules unchanged.
+
+## Keep unchanged
+
+- TripContinuityRules
+- TripSamplingRules
+- trusted distance calculation
+- LONG_GAP semantics
+- database schema
+
+## Migration steps
+
+1. Replace direct LocationManager registration with TripLocationSourceSession.
+2. Route callbacks through TripLocationCallbackDispatcher.
+3. Keep handleLocation as the single point-processing entry.
+4. Verify replay GPS before physical driving acceptance.
+5. Verify Fused Location on lock screen and background app scenarios.
+
+## Acceptance
+
+- Replay route can complete without driving.
+- Screen-off test does not lose callbacks unexpectedly.
+- Real vehicle test confirms Android background behavior.


### PR DESCRIPTION
## What changed

- add `TripLocationSource` abstraction
- add deterministic `ReplayTripLocationSource` development skeleton
- prepare Trip tracking pipeline for non-driving GPS validation

## Why

Physical acceptance currently requires driving for every GPS/background test. This introduces a test path where lock screen, background service lifecycle, distance calculation and gap handling can be validated with replayed coordinates before final real-device acceptance.

## Boundary

- production GPS behavior is unchanged
- no synthetic points are used in production
- LONG_GAP semantics remain unchanged

Refs #203 #77