### PR TITLE
fix(trip): add non-GMS location fallback

### DIFF
--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -4,22 +4,42 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
 import android.os.Looper
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
+import java.util.concurrent.atomic.AtomicBoolean
 
-/** Production Trip source backed by Google Play services fused location. */
-class FusedTripLocationSource(context: Context) : TripLocationSource {
+/**
+ * Production Trip source backed by Google Play services fused location when available.
+ *
+ * Non-GMS devices transparently fall back to Android's platform fused/GPS/network source so
+ * starting a Trip never depends on Google Play services being installed.
+ */
+class FusedTripLocationSource(private val context: Context) : TripLocationSource {
     private val client: FusedLocationProviderClient =
         LocationServices.getFusedLocationProviderClient(context)
+    private val platformFallback = PlatformTripLocationSource(context)
+    private val fallbackStarted = AtomicBoolean(false)
 
+    @Volatile private var running = false
     private var callback: LocationCallback? = null
 
     @SuppressLint("MissingPermission")
     override fun start(callback: (Location) -> Unit) {
+        stop()
+        running = true
+        fallbackStarted.set(false)
+
+        if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) != ConnectionResult.SUCCESS) {
+            startPlatformFallback(callback)
+            return
+        }
+
         val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 4_000L)
             .setMinUpdateIntervalMillis(2_000L)
             .setMinUpdateDistanceMeters(0f)
@@ -32,14 +52,28 @@ class FusedTripLocationSource(context: Context) : TripLocationSource {
             }
         }
 
-        this.callback?.let(client::removeLocationUpdates)
         this.callback = fusedCallback
         // The service starts this source from an IO coroutine; always provide a concrete Looper.
         client.requestLocationUpdates(request, fusedCallback, Looper.getMainLooper())
+            .addOnFailureListener {
+                if (!running) return@addOnFailureListener
+                this.callback?.let(client::removeLocationUpdates)
+                this.callback = null
+                startPlatformFallback(callback)
+            }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startPlatformFallback(callback: (Location) -> Unit) {
+        if (!running || !fallbackStarted.compareAndSet(false, true)) return
+        platformFallback.start(callback)
     }
 
     override fun stop() {
+        running = false
         callback?.let(client::removeLocationUpdates)
         callback = null
+        platformFallback.stop()
+        fallbackStarted.set(false)
     }
 }

--- a/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
@@ -1,0 +1,72 @@
+package com.evchargebook.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Looper
+
+/**
+ * Framework-only fallback for devices where Google Play services location is unavailable.
+ *
+ * Prefer the platform fused provider when the device exposes it; otherwise fall back to the
+ * same GPS/network providers the app historically used. This keeps Trip recording functional
+ * on non-GMS Android devices without changing Trip continuity or persistence rules.
+ */
+class PlatformTripLocationSource(context: Context) : TripLocationSource {
+    private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    private var listener: LocationListener? = null
+
+    @SuppressLint("MissingPermission")
+    override fun start(callback: (Location) -> Unit) {
+        stop()
+        val newListener = LocationListener(callback)
+        listener = newListener
+
+        val providers = locationManager.allProviders
+        val fusedProvider = PLATFORM_FUSED_PROVIDER.takeIf { it in providers }
+        if (fusedProvider != null) {
+            val fusedRegistration = runCatching {
+                locationManager.requestLocationUpdates(
+                    fusedProvider,
+                    SAMPLE_INTERVAL_MS,
+                    0f,
+                    newListener,
+                    Looper.getMainLooper()
+                )
+            }
+            if (fusedRegistration.isSuccess) return
+        }
+
+        val fallbackProviders = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .filter { it in providers }
+        if (fallbackProviders.isEmpty()) {
+            listener = null
+            throw IllegalStateException("No platform location provider available")
+        }
+
+        fallbackProviders.forEach { provider ->
+            locationManager.requestLocationUpdates(
+                provider,
+                SAMPLE_INTERVAL_MS,
+                0f,
+                newListener,
+                Looper.getMainLooper()
+            )
+        }
+    }
+
+    override fun stop() {
+        listener?.let { current -> runCatching { locationManager.removeUpdates(current) } }
+        listener = null
+    }
+
+    private companion object {
+        // LocationManager.FUSED_PROVIDER is API 31, but the provider name itself has been used by
+        // Android's fused provider since earlier releases. Use the stable provider string because
+        // this app supports API 26+.
+        const val PLATFORM_FUSED_PROVIDER = "fused"
+        const val SAMPLE_INTERVAL_MS = 4_000L
+    }
+}


### PR DESCRIPTION
## Why

The production Trip source now prefers Google Play services Fused, but EV Charge Book must not stop recording on Android devices/ROMs where Google Play services location is unavailable.

## What changed

- add `PlatformTripLocationSource`
- prefer the framework `fused` provider when the device exposes it
- fall back further to framework GPS/network providers when needed
- make `FusedTripLocationSource` check Google Play services availability before registration
- if Google Play fused registration fails asynchronously, switch once to the platform fallback
- stop both sources cleanly when the Trip service ends

## Data-truth boundary

All sources feed the same existing `handleLocation` path. No point synthesis, road snapping, timestamp rewriting or LONG_GAP weakening is introduced.

## Acceptance

- Android CI Green
- GMS device still uses Google Play fused
- non-GMS/unavailable-GMS device can start and continue Trip through platform location
- final lock-screen/background acceptance remains #203/#77

Refs #203 #77.