### PR TITLE
fix(trip): keep stationary gps drift out of distance

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripSamplingRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSamplingRules.kt
@@ -38,7 +38,14 @@ object TripSamplingRules {
             return TripSamplingDecision(false, false, "GPS 跳点")
         }
 
-        val moving = (reportedSpeedMps ?: 0.0) >= MOVING_SPEED_MPS || segmentDistanceMeters >= MOVING_DISTANCE_METERS
+        // When a trusted device speed is present, use it as the primary motion signal. This keeps
+        // several metres of normal stationary GNSS coordinate drift from turning a red-light stop
+        // into fake movement. Distance remains the fallback only when no trusted speed is present.
+        val moving = if (reportedSpeedMps != null) {
+            reportedSpeedMps >= MOVING_SPEED_MPS
+        } else {
+            segmentDistanceMeters >= MOVING_DISTANCE_METERS
+        }
         if (!moving && deltaSeconds in 1 until STATIONARY_STORE_INTERVAL_SECONDS) {
             return TripSamplingDecision(false, false, "静止降频")
         }

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -80,7 +80,6 @@ class TripTrackingService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            // Legacy/stale notification PendingIntents must never bypass the end-SOC completion flow.
             ACTION_STOP -> Unit
             ACTION_START -> {
                 val tripId = intent.getLongExtra(EXTRA_TRIP_ID, 0L)
@@ -191,8 +190,7 @@ class TripTrackingService : Service() {
             recordEvent(tripId, TripDiagnosticEventType.PROVIDER_DISABLED, provider = LocationManager.NETWORK_PROVIDER)
         }
 
-        val hasUsableProvider =
-            (fineGranted && gpsEnabled) || (coarseGranted && networkEnabled)
+        val hasUsableProvider = (fineGranted && gpsEnabled) || (coarseGranted && networkEnabled)
         if (!hasUsableProvider) {
             serviceScope.launch { interruptForRepair(tripId, TripTrackingRepairReason.LOCATION_PROVIDER_DISABLED) }
             return
@@ -206,9 +204,7 @@ class TripTrackingService : Service() {
                     val activeTripId = currentTripId ?: return@callback
                     lastCallbackAtEpochMillis = System.currentTimeMillis()
                     serviceScope.launch {
-                        pointMutex.withLock {
-                            handleLocation(activeTripId, location)
-                        }
+                        pointMutex.withLock { handleLocation(activeTripId, location) }
                     }
                 }
             }
@@ -345,7 +341,7 @@ class TripTrackingService : Service() {
 
         val newMovingSeconds = TripSamplingRules.movingSeconds(session.movingSeconds ?: 0, statsDeltaSeconds, decision.moving)
         val newStoppedSeconds = TripSamplingRules.stoppedSeconds(session.stoppedSeconds ?: 0, statsDeltaSeconds, decision.moving)
-        val newDistance = session.distanceMeters + trustedSegmentDistance
+        val newDistance = session.distanceMeters + if (decision.moving) trustedSegmentDistance else 0.0
         val altitude = location.altitude.takeIf { location.hasAltitude() }
 
         val point = TripPointEntity(

--- a/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSamplingRulesTest.kt
@@ -29,6 +29,20 @@ class TripSamplingRulesTest {
     }
 
     @Test
+    fun trustedZeroSpeedWinsOverSeveralMetresOfStationaryGpsDrift() {
+        val decision = TripSamplingRules.decide(2, 6.5, 0.0, 8.0)
+        assertTrue(decision.accept)
+        assertFalse(decision.moving)
+    }
+
+    @Test
+    fun distanceStillDetectsMovementWhenTrustedSpeedIsUnavailable() {
+        val decision = TripSamplingRules.decide(2, 6.5, null, 8.0)
+        assertTrue(decision.accept)
+        assertTrue(decision.moving)
+    }
+
+    @Test
     fun stationaryHeartbeatAccumulatesStoppedTime() {
         val decision = TripSamplingRules.decide(2, 1.0, 0.0, 10.0)
         assertTrue(decision.accept)


### PR DESCRIPTION
## Follow-up to #226

The faster 1 Hz provider cadence + 2 s stationary heartbeat makes live speed react promptly, but accepted stationary coordinate jitter must not become distance.

## What changed

- when a trusted reported speed exists, use it as the primary moving/stationary signal
- use segment distance as the motion fallback only when trusted speed is unavailable
- a trusted 0 m/s reading therefore wins over several metres of normal stationary GNSS coordinate drift
- accepted stationary heartbeat points still persist so `当前速度` can show 0 and `stoppedSeconds` can advance
- stationary heartbeat contributes 0 m to Trip distance
- moving segments continue to accumulate trusted distance
- add regression tests for zero-speed + 6.5 m drift and no-speed distance fallback

## Boundary

No GPS point is deleted or rewritten. Route facts remain available; only aggregate distance/moving statistics stop treating a trusted stationary fix as driving.

Refs #222.