### PR TITLE
fix(trip): migrate production tracking to fused location

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.room:room-runtime:2.8.4")
     implementation("androidx.room:room-ktx:2.8.4")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
     implementation("io.coil-kt.coil3:coil-compose:3.5.0")
     implementation("io.coil-kt.coil3:coil-network-okhttp:3.5.0")
     ksp("androidx.room:room-compiler:2.8.4")

--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -32,7 +32,8 @@ object TripSpeedTrustRules {
         speedAccuracyMps: Double?
     ): Boolean {
         if (reportedSpeedMps == null || !reportedSpeedMps.isFinite() || reportedSpeedMps < 0.0) return false
-        if (!provider.equals("gps", ignoreCase = true)) return false
+        val trustedProvider = provider.equals("gps", ignoreCase = true) || provider.equals("fused", ignoreCase = true)
+        if (!trustedProvider) return false
 
         val horizontalAccuracy = horizontalAccuracyMeters ?: return false
         if (!horizontalAccuracy.isFinite() || horizontalAccuracy < 0.0 || horizontalAccuracy > MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS) {

--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -1,0 +1,45 @@
+package com.evchargebook.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.os.Looper
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+
+/** Production Trip source backed by Google Play services fused location. */
+class FusedTripLocationSource(context: Context) : TripLocationSource {
+    private val client: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+
+    private var callback: LocationCallback? = null
+
+    @SuppressLint("MissingPermission")
+    override fun start(callback: (Location) -> Unit) {
+        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 4_000L)
+            .setMinUpdateIntervalMillis(2_000L)
+            .setMinUpdateDistanceMeters(0f)
+            .setMaxUpdateDelayMillis(0L)
+            .build()
+
+        val fusedCallback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                result.locations.forEach(callback)
+            }
+        }
+
+        this.callback?.let(client::removeLocationUpdates)
+        this.callback = fusedCallback
+        // The service starts this source from an IO coroutine; always provide a concrete Looper.
+        client.requestLocationUpdates(request, fusedCallback, Looper.getMainLooper())
+    }
+
+    override fun stop() {
+        callback?.let(client::removeLocationUpdates)
+        callback = null
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/location/TripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/TripLocationSource.kt
@@ -1,0 +1,14 @@
+package com.evchargebook.location
+
+import android.location.Location
+
+/**
+ * Location-source boundary for Trip tracking.
+ *
+ * Production currently uses FusedLocationProviderClient. The service keeps all
+ * continuity, sampling and persistence decisions outside this source.
+ */
+interface TripLocationSource {
+    fun start(callback: (Location) -> Unit)
+    fun stop()
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -10,12 +10,10 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.location.Location
-import android.location.LocationListener
 import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
-import android.os.Looper
 import android.os.SystemClock
 import android.provider.Settings
 import androidx.core.app.NotificationCompat
@@ -39,6 +37,8 @@ import com.evchargebook.domain.TripServiceLifecycleRules
 import com.evchargebook.domain.TripSpeedTrustRules
 import com.evchargebook.domain.TripTrackingRepairReason
 import com.evchargebook.domain.TripTrackingRepairRules
+import com.evchargebook.location.FusedTripLocationSource
+import com.evchargebook.location.TripLocationSource
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +58,7 @@ class TripTrackingService : Service() {
     private val pointMutex = Mutex()
     private val repairInProgress = AtomicBoolean(false)
     private lateinit var locationManager: LocationManager
+    private var locationSource: TripLocationSource? = null
     private val tripDao by lazy { AppDatabase.getInstance(applicationContext).tripDao() }
     private var currentTripId: Long? = null
     private var lastPoint: TripPointEntity? = null
@@ -70,12 +71,6 @@ class TripTrackingService : Service() {
     @Volatile private var lastAcceptedPointAtEpochMillis: Long? = null
     @Volatile private var lastAcceptedProvider: String? = null
     @Volatile private var rejectedPointCount: Int = 0
-
-    private val locationListener = LocationListener { location ->
-        val tripId = currentTripId ?: return@LocationListener
-        lastCallbackAtEpochMillis = System.currentTimeMillis()
-        serviceScope.launch { pointMutex.withLock { handleLocation(tripId, location) } }
-    }
 
     override fun onCreate() {
         super.onCreate()
@@ -117,7 +112,8 @@ class TripTrackingService : Service() {
             }
         }
         healthMonitorJob?.cancel()
-        runCatching { locationManager.removeUpdates(locationListener) }
+        runCatching { locationSource?.stop() }
+        locationSource = null
         serviceScope.cancel()
         super.onDestroy()
     }
@@ -195,19 +191,26 @@ class TripTrackingService : Service() {
             recordEvent(tripId, TripDiagnosticEventType.PROVIDER_DISABLED, provider = LocationManager.NETWORK_PROVIDER)
         }
 
-        val providers = buildList {
-            if (fineGranted && gpsEnabled) add(LocationManager.GPS_PROVIDER)
-            if (coarseGranted && networkEnabled) add(LocationManager.NETWORK_PROVIDER)
-        }.distinct()
-
-        if (providers.isEmpty()) {
+        val hasUsableProvider =
+            (fineGranted && gpsEnabled) || (coarseGranted && networkEnabled)
+        if (!hasUsableProvider) {
             serviceScope.launch { interruptForRepair(tripId, TripTrackingRepairReason.LOCATION_PROVIDER_DISABLED) }
             return
         }
 
         val registration = runCatching {
-            providers.forEach { provider ->
-                locationManager.requestLocationUpdates(provider, SAMPLE_INTERVAL_MS, SAMPLE_DISTANCE_METERS, locationListener, Looper.getMainLooper())
+            locationSource?.stop()
+            FusedTripLocationSource(applicationContext).also { source ->
+                locationSource = source
+                source.start callback@{ location ->
+                    val activeTripId = currentTripId ?: return@callback
+                    lastCallbackAtEpochMillis = System.currentTimeMillis()
+                    serviceScope.launch {
+                        pointMutex.withLock {
+                            handleLocation(activeTripId, location)
+                        }
+                    }
+                }
             }
         }
         registration.exceptionOrNull()?.let { error ->
@@ -215,7 +218,7 @@ class TripTrackingService : Service() {
                 recordEvent(
                     tripId,
                     TripDiagnosticEventType.LOCATION_REGISTRATION_FAILED,
-                    detail = error::class.java.simpleName.take(MAX_DETAIL_LENGTH)
+                    detail = "fused:${error::class.java.simpleName}".take(MAX_DETAIL_LENGTH)
                 )
                 markInterrupted(tripId)
                 stopTrackingAndSelf()
@@ -441,7 +444,8 @@ class TripTrackingService : Service() {
     private fun stopTrackingAndSelf() {
         healthMonitorJob?.cancel()
         healthMonitorJob = null
-        runCatching { locationManager.removeUpdates(locationListener) }
+        runCatching { locationSource?.stop() }
+        locationSource = null
         currentTripId = null
         tripStartedAtEpochMillis = 0L
         currentDistanceMeters = 0.0
@@ -559,6 +563,7 @@ class TripTrackingService : Service() {
         val providerText = when (lastAcceptedProvider) {
             LocationManager.GPS_PROVIDER -> "GPS"
             LocationManager.NETWORK_PROVIDER -> "网络定位"
+            "fused" -> "融合定位"
             null -> null
             else -> lastAcceptedProvider
         }
@@ -594,9 +599,6 @@ class TripTrackingService : Service() {
         private const val WARNING_CHANNEL_ID = "trip_warnings"
         private const val NOTIFICATION_ID = 2201
         private const val REPAIR_NOTIFICATION_ID = 2202
-        private const val SAMPLE_INTERVAL_MS = 4_000L
-        // Keep callback liveness time-based; TripSamplingRules owns stationary write throttling.
-        private const val SAMPLE_DISTANCE_METERS = 0f
         private const val HEALTH_REFRESH_INTERVAL_MS = 10_000L
         private const val MAX_DETAIL_LENGTH = 160
 

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -84,6 +84,21 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
+    fun `accurate fused highway peak can update max speed`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMaxSpeed(
+                reportedSpeedMps = 30.3,
+                deltaSeconds = 4,
+                trustedDistanceMeters = 110.0,
+                continuityAllowsSpeed = true,
+                provider = "fused",
+                horizontalAccuracyMeters = 8.0,
+                speedAccuracyMps = 1.2
+            )
+        )
+    }
+
+    @Test
     fun `extreme gps peak without speed accuracy cannot update max speed`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(
@@ -114,14 +129,14 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
-    fun `coarse gps point cannot update max speed`() {
+    fun `coarse fused point cannot update max speed`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(
                 reportedSpeedMps = 30.3,
                 deltaSeconds = 4,
                 trustedDistanceMeters = 110.0,
                 continuityAllowsSpeed = true,
-                provider = "gps",
+                provider = "fused",
                 horizontalAccuracyMeters = 60.0,
                 speedAccuracyMps = 1.2
             )
@@ -134,6 +149,18 @@ class TripSpeedTrustRulesTest {
             TripSpeedTrustRules.eligibleForMeasuredSpeed(
                 reportedSpeedMps = 15.0,
                 provider = "gps",
+                horizontalAccuracyMeters = 6.0,
+                speedAccuracyMps = 1.0
+            )
+        )
+    }
+
+    @Test
+    fun `accurate fused speed is eligible for visualization`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForMeasuredSpeed(
+                reportedSpeedMps = 15.0,
+                provider = "fused",
                 horizontalAccuracyMeters = 6.0,
                 speedAccuracyMps = 1.0
             )


### PR DESCRIPTION
## Problem

Fresh v0.6.30 physical evidence still shows real Trip point gaps while the phone is locked or another app stays foreground. The previous `LocationManager` path is no longer sufficient as the production source.

## What changed

- add Google Play services location dependency
- add a narrow `TripLocationSource` boundary
- add production `FusedTripLocationSource`
  - high accuracy target interval 4s
  - minimum interval 2s
  - 0m displacement gate
  - no intentional batching (`maxUpdateDelay=0`)
  - explicit main Looper because the service starts registration from an IO coroutine
- migrate `TripTrackingService` production callbacks from direct `LocationManager.requestLocationUpdates` to the fused source
- preserve the existing `handleLocation` processing path, original `Location.time`, freshness checks, continuity, trusted distance and >=120s LONG_GAP behavior
- keep system provider/permission health checks and explicit INTERRUPTED repair semantics
- allow accurate `provider=fused` speed samples through the same horizontal/speed-accuracy trust gates as GPS; network speed remains rejected
- add fused speed trust regression coverage

## Data-truth boundary

This does **not** synthesize points, connect missing geometry, weaken LONG_GAP, or rewrite captured coordinates/timestamps. If Android/OEM still withholds fixes, the gap remains visible as a real gap.

## Why this supersedes #204

#204 accumulated replay/foundation work on an older base and is now not directly mergeable with current `main`. This PR ports only the production migration needed for the physical blocker onto the latest `main`, including the recently merged live elapsed timer.

## Acceptance

- Android CI Green
- then physical sequence: foreground -> lock screen / another app foreground while moving -> stationary 2–3 min -> resume
- verify point cadence/gaps, trusted distance, speed visibility, stoppedSeconds, provider-loss behavior and no false geometry bridging

Refs #203 #77. Supersedes #204 for the production fix.