### PR TITLE
fix(dashboard): polish recent trip and charging cards

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.evchargebook.data.entity.TripSessionEntity
+import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.location.AndroidGeocoderAddressResolver
 import com.evchargebook.ui.theme.EVDesignTokens
 import java.text.SimpleDateFormat
@@ -56,6 +57,8 @@ fun DashboardRecentTripCard(
         return
     }
 
+    val isActive = trip.status == TripStatus.RECORDING
+    val isInterrupted = trip.status == TripStatus.INTERRUPTED
     val context = androidx.compose.ui.platform.LocalContext.current
     val resolver = remember(context) { AndroidGeocoderAddressResolver(context) }
     var startAddress by remember(trip.id) { mutableStateOf<String?>(null) }
@@ -64,19 +67,33 @@ fun DashboardRecentTripCard(
 
     LaunchedEffect(
         trip.id,
+        trip.status,
         trip.startLatitude,
         trip.startLongitude,
-        trip.endLatitude,
-        trip.endLongitude
+        if (isActive) null else trip.endLatitude,
+        if (isActive) null else trip.endLongitude
     ) {
         resolving = true
         startAddress = resolveEndpoint(resolver, trip.startLatitude, trip.startLongitude)
         endAddress = when {
+            isActive -> null
             trip.endLatitude == null || trip.endLongitude == null -> null
             trip.startLatitude == trip.endLatitude && trip.startLongitude == trip.endLongitude -> startAddress
             else -> resolveEndpoint(resolver, trip.endLatitude, trip.endLongitude)
         }
         resolving = false
+    }
+
+    val statusText = when {
+        isActive -> "进行中"
+        isInterrupted -> "已中断"
+        else -> "已完成"
+    }
+    val statusColor = if (isInterrupted) MaterialTheme.colorScheme.error else EVDesignTokens.Energy.green
+    val endText = if (isActive) {
+        if (trip.endLatitude != null && trip.endLongitude != null) "当前位置 · 持续更新" else "等待当前位置"
+    } else {
+        endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)
     }
 
     Surface(
@@ -93,7 +110,9 @@ fun DashboardRecentTripCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onOpenTrip(trip.id) }
+                    .clickable {
+                        if (trip.status == TripStatus.COMPLETED) onOpenTrip(trip.id) else onViewAll()
+                    }
                     .padding(top = 1.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -111,13 +130,13 @@ fun DashboardRecentTripCard(
                     )
                     Surface(
                         shape = CircleShape,
-                        color = EVDesignTokens.Energy.green.copy(alpha = 0.10f)
+                        color = statusColor.copy(alpha = 0.10f)
                     ) {
                         Text(
-                            "已完成",
+                            statusText,
                             modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
                             style = MaterialTheme.typography.labelSmall,
-                            color = EVDesignTokens.Energy.green
+                            color = statusColor
                         )
                     }
                 }
@@ -135,9 +154,7 @@ fun DashboardRecentTripCard(
                         TripEndpointRow(
                             address = endpointText(startAddress, trip.startLatitude, trip.startLongitude, resolving)
                         )
-                        TripEndpointRow(
-                            address = endpointText(endAddress, trip.endLatitude, trip.endLongitude, resolving)
-                        )
+                        TripEndpointRow(address = endText)
                     }
                 }
 
@@ -153,7 +170,11 @@ fun DashboardRecentTripCard(
                     MetricSeparator()
                     TripMetric(formatConsumptionValue(trip.averageConsumptionKwhPer100Km), "kWh/100km", Modifier.weight(1.15f))
                     MetricSeparator()
-                    TripMetric(formatSocConsumed(trip.startSoc, trip.endSoc), "SOC", Modifier.weight(1f))
+                    TripMetric(
+                        value = if (isActive) trip.startSoc?.let { "$it%" } ?: "--" else formatSocConsumed(trip.startSoc, trip.endSoc),
+                        label = if (isActive) "起始SOC" else "SOC",
+                        modifier = Modifier.weight(1f)
+                    )
                 }
             }
         }
@@ -229,23 +250,22 @@ private fun TripEndpointRow(address: String) {
 
 @Composable
 private fun TripRouteRail() {
-    val markerColor = MaterialTheme.colorScheme.onSurfaceVariant
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Icon(
             imageVector = Icons.Default.PlayArrow,
             contentDescription = "起点",
-            tint = markerColor.copy(alpha = 0.92f),
+            tint = EVDesignTokens.Energy.green,
             modifier = Modifier.size(16.dp)
         )
         Box(
             Modifier
                 .size(width = 1.dp, height = 28.dp)
-                .background(markerColor.copy(alpha = 0.38f))
+                .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f))
         )
         Icon(
             imageVector = Icons.Default.Flag,
-            contentDescription = "终点",
-            tint = markerColor.copy(alpha = 0.82f),
+            contentDescription = "终点或当前位置",
+            tint = MaterialTheme.colorScheme.error,
             modifier = Modifier.size(15.dp)
         )
     }
@@ -305,7 +325,7 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
-                        "完成第一段行程后，这里会显示距离、SOC 与可信的能耗估算。",
+                        "开始或完成第一段行程后，这里会显示当前进度、距离、SOC 与可信的能耗估算。",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardScreen.kt
@@ -54,6 +54,9 @@ fun DashboardScreen(
         .asSequence()
         .filter { it.vehicleId == selectedVehicleId && TripValidityRules.isEligibleForAnalytics(it) }
         .maxByOrNull { it.endedAtEpochMillis ?: it.startedAtEpochMillis }
+    val dashboardTrip = state.activeTrip
+        ?.takeIf { it.vehicleId == selectedVehicleId }
+        ?: latestCompletedTrip
 
     LazyColumn(
         modifier = Modifier
@@ -81,7 +84,7 @@ fun DashboardScreen(
         }
         item {
             DashboardRecentTripCard(
-                trip = latestCompletedTrip,
+                trip = dashboardTrip,
                 onViewAll = onOpenTrips,
                 onOpenTrip = onOpenTripDetail
             )
@@ -147,7 +150,7 @@ private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
             .padding(vertical = MaterialTheme.spacing.sm),
         verticalAlignment = Alignment.Top
     ) {
-        TimelineRail(isLast = true)
+        ChargingMarker()
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -157,7 +160,7 @@ private fun EmptyChargingTimeline(onAddClick: () -> Unit) {
             )
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
             Text(
-                "记录后会在这里形成连续的充电时间轴。",
+                "记录后会在这里显示最近的充电记录。",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -183,7 +186,7 @@ private fun ChargingTimelineRow(
             .padding(vertical = MaterialTheme.spacing.sm),
         verticalAlignment = Alignment.Top
     ) {
-        TimelineRail(isLast = false)
+        ChargingMarker()
         Spacer(Modifier.size(MaterialTheme.spacing.md))
         Column(modifier = Modifier.weight(1f)) {
             Row(
@@ -193,13 +196,15 @@ private fun ChargingTimelineRow(
             ) {
                 Text(
                     record.location ?: "未命名充电地点",
+                    modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold
                 )
                 Text(
-                    "¥ ${two(record.cost)}",
+                    "+ ${one(record.energyKwh)} kWh",
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold
+                    fontWeight = FontWeight.SemiBold,
+                    color = EVDesignTokens.Energy.green
                 )
             }
             Spacer(Modifier.height(MaterialTheme.spacing.xxs))
@@ -209,13 +214,14 @@ private fun ChargingTimelineRow(
             ) {
                 Text(
                     "${formatTime(record.chargeTimeEpochMillis)} · ${record.chargerType ?: "未标记方式"}",
+                    modifier = Modifier.weight(1f),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    "+ ${one(record.energyKwh)} kWh",
+                    "¥ ${two(record.cost)}",
                     style = MaterialTheme.typography.bodySmall,
-                    color = EVDesignTokens.Energy.green
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             }
         }
@@ -223,28 +229,19 @@ private fun ChargingTimelineRow(
 }
 
 @Composable
-private fun TimelineRail(isLast: Boolean) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Box(
-            modifier = Modifier
-                .size(32.dp)
-                .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Default.Bolt,
-                contentDescription = null,
-                tint = EVDesignTokens.Energy.green,
-                modifier = Modifier.size(16.dp)
-            )
-        }
-        if (!isLast) {
-            Box(
-                modifier = Modifier
-                    .size(width = 1.dp, height = 32.dp)
-                    .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.55f))
-            )
-        }
+private fun ChargingMarker() {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            Icons.Default.Bolt,
+            contentDescription = null,
+            tint = EVDesignTokens.Energy.green,
+            modifier = Modifier.size(16.dp)
+        )
     }
 }
 


### PR DESCRIPTION
## Device feedback

1. Recent Trip start/end icons are neutral and should reuse the colored Trip endpoint language.
2. An in-progress Trip should appear on Dashboard instead of only the latest completed Trip.
3. The vertical rail under each charging bolt icon is unnecessary.
4. Recent charging should show replenished energy above the price.

## Changes

- Dashboard Recent Trip now prioritizes the selected vehicle's `activeTrip`; falls back to latest completed Trip only when no active Trip exists.
- `RECORDING` shows a `进行中` pill and tapping the card opens the Trip workspace instead of completed-detail navigation.
- Active Trip start address is resolved normally, while the live endpoint is shown as `当前位置 · 持续更新` to avoid reverse-geocoding every 1 Hz GPS update.
- Start marker reuses the green PlayArrow; end/current marker reuses the red Flag treatment.
- Completed and interrupted status rendering remains explicit.
- Recent charging rows remove the decorative vertical rail under the bolt icon.
- Right-side charging values now show `+ xx.x kWh` on top and price below.
- Empty charging copy no longer calls the section a timeline after removing the rail.

No data model, GPS, Trip truth rules, or charging calculations are changed.