### PR TITLE
fix(trip): smooth route gestures and SOC wheel

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveTelemetryV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveTelemetryV06.kt
@@ -1,5 +1,8 @@
 package com.evchargebook.ui.trip
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,6 +45,7 @@ import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
+import kotlinx.coroutines.launch
 
 private const val ACTIVE_TREND_LONG_GAP_MS = 120_000L
 
@@ -182,7 +187,26 @@ private fun ActiveRouteCanvasV06(
 ) {
     var zoom by remember(viewportKey) { mutableFloatStateOf(1f) }
     var pan by remember(viewportKey) { mutableStateOf(Offset.Zero) }
+    val scope = rememberCoroutineScope()
     val viewportChanged = zoom > 1.001f || pan != Offset.Zero
+
+    fun animateBackToFullRoute() {
+        val startZoom = zoom
+        val startPan = pan
+        scope.launch {
+            animate(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)
+            ) { fraction, _ ->
+                zoom = startZoom + (1f - startZoom) * fraction
+                pan = Offset(
+                    x = startPan.x * (1f - fraction),
+                    y = startPan.y * (1f - fraction)
+                )
+            }
+        }
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
@@ -193,7 +217,7 @@ private fun ActiveRouteCanvasV06(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             if (viewportChanged) {
-                TextButton(onClick = { zoom = 1f; pan = Offset.Zero }) {
+                TextButton(onClick = ::animateBackToFullRoute) {
                     Text("回到全程", style = MaterialTheme.typography.labelSmall)
                 }
             }
@@ -203,15 +227,23 @@ private fun ActiveRouteCanvasV06(
             Modifier
                 .fillMaxWidth()
                 .height(170.dp)
-                .pointerInput(geometry, zoom, pan) {
-                    detectTransformGestures(panZoomLock = true) { _, gesturePan, gestureZoom, _ ->
-                        val newZoom = (zoom * gestureZoom).coerceIn(1f, 6f)
+                .pointerInput(viewportKey) {
+                    detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
+                        val oldZoom = zoom.coerceAtLeast(1f)
+                        val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
+                        val ratio = newZoom / oldZoom
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val anchoredPan = Offset(
+                            x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
+                            y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio
+                        )
                         val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
                         val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
+
                         zoom = newZoom
                         pan = Offset(
-                            x = (pan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
-                            y = (pan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY)
+                            x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
+                            y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY)
                         )
                     }
                 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripCompletionScreenV07.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripCompletionScreenV07.kt
@@ -1,8 +1,12 @@
 package com.evchargebook.ui.trip
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -12,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -37,6 +42,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,6 +57,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
@@ -60,6 +68,8 @@ import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 /**
  * Trip v0.7 completion surface.
@@ -313,52 +323,88 @@ private fun CompactSocWheelV07(
     modifier: Modifier = Modifier
 ) {
     val accent = EVDesignTokens.Energy.green
-    val thresholdPx = with(LocalDensity.current) { 24.dp.toPx() }
-    var accumulatedDrag by remember(value) { mutableFloatStateOf(0f) }
-    val previous = (value - 1).coerceAtLeast(0)
-    val next = (value + 1).coerceAtMost(100)
+    val stepPx = with(LocalDensity.current) { 34.dp.toPx() }
+    val scope = rememberCoroutineScope()
+    val currentValue by rememberUpdatedState(value)
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    var dragOffsetPx by remember { mutableFloatStateOf(0f) }
+
+    fun settle(snapToNearest: Boolean) {
+        val startOffset = dragOffsetPx
+        if (snapToNearest && abs(startOffset) >= stepPx * 0.45f) {
+            val targetValue = if (startOffset > 0f) currentValue - 1 else currentValue + 1
+            val clamped = targetValue.coerceIn(0, 100)
+            if (clamped != currentValue) {
+                currentOnValueChange(clamped)
+                dragOffsetPx = startOffset + if (startOffset > 0f) -stepPx else stepPx
+            }
+        }
+        val settleFrom = dragOffsetPx
+        scope.launch {
+            animate(
+                initialValue = settleFrom,
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 150, easing = FastOutSlowInEasing)
+            ) { animated, _ -> dragOffsetPx = animated }
+        }
+    }
 
     Column(
         modifier = modifier
             .semantics { contentDescription = "$label $value%，上下滑动调整" }
-            .pointerInput(value) {
+            .pointerInput(Unit) {
                 detectVerticalDragGestures(
                     onVerticalDrag = { change, dragAmount ->
                         change.consume()
-                        accumulatedDrag += dragAmount
-                        if (abs(accumulatedDrag) >= thresholdPx) {
-                            val newValue = if (accumulatedDrag > 0f) value - 1 else value + 1
-                            onValueChange(newValue.coerceIn(0, 100))
-                            accumulatedDrag = 0f
+                        var offset = dragOffsetPx + dragAmount
+                        val steps = (abs(offset) / stepPx).toInt()
+                        if (steps > 0) {
+                            val direction = if (offset > 0f) -1 else 1
+                            val target = (currentValue + direction * steps).coerceIn(0, 100)
+                            val consumedSteps = abs(target - currentValue)
+                            if (consumedSteps > 0) {
+                                currentOnValueChange(target)
+                                offset += if (offset > 0f) -stepPx * consumedSteps else stepPx * consumedSteps
+                            }
                         }
+                        dragOffsetPx = offset.coerceIn(-stepPx, stepPx)
                     },
-                    onDragEnd = { accumulatedDrag = 0f },
-                    onDragCancel = { accumulatedDrag = 0f }
+                    onDragEnd = { settle(snapToNearest = true) },
+                    onDragCancel = { settle(snapToNearest = false) }
                 )
             }
             .padding(horizontal = 4.dp, vertical = 2.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(1.dp)
+        verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
         Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(
-            if (value > 0) previous.toString() else "",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .42f)
-        )
-        Surface(shape = MaterialTheme.shapes.medium, color = accent.copy(alpha = .10f)) {
-            Text(
-                "$value%",
-                modifier = Modifier.padding(horizontal = 18.dp, vertical = 7.dp),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = accent
-            )
+        Box(modifier = Modifier.fillMaxWidth().height(102.dp), contentAlignment = Alignment.Center) {
+            Surface(
+                modifier = Modifier.fillMaxWidth().height(38.dp),
+                shape = MaterialTheme.shapes.medium,
+                color = accent.copy(alpha = .10f)
+            ) {}
+            Column(
+                modifier = Modifier.offset { IntOffset(0, dragOffsetPx.roundToInt()) },
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(0.dp)
+            ) {
+                SocWheelValueV07((value - 1).takeIf { it >= 0 }, selected = false, accent = accent)
+                SocWheelValueV07(value, selected = true, accent = accent)
+                SocWheelValueV07((value + 1).takeIf { it <= 100 }, selected = false, accent = accent)
+            }
         }
+    }
+}
+
+@Composable
+private fun SocWheelValueV07(value: Int?, selected: Boolean, accent: Color) {
+    Box(modifier = Modifier.height(34.dp), contentAlignment = Alignment.Center) {
         Text(
-            if (value < 100) next.toString() else "",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .42f)
+            text = value?.let { if (selected) "$it%" else it.toString() } ?: "",
+            style = if (selected) MaterialTheme.typography.titleMedium else MaterialTheme.typography.labelMedium,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .48f)
         )
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
@@ -1,6 +1,9 @@
 package com.evchargebook.ui.trip
 
 import android.os.SystemClock
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +34,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,8 +57,9 @@ import com.evchargebook.domain.trip.TripGeoPoint
 import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
-import kotlinx.coroutines.delay
 import java.util.Locale
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Completed-Trip playback surface for the current no-basemap renderer.
@@ -283,9 +288,29 @@ private fun PlaybackCanvasV06(
     accent: androidx.compose.ui.graphics.Color
 ) {
     val endColor = MaterialTheme.colorScheme.error
-    var zoom by remember(points.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
-    var pan by remember(points.firstOrNull()?.tripId) { mutableStateOf(Offset.Zero) }
+    val viewportKey = points.firstOrNull()?.tripId
+    var zoom by remember(viewportKey) { mutableFloatStateOf(1f) }
+    var pan by remember(viewportKey) { mutableStateOf(Offset.Zero) }
+    val scope = rememberCoroutineScope()
     val viewportChanged = zoom > 1.001f || pan != Offset.Zero
+
+    fun animateBackToFullRoute() {
+        val startZoom = zoom
+        val startPan = pan
+        scope.launch {
+            animate(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)
+            ) { fraction, _ ->
+                zoom = startZoom + (1f - startZoom) * fraction
+                pan = Offset(
+                    x = startPan.x * (1f - fraction),
+                    y = startPan.y * (1f - fraction)
+                )
+            }
+        }
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
@@ -296,7 +321,7 @@ private fun PlaybackCanvasV06(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             if (viewportChanged) {
-                TextButton(onClick = { zoom = 1f; pan = Offset.Zero }) {
+                TextButton(onClick = ::animateBackToFullRoute) {
                     Text("回到全程", style = MaterialTheme.typography.labelSmall)
                 }
             }
@@ -306,15 +331,23 @@ private fun PlaybackCanvasV06(
             Modifier
                 .fillMaxWidth()
                 .height(190.dp)
-                .pointerInput(points, zoom, pan) {
-                    detectTransformGestures(panZoomLock = true) { _, gesturePan, gestureZoom, _ ->
-                        val newZoom = (zoom * gestureZoom).coerceIn(1f, 6f)
+                .pointerInput(viewportKey) {
+                    detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
+                        val oldZoom = zoom.coerceAtLeast(1f)
+                        val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
+                        val ratio = newZoom / oldZoom
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val anchoredPan = Offset(
+                            x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
+                            y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio
+                        )
                         val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
                         val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
+
                         zoom = newZoom
                         pan = Offset(
-                            x = (pan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
-                            y = (pan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY)
+                            x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
+                            y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY)
                         )
                     }
                 }


### PR DESCRIPTION
## Device feedback

- route pinch/zoom feels mechanically stiff
- end-Trip SOC up/down adjustment jumps too abruptly

## Route changes

- stable gesture detector for active and completed playback routes
- pinch zoom anchored to the actual two-finger centroid
- preserve 1x..6x limits and pan bounds
- animate `回到全程` over 220 ms
- preserve truthful geometry, speed styling and LONG_GAP breaks

## SOC changes

- continuous number-column motion follows the finger
- one drag can cross multiple integer SOC values
- preserve residual drag offset when crossing rows
- release snaps/settles over 150 ms
- 0..100 external SOC remains source of truth; no keyboard/modal picker

## Rebase note

This is the clean latest-main port of the already CI-green #229 implementation so it does not overwrite #226/#227/#228.

Refs #223. Supersedes #229.