### PR TITLE
fix(trip): make elevation analytics less noisy

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/trip/TripElevationAnalytics.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/trip/TripElevationAnalytics.kt
@@ -7,9 +7,9 @@ import kotlin.math.abs
 /**
  * Presentation analytics derived from already-persisted TripPoint altitude facts.
  *
- * This deliberately does not change Trip/GPS acceptance rules. It only avoids turning
- * obviously weak vertical fixes, tiny altitude jitter, or long GPS gaps into cumulative
- * climb/descent claims.
+ * Raw TripPoint altitude remains untouched. The presentation layer applies conservative vertical
+ * accuracy filtering plus a small median filter inside continuous GPS segments so isolated GNSS
+ * altitude spikes do not become user-facing min/max or climb/descent claims.
  */
 data class TripElevationSummary(
     val startAltitudeMeters: Double,
@@ -24,12 +24,20 @@ data class TripElevationSummary(
     val hasCumulativeEstimate: Boolean get() = trustedSampleCount >= 2
 }
 
-object TripElevationAnalytics {
-    const val MAX_VERTICAL_ACCURACY_METERS = 30.0
-    const val MIN_SIGNIFICANT_ALTITUDE_CHANGE_METERS = 3.0
+data class TripElevationSample(
+    val capturedAtEpochMillis: Long,
+    val altitudeMeters: Double,
+    val verticalAccuracyMeters: Double?
+)
 
-    fun summarize(points: List<TripPointEntity>): TripElevationSummary? {
-        val samples = points
+object TripElevationAnalytics {
+    const val MAX_VERTICAL_ACCURACY_METERS = 20.0
+    const val MIN_SIGNIFICANT_ALTITUDE_CHANGE_METERS = 4.0
+    private const val MEDIAN_WINDOW_RADIUS = 2
+    private const val MIN_SAMPLES_FOR_MEDIAN_FILTER = 7
+
+    fun filteredSeries(points: List<TripPointEntity>): List<TripElevationSample> {
+        val trusted = points
             .asSequence()
             .sortedBy { it.capturedAtEpochMillis }
             .mapNotNull { point ->
@@ -40,7 +48,7 @@ object TripElevationAnalytics {
                 ) {
                     return@mapNotNull null
                 }
-                ElevationSample(
+                TripElevationSample(
                     capturedAtEpochMillis = point.capturedAtEpochMillis,
                     altitudeMeters = altitude,
                     verticalAccuracyMeters = verticalAccuracy
@@ -48,6 +56,15 @@ object TripElevationAnalytics {
             }
             .toList()
 
+        if (trusted.size < MIN_SAMPLES_FOR_MEDIAN_FILTER) return trusted
+
+        return splitContinuousSegments(trusted).flatMap { segment ->
+            if (segment.size < MIN_SAMPLES_FOR_MEDIAN_FILTER) segment else medianFilter(segment)
+        }
+    }
+
+    fun summarize(points: List<TripPointEntity>): TripElevationSummary? {
+        val samples = filteredSeries(points)
         if (samples.isEmpty()) return null
 
         var gainMeters = 0.0
@@ -91,9 +108,43 @@ object TripElevationAnalytics {
         )
     }
 
-    private data class ElevationSample(
-        val capturedAtEpochMillis: Long,
-        val altitudeMeters: Double,
-        val verticalAccuracyMeters: Double?
-    )
+    private fun splitContinuousSegments(samples: List<TripElevationSample>): List<List<TripElevationSample>> {
+        if (samples.isEmpty()) return emptyList()
+        val result = mutableListOf<MutableList<TripElevationSample>>()
+        var current = mutableListOf(samples.first())
+        result += current
+        samples.zipWithNext().forEach { (previous, next) ->
+            val deltaSeconds = ((next.capturedAtEpochMillis - previous.capturedAtEpochMillis) / 1000)
+                .coerceAtLeast(0L)
+            if (deltaSeconds >= TripContinuityRules.LONG_GAP_SECONDS) {
+                current = mutableListOf()
+                result += current
+            }
+            current += next
+        }
+        return result.filter { it.isNotEmpty() }
+    }
+
+    private fun medianFilter(segment: List<TripElevationSample>): List<TripElevationSample> =
+        segment.mapIndexed { index, sample ->
+            val altitudeWindow = List(MEDIAN_WINDOW_RADIUS * 2 + 1) { offset ->
+                val sourceIndex = (index + offset - MEDIAN_WINDOW_RADIUS).coerceIn(0, segment.lastIndex)
+                segment[sourceIndex].altitudeMeters
+            }
+            val accuracyWindow = List(MEDIAN_WINDOW_RADIUS * 2 + 1) { offset ->
+                val sourceIndex = (index + offset - MEDIAN_WINDOW_RADIUS).coerceIn(0, segment.lastIndex)
+                segment[sourceIndex].verticalAccuracyMeters
+            }.filterNotNull()
+
+            sample.copy(
+                altitudeMeters = median(altitudeWindow),
+                verticalAccuracyMeters = accuracyWindow.takeIf { it.isNotEmpty() }?.let(::median)
+            )
+        }
+
+    private fun median(values: List<Double>): Double {
+        val sorted = values.sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 1) sorted[middle] else (sorted[middle - 1] + sorted[middle]) / 2.0
+    }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.domain.TripSpeedTrustRules
+import com.evchargebook.domain.trip.TripElevationAnalytics
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 
@@ -30,8 +31,8 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
         }
     }
     val altitudeSamples = remember(points) {
-        points.mapNotNull { point ->
-            trustedDetailAltitudeV06(point)?.let { TripTrendSampleV06(point.capturedAtEpochMillis, it) }
+        TripElevationAnalytics.filteredSeries(points).map { sample ->
+            TripTrendSampleV06(sample.capturedAtEpochMillis, sample.altitudeMeters)
         }
     }
 
@@ -53,7 +54,7 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text("趋势", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                     Text(
-                        "横轴为行程时间，纵轴为可信样本值；超过 2 分钟的缺口保持断开。",
+                        "横轴为行程时间，纵轴为可信样本值；海拔使用稳健滤波，超过 2 分钟的缺口保持断开。",
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -160,15 +161,6 @@ private fun trustedDetailSpeedV06(point: TripPointEntity): Double? {
             speedAccuracyMps = point.speedAccuracyMps
         )
     }
-}
-
-private fun trustedDetailAltitudeV06(point: TripPointEntity): Double? {
-    val altitude = point.altitudeMeters?.takeIf { it.isFinite() } ?: return null
-    val verticalAccuracy = point.verticalAccuracyMeters
-    if (verticalAccuracy != null && (!verticalAccuracy.isFinite() || verticalAccuracy > 50.0)) return null
-    val horizontalAccuracy = point.horizontalAccuracyMeters
-    if (horizontalAccuracy != null && (!horizontalAccuracy.isFinite() || horizontalAccuracy > 80.0)) return null
-    return altitude
 }
 
 private fun formatDetailTrendValueV06(value: Double, unit: String): String =

--- a/android/app/src/test/java/com/evchargebook/domain/trip/TripElevationAnalyticsTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/trip/TripElevationAnalyticsTest.kt
@@ -12,9 +12,9 @@ class TripElevationAnalyticsTest {
         val summary = TripElevationAnalytics.summarize(
             listOf(
                 point(seconds = 0, altitude = 10.0, verticalAccuracy = 2.0),
-                point(seconds = 10, altitude = 12.0, verticalAccuracy = 2.0), // jitter below 3m deadband
-                point(seconds = 20, altitude = 16.0, verticalAccuracy = 2.0), // +6m from anchor
-                point(seconds = 30, altitude = 11.0, verticalAccuracy = 2.0)  // -5m
+                point(seconds = 10, altitude = 12.0, verticalAccuracy = 2.0),
+                point(seconds = 20, altitude = 16.0, verticalAccuracy = 2.0),
+                point(seconds = 30, altitude = 11.0, verticalAccuracy = 2.0)
             )
         )!!
 
@@ -87,6 +87,35 @@ class TripElevationAnalyticsTest {
         )!!
 
         assertEquals(9.0, summary.elevationGainMeters, 0.001)
+    }
+
+    @Test
+    fun `median filter suppresses isolated altitude spikes on a flat drive`() {
+        val altitudes = listOf(100.0, 112.0, 99.0, 111.0, 100.0, 102.0, 98.0, 101.0, 100.0)
+        val summary = TripElevationAnalytics.summarize(
+            altitudes.mapIndexed { index, altitude ->
+                point(seconds = index * 5L, altitude = altitude, verticalAccuracy = 4.0)
+            }
+        )!!
+
+        assertTrue(summary.maxAltitudeMeters - summary.minAltitudeMeters <= 3.0)
+        assertTrue(summary.elevationGainMeters <= 4.0)
+        assertTrue(summary.elevationLossMeters <= 4.0)
+    }
+
+    @Test
+    fun `median filter keeps a sustained climb visible`() {
+        val altitudes = listOf(100.0, 102.0, 104.0, 106.0, 108.0, 110.0, 112.0, 114.0, 116.0)
+        val summary = TripElevationAnalytics.summarize(
+            altitudes.mapIndexed { index, altitude ->
+                point(seconds = index * 5L, altitude = altitude, verticalAccuracy = 3.0)
+            }
+        )!!
+
+        assertEquals(100.0, summary.startAltitudeMeters, 0.001)
+        assertEquals(116.0, summary.endAltitudeMeters, 0.001)
+        assertEquals(16.0, summary.elevationGainMeters, 0.001)
+        assertEquals(0.0, summary.elevationLossMeters, 0.001)
     }
 
     @Test


### PR DESCRIPTION
## Device feedback

A mostly flat/casual drive can currently show a height range of more than ten meters.

## What changed

- keep persisted raw TripPoint altitude untouched
- tighten accepted vertical accuracy from 30 m to 20 m
- build a shared presentation elevation series
- for sufficiently dense continuous segments, apply a 5-sample median filter with edge clamping
- never filter across >=120 s LONG_GAP boundaries
- raise the minimum significant cumulative altitude change from 3 m to 4 m
- use the same filtered series for completed Trip altitude trend and summary
- add regression coverage for noisy flat altitude and sustained climb

## Why

GNSS vertical accuracy is materially weaker/noisier than horizontal position. Raw min/max amplifies isolated spikes, so the UI should treat altitude as an uncertainty-aware estimate rather than an exact sensor value.

## Boundary

- no raw GPS point is rewritten
- no synthetic route point is introduced
- this does not yet change persisted altitude datum to API 34+ MSL altitude; that needs an explicit migration/data-semantics decision

Refs #225.