### PR TITLE
feat(trip): seed end SOC from recent vehicle consumption

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -283,11 +283,19 @@ fun MainApp(
         val active = state.activeTrip ?: return
         val tripVehicle = state.vehicles.firstOrNull { it.id == active.vehicleId } ?: state.vehicle
         val startSoc = active.startSoc ?: state.currentSoc ?: 50
+        val historicalConsumption = TripEndSocEstimator.historicalAverageConsumptionKwhPer100Km(
+            state.trips
+                .asSequence()
+                .filter { it.vehicleId == active.vehicleId && it.status == TripStatus.COMPLETED }
+                .map { it.averageConsumptionKwhPer100Km }
+                .toList()
+        )
         tripStartSoc = startSoc
         tripEndSoc = TripEndSocEstimator.estimate(
             startSoc = startSoc,
             distanceMeters = active.distanceMeters,
-            batteryCapacityKwh = tripVehicle?.batteryCapacityKwh
+            batteryCapacityKwh = tripVehicle?.batteryCapacityKwh,
+            averageConsumptionKwhPer100Km = historicalConsumption
         ) ?: startSoc
         tripCompletionError = if (active.startSoc == null && state.currentSoc == null) {
             "未读取到开始 SOC，当前为默认值，请滚动选择实际电量"

--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripEndSocEstimator.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripEndSocEstimator.kt
@@ -10,6 +10,25 @@ import kotlin.math.roundToInt
  */
 object TripEndSocEstimator {
     const val DEFAULT_CONSUMPTION_KWH_PER_100_KM = 15.0
+    private const val MIN_REASONABLE_CONSUMPTION_KWH_PER_100_KM = 5.0
+    private const val MAX_REASONABLE_CONSUMPTION_KWH_PER_100_KM = 40.0
+    private const val HISTORY_SAMPLE_LIMIT = 5
+
+    /**
+     * Uses the newest plausible completed-Trip values. Callers should pass history in newest-first
+     * order; invalid/outlier values are ignored before the small-sample average is calculated.
+     */
+    fun historicalAverageConsumptionKwhPer100Km(values: Iterable<Double?>): Double? {
+        val samples = values.asSequence()
+            .mapNotNull { value ->
+                value?.takeIf {
+                    it.isFinite() && it in MIN_REASONABLE_CONSUMPTION_KWH_PER_100_KM..MAX_REASONABLE_CONSUMPTION_KWH_PER_100_KM
+                }
+            }
+            .take(HISTORY_SAMPLE_LIMIT)
+            .toList()
+        return samples.takeIf { it.isNotEmpty() }?.average()
+    }
 
     fun estimate(
         startSoc: Int?,
@@ -22,7 +41,9 @@ object TripEndSocEstimator {
         if (!distanceMeters.isFinite() || distanceMeters <= 0.0) return start
 
         val consumption = averageConsumptionKwhPer100Km
-            ?.takeIf { it.isFinite() && it in 5.0..40.0 }
+            ?.takeIf {
+                it.isFinite() && it in MIN_REASONABLE_CONSUMPTION_KWH_PER_100_KM..MAX_REASONABLE_CONSUMPTION_KWH_PER_100_KM
+            }
             ?: DEFAULT_CONSUMPTION_KWH_PER_100_KM
         val distanceKm = distanceMeters / 1000.0
         val consumedKwh = distanceKm / 100.0 * consumption

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripEndSocEstimatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripEndSocEstimatorTest.kt
@@ -29,6 +29,24 @@ class TripEndSocEstimatorTest {
     }
 
     @Test
+    fun averagesNewestPlausibleHistoryAndIgnoresOutliers() {
+        val average = TripEndSocEstimator.historicalAverageConsumptionKwhPer100Km(
+            listOf(16.0, null, 80.0, 14.0, 18.0, 13.0, 17.0, 12.0)
+        )
+
+        assertEquals(15.6, average!!, 0.0001)
+    }
+
+    @Test
+    fun returnsNullWhenHistoricalConsumptionHasNoPlausibleSamples() {
+        assertNull(
+            TripEndSocEstimator.historicalAverageConsumptionKwhPer100Km(
+                listOf(null, Double.NaN, 0.0, 45.0)
+            )
+        )
+    }
+
+    @Test
     fun keepsStartSocWhenDistanceOrCapacityCannotEstimateDrop() {
         assertEquals(
             62,


### PR DESCRIPTION
## Summary

Finish the v0.7 end-SOC estimator priority requested in #205: use the vehicle's recent completed-Trip consumption when available, otherwise keep the generic 15 kWh/100km fallback.

## Behavior

- Read completed Trip history already present in the current vehicle state list (newest first).
- Use up to 5 recent plausible `averageConsumptionKwhPer100Km` samples.
- Ignore null / NaN / obviously implausible values outside 5–40 kWh/100km.
- Average the remaining recent samples.
- Feed that average into `TripEndSocEstimator` as the preferred completion-wheel seed.
- If no usable history exists, retain the existing 15 kWh/100km fallback.
- The result is still only the initial end-SOC wheel value; save remains explicit user confirmation and no value is presented as BMS truth.

## Tests

Adds coverage for recent-history averaging, sample limit and outlier filtering.

## Boundary

- no schema change;
- no GPS/tracking change;
- no change to the SOC wheel UI;
- no model-specific default yet.

Related: #205
Follows: #210 #211 #212