### PR TITLE
fix(trip): make live speed and distance react faster

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripSamplingRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSamplingRules.kt
@@ -14,7 +14,9 @@ object TripSamplingRules {
     const val MAX_IMPLIED_SPEED_MPS = 90.0
     const val MOVING_SPEED_MPS = 1.0
     const val MOVING_DISTANCE_METERS = 5.0
-    const val STATIONARY_STORE_INTERVAL_SECONDS = 15L
+    // Keep a short stationary heartbeat so active speed/stopped time does not look frozen,
+    // while still avoiding one Room write for every 1 Hz provider callback at a long stop.
+    const val STATIONARY_STORE_INTERVAL_SECONDS = 2L
 
     fun decide(
         deltaSeconds: Long,

--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -40,8 +40,8 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
             return
         }
 
-        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 4_000L)
-            .setMinUpdateIntervalMillis(2_000L)
+        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1_000L)
+            .setMinUpdateIntervalMillis(1_000L)
             .setMinUpdateDistanceMeters(0f)
             .setMaxUpdateDelayMillis(0L)
             .build()

--- a/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
@@ -67,6 +67,6 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
         // Android's fused provider since earlier releases. Use the stable provider string because
         // this app supports API 26+.
         const val PLATFORM_FUSED_PROVIDER = "fused"
-        const val SAMPLE_INTERVAL_MS = 4_000L
+        const val SAMPLE_INTERVAL_MS = 1_000L
     }
 }

--- a/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
@@ -17,29 +17,29 @@ class TripSamplingRulesTest {
     }
 
     @Test
-    fun throttlesStationaryPointsBeforeFifteenSeconds() {
-        assertFalse(TripSamplingRules.decide(8, 1.0, 0.0, 10.0).accept)
+    fun throttlesOneSecondStationaryPoint() {
+        assertFalse(TripSamplingRules.decide(1, 1.0, 0.0, 10.0).accept)
     }
 
     @Test
-    fun keepsStationaryHeartbeatAfterFifteenSeconds() {
-        val decision = TripSamplingRules.decide(15, 1.0, 0.0, 10.0)
+    fun keepsStationaryHeartbeatAfterTwoSeconds() {
+        val decision = TripSamplingRules.decide(2, 1.0, 0.0, 10.0)
         assertTrue(decision.accept)
         assertFalse(decision.moving)
     }
 
     @Test
     fun stationaryHeartbeatAccumulatesStoppedTime() {
-        val decision = TripSamplingRules.decide(16, 1.0, 0.0, 10.0)
+        val decision = TripSamplingRules.decide(2, 1.0, 0.0, 10.0)
         assertTrue(decision.accept)
         assertFalse(decision.moving)
-        assertEquals(46L, TripSamplingRules.stoppedSeconds(30L, 16L, decision.moving))
-        assertEquals(30L, TripSamplingRules.movingSeconds(30L, 16L, decision.moving))
+        assertEquals(32L, TripSamplingRules.stoppedSeconds(30L, 2L, decision.moving))
+        assertEquals(30L, TripSamplingRules.movingSeconds(30L, 2L, decision.moving))
     }
 
     @Test
-    fun acceptsNormalMovingSegment() {
-        val decision = TripSamplingRules.decide(4, 18.0, 4.0, 8.0)
+    fun acceptsOneSecondMovingSegment() {
+        val decision = TripSamplingRules.decide(1, 6.0, 6.0, 8.0)
         assertTrue(decision.accept)
         assertTrue(decision.moving)
     }


### PR DESCRIPTION
## Device feedback

GPS continuity is now good, but active speed/distance still feels delayed, especially when stopping at a red light.

## What changed

- request high-accuracy Trip location at ~1 Hz instead of ~4 s on Google Fused
- match the platform fused/GPS/network fallback to the same 1 Hz target
- keep `maxUpdateDelay=0` and 0 m displacement gating
- shorten stationary persistence heartbeat from 15 s to 2 s
- keep the first/ongoing moving samples at provider cadence, so distance and current speed refresh much more often
- retain all existing accuracy, jump, continuity, speed-trust and LONG_GAP gates
- update sampling regression tests for 1 s moving cadence and 2 s stationary heartbeat

## Important speed semantics

No `+3 km/h` correction is added. EV Charge Book continues to display trusted GPS ground speed; the vehicle cluster may intentionally read slightly higher. This PR fixes latency, not calibration-by-offset.

## Expected device behavior

- moving distance/speed refresh about once per second when the provider delivers at that cadence
- after stopping, current speed should fall to 0 within roughly 2 s instead of remaining stale for up to 15 s
- long stationary periods still avoid a Room write every provider callback

Refs #222 #77.