### PR TITLE
feat(trip): add SOC override model foundation

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripSocAdjustmentV07.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripSocAdjustmentV07.kt
@@ -1,0 +1,26 @@
+package com.evchargebook.domain.trip
+
+/**
+ * Trip v0.7 SOC adjustment foundation.
+ *
+ * Keeps original measured snapshots separate from user corrections.
+ * The UI may present an editable SOC value without overwriting the original fact.
+ */
+data class TripSocAdjustmentV07(
+    val startSocSnapshot: Int?,
+    val startSocOverride: Int?,
+    val endSocSnapshot: Int?,
+    val endSocOverride: Int?
+) {
+    val effectiveStartSoc: Int?
+        get() = startSocOverride ?: startSocSnapshot
+
+    val effectiveEndSoc: Int?
+        get() = endSocOverride ?: endSocSnapshot
+}
+
+enum class TripSocSourceV07 {
+    VEHICLE_SNAPSHOT,
+    USER_OVERRIDE,
+    ESTIMATED
+}


### PR DESCRIPTION
## Summary

Add the Trip v0.7 SOC adjustment data foundation after the inline wheel UI design.

## Included

- Separate original SOC snapshots from user corrections.
- Add effective SOC resolution rules.
- Add SOC source classification foundation.

## Scope

This PR does not change Trip persistence wiring yet.
It prepares the domain model for:

- sentry/security drain correction;
- app-not-running correction;
- user-known SOC adjustment;
- estimated end SOC initialization.

## Guardrails

- Never overwrite original measured snapshots.
- Estimated SOC remains distinguishable from vehicle-measured SOC.
- Keep existing TripEnergyCalculator semantics.

Related: #205