### PR TITLE
fix(trip): recover from silent location providers

### DIFF
--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -3,6 +3,7 @@ package com.evchargebook.location
 import android.annotation.SuppressLint
 import android.content.Context
 import android.location.Location
+import android.os.Handler
 import android.os.Looper
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -17,17 +18,20 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Production Trip source backed by Google Play services fused location when available.
  *
- * Non-GMS devices transparently fall back to Android's platform fused/GPS/network source so
- * starting a Trip never depends on Google Play services being installed.
+ * A successful registration is not treated as proof that the provider is healthy: some devices
+ * can accept a request but never deliver a fix. If the primary source stays silent, switch to the
+ * framework GPS/network fallback before the Trip health UI reaches its degraded boundary.
  */
 class FusedTripLocationSource(private val context: Context) : TripLocationSource {
     private val client: FusedLocationProviderClient =
         LocationServices.getFusedLocationProviderClient(context)
     private val platformFallback = PlatformTripLocationSource(context)
     private val fallbackStarted = AtomicBoolean(false)
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     @Volatile private var running = false
     private var callback: LocationCallback? = null
+    private var primarySilenceWatchdog: Runnable? = null
 
     @SuppressLint("MissingPermission")
     override fun start(callback: (Location) -> Unit) {
@@ -48,17 +52,24 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
 
         val fusedCallback = object : LocationCallback() {
             override fun onLocationResult(result: LocationResult) {
-                result.locations.forEach(callback)
+                if (!running || fallbackStarted.get()) return
+                val locations = result.locations
+                if (locations.isEmpty()) return
+                armPrimarySilenceWatchdog(callback)
+                locations.forEach(callback)
             }
         }
 
         this.callback = fusedCallback
         // The service starts this source from an IO coroutine; always provide a concrete Looper.
         client.requestLocationUpdates(request, fusedCallback, Looper.getMainLooper())
+            .addOnSuccessListener {
+                if (running && this.callback === fusedCallback && !fallbackStarted.get()) {
+                    armPrimarySilenceWatchdog(callback)
+                }
+            }
             .addOnFailureListener {
                 if (!running) return@addOnFailureListener
-                this.callback?.let(client::removeLocationUpdates)
-                this.callback = null
                 startPlatformFallback(callback)
             }
     }
@@ -66,14 +77,40 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
     @SuppressLint("MissingPermission")
     private fun startPlatformFallback(callback: (Location) -> Unit) {
         if (!running || !fallbackStarted.compareAndSet(false, true)) return
+        cancelPrimarySilenceWatchdog()
+        this.callback?.let(client::removeLocationUpdates)
+        this.callback = null
         platformFallback.start(callback)
+    }
+
+    private fun armPrimarySilenceWatchdog(callback: (Location) -> Unit) {
+        cancelPrimarySilenceWatchdog()
+        if (!running || fallbackStarted.get()) return
+        val watchdog = Runnable {
+            if (running && !fallbackStarted.get()) {
+                startPlatformFallback(callback)
+            }
+        }
+        primarySilenceWatchdog = watchdog
+        mainHandler.postDelayed(watchdog, PRIMARY_SILENCE_TIMEOUT_MS)
+    }
+
+    private fun cancelPrimarySilenceWatchdog() {
+        primarySilenceWatchdog?.let(mainHandler::removeCallbacks)
+        primarySilenceWatchdog = null
     }
 
     override fun stop() {
         running = false
+        cancelPrimarySilenceWatchdog()
         callback?.let(client::removeLocationUpdates)
         callback = null
         platformFallback.stop()
         fallbackStarted.set(false)
+    }
+
+    private companion object {
+        // TripGpsHealth becomes DEGRADED after 15s; fail over before the user sees a dead source.
+        const val PRIMARY_SILENCE_TIMEOUT_MS = 12_000L
     }
 }

--- a/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
@@ -8,11 +8,11 @@ import android.location.LocationManager
 import android.os.Looper
 
 /**
- * Framework-only fallback for devices where Google Play services location is unavailable.
+ * Framework-only fallback for devices where Google Play services location is unavailable or stalls.
  *
- * Prefer the platform fused provider when the device exposes it; otherwise fall back to the
- * same GPS/network providers the app historically used. This keeps Trip recording functional
- * on non-GMS Android devices without changing Trip continuity or persistence rules.
+ * Do not prefer the framework provider named "fused" here. Some OEM/China ROMs expose that name
+ * and accept registration without ever producing fixes. The fallback deliberately returns to the
+ * historically proven GPS/network providers and registers every enabled provider independently.
  */
 class PlatformTripLocationSource(context: Context) : TripLocationSource {
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -24,36 +24,33 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
         val newListener = LocationListener(callback)
         listener = newListener
 
-        val providers = locationManager.allProviders
-        val fusedProvider = PLATFORM_FUSED_PROVIDER.takeIf { it in providers }
-        if (fusedProvider != null) {
-            val fusedRegistration = runCatching {
+        val providers = locationManager.allProviders.toSet()
+        val candidates = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .filter { provider ->
+                provider in providers && runCatching { locationManager.isProviderEnabled(provider) }.getOrDefault(false)
+            }
+
+        var successfulRegistrations = 0
+        var lastFailure: Throwable? = null
+        candidates.forEach { provider ->
+            runCatching {
                 locationManager.requestLocationUpdates(
-                    fusedProvider,
+                    provider,
                     SAMPLE_INTERVAL_MS,
                     0f,
                     newListener,
                     Looper.getMainLooper()
                 )
+            }.onSuccess {
+                successfulRegistrations += 1
+            }.onFailure { error ->
+                lastFailure = error
             }
-            if (fusedRegistration.isSuccess) return
         }
 
-        val fallbackProviders = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
-            .filter { it in providers }
-        if (fallbackProviders.isEmpty()) {
+        if (successfulRegistrations == 0) {
             listener = null
-            throw IllegalStateException("No platform location provider available")
-        }
-
-        fallbackProviders.forEach { provider ->
-            locationManager.requestLocationUpdates(
-                provider,
-                SAMPLE_INTERVAL_MS,
-                0f,
-                newListener,
-                Looper.getMainLooper()
-            )
+            throw IllegalStateException("No enabled platform GPS/network provider could be registered", lastFailure)
         }
     }
 
@@ -63,10 +60,6 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
     }
 
     private companion object {
-        // LocationManager.FUSED_PROVIDER is API 31, but the provider name itself has been used by
-        // Android's fused provider since earlier releases. Use the stable provider string because
-        // this app supports API 26+.
-        const val PLATFORM_FUSED_PROVIDER = "fused"
         const val SAMPLE_INTERVAL_MS = 1_000L
     }
 }


### PR DESCRIPTION
## P0 regression

2026-08-31 real-device testing found that a Trip can start while GPS never responds, leaving the whole session without recorded Trip points.

## Root cause

The non-GMS fallback treated successful registration of the framework provider named `fused` as proof that the source was healthy. Some OEM/China ROMs can expose that provider and accept registration without delivering fixes. The Google Play Fused path had the same silent-stall class: it only fell back on explicit registration failure, not on successful registration with zero callbacks.

## Fix

- platform fallback no longer trusts the framework `fused` provider name
- register enabled GPS + network providers directly and independently
- keep tracking if either provider registration succeeds
- add a 12s no-callback watchdog to the Google Play Fused primary
- if the primary stays silent, remove it and switch to platform GPS/network before the existing 15s DEGRADED boundary
- keep the existing 1s target cadence and 0m displacement

## Truth boundaries preserved

- original `Location.time` remains authoritative
- existing Trip continuity / sampling / speed trust rules are unchanged
- `LONG_GAP_SECONDS = 120` is unchanged
- no synthetic points, road snapping, or fabricated distance

## Acceptance

- Android CI green
- physical device: Trip receives a first fix instead of waiting indefinitely
- normal foreground drive records points/distance
- lock-screen/background drive remains functional
- #203 stays open until the physical-device pass succeeds

Refs #203 #77