### PR TITLE
feat: add auto-trip eligibility policy spike

### DIFF
--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
@@ -101,6 +101,7 @@ sealed class AutoTripDecision(open val reason: AutoTripReasonCode) {
  * - PROMPT_ONLY never returns Start.
  * - VERIFIED_AUTO_START fails closed when required capabilities are unavailable.
  * - FGS background-start denial downgrades to a user-visible prompt rather than a silent start.
+ * - Failed/terminal sessions never silently retry themselves.
  * - No Trip is created here; a future TripStartCoordinator owns that authority.
  */
 object AutoTripEligibilityPolicy {
@@ -132,6 +133,7 @@ object AutoTripEligibilityPolicy {
             AutoTripDetectionState.RECORDING,
             AutoTripDetectionState.POSSIBLE_END,
             AutoTripDetectionState.END_CONFIRMATION,
+            AutoTripDetectionState.START_FAILED,
             AutoTripDetectionState.BLOCKED,
             -> return AutoTripDecision.Block(AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
 

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
@@ -1,0 +1,175 @@
+package com.evchargebook.autotrip
+
+/**
+ * User-selected behavior for vehicle Bluetooth automation.
+ *
+ * This model is intentionally pure Kotlin and is not wired into production receivers yet.
+ */
+enum class AutoTripMode {
+    OFF,
+    PROMPT_ONLY,
+    VERIFIED_AUTO_START,
+}
+
+/**
+ * Product-level lifecycle for one Bluetooth detection session.
+ */
+enum class AutoTripDetectionState {
+    IDLE,
+    BLUETOOTH_CANDIDATE,
+    VERIFYING_DRIVE,
+    READY_TO_START,
+    STARTING,
+    RECORDING,
+    POSSIBLE_END,
+    END_CONFIRMATION,
+    IGNORED,
+    EXPIRED,
+    START_FAILED,
+    BLOCKED,
+}
+
+/**
+ * Stable, machine-readable reasons used by policy decisions, tests and future local audit logs.
+ */
+enum class AutoTripReasonCode {
+    OFF,
+    DEVICE_NOT_BOUND,
+    BLUETOOTH_NOT_CONNECTED,
+    ACTIVE_TRIP_EXISTS,
+    SESSION_IGNORED,
+    SESSION_EXPIRED,
+    SESSION_NOT_ELIGIBLE,
+    COOLDOWN_ACTIVE,
+    NOTIFICATION_PERMISSION_MISSING,
+    LOCATION_PERMISSION_MISSING,
+    PROVIDER_UNAVAILABLE,
+    FGS_START_NOT_ALLOWED,
+    PROMPT_ONLY,
+    WAITING_FOR_EVIDENCE,
+    VERIFIED_BY_MOVEMENT,
+    VERIFIED_BY_MOVEMENT_AND_ACTIVITY,
+}
+
+/**
+ * Pre-classified evidence produced by a future bounded evidence collector.
+ *
+ * Thresholds do not live here. The collector is responsible for deciding whether movement is
+ * trusted according to the current location quality rules. This keeps policy free of magic
+ * distance/speed constants and lets Phase 0/Shadow Mode calibrate them separately.
+ */
+data class DriveEvidenceSummary(
+    val bluetoothConnected: Boolean,
+    val hasTrustedMovement: Boolean,
+    val inVehicleDetected: Boolean = false,
+)
+
+/**
+ * Complete policy input. Callers must provide current capability/permission state instead of
+ * allowing the policy to reach into Android framework APIs.
+ */
+data class AutoTripEligibilityInput(
+    val mode: AutoTripMode,
+    val deviceBound: Boolean,
+    val detectionState: AutoTripDetectionState = AutoTripDetectionState.IDLE,
+    val activeTripExists: Boolean = false,
+    val cooldownActive: Boolean = false,
+    val notificationPermissionGranted: Boolean = true,
+    val locationPermissionGranted: Boolean = true,
+    val locationProviderAvailable: Boolean = true,
+    val foregroundServiceStartAllowed: Boolean = true,
+    val evidence: DriveEvidenceSummary,
+)
+
+sealed class AutoTripDecision(open val reason: AutoTripReasonCode) {
+    data class Ignore(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Prompt(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Verify(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Start(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Block(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+}
+
+/**
+ * Pure decision policy for #235.
+ *
+ * Important boundaries:
+ * - Bluetooth is a candidate signal, never proof of driving by itself.
+ * - PROMPT_ONLY never returns Start.
+ * - VERIFIED_AUTO_START fails closed when required capabilities are unavailable.
+ * - FGS background-start denial downgrades to a user-visible prompt rather than a silent start.
+ * - No Trip is created here; a future TripStartCoordinator owns that authority.
+ */
+object AutoTripEligibilityPolicy {
+    fun decide(input: AutoTripEligibilityInput): AutoTripDecision {
+        if (input.mode == AutoTripMode.OFF) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.OFF)
+        }
+
+        if (!input.deviceBound) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.DEVICE_NOT_BOUND)
+        }
+
+        if (!input.evidence.bluetoothConnected) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.BLUETOOTH_NOT_CONNECTED)
+        }
+
+        if (input.activeTripExists) {
+            return AutoTripDecision.Block(AutoTripReasonCode.ACTIVE_TRIP_EXISTS)
+        }
+
+        when (input.detectionState) {
+            AutoTripDetectionState.IGNORED ->
+                return AutoTripDecision.Ignore(AutoTripReasonCode.SESSION_IGNORED)
+
+            AutoTripDetectionState.EXPIRED ->
+                return AutoTripDecision.Ignore(AutoTripReasonCode.SESSION_EXPIRED)
+
+            AutoTripDetectionState.STARTING,
+            AutoTripDetectionState.RECORDING,
+            AutoTripDetectionState.POSSIBLE_END,
+            AutoTripDetectionState.END_CONFIRMATION,
+            AutoTripDetectionState.BLOCKED,
+            -> return AutoTripDecision.Block(AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+
+            else -> Unit
+        }
+
+        if (input.cooldownActive) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.COOLDOWN_ACTIVE)
+        }
+
+        if (!input.notificationPermissionGranted) {
+            return AutoTripDecision.Block(AutoTripReasonCode.NOTIFICATION_PERMISSION_MISSING)
+        }
+
+        if (input.mode == AutoTripMode.PROMPT_ONLY) {
+            return AutoTripDecision.Prompt(AutoTripReasonCode.PROMPT_ONLY)
+        }
+
+        if (!input.locationPermissionGranted) {
+            return AutoTripDecision.Block(AutoTripReasonCode.LOCATION_PERMISSION_MISSING)
+        }
+
+        if (!input.locationProviderAvailable) {
+            return AutoTripDecision.Block(AutoTripReasonCode.PROVIDER_UNAVAILABLE)
+        }
+
+        if (!input.foregroundServiceStartAllowed) {
+            return AutoTripDecision.Prompt(AutoTripReasonCode.FGS_START_NOT_ALLOWED)
+        }
+
+        if (!input.evidence.hasTrustedMovement) {
+            return AutoTripDecision.Verify(AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+        }
+
+        return if (input.evidence.inVehicleDetected) {
+            AutoTripDecision.Start(AutoTripReasonCode.VERIFIED_BY_MOVEMENT_AND_ACTIVITY)
+        } else {
+            AutoTripDecision.Start(AutoTripReasonCode.VERIFIED_BY_MOVEMENT)
+        }
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -55,6 +55,17 @@ class AutoTripEligibilityPolicyTest {
     }
 
     @Test
+    fun `start failed session cannot silently retry`() {
+        val decision = decide(
+            detectionState = AutoTripDetectionState.START_FAILED,
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+    }
+
+    @Test
     fun `cooldown suppresses a new candidate`() {
         val decision = decide(cooldownActive = true)
 

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -176,7 +176,7 @@ class AutoTripEligibilityPolicyTest {
         decision: AutoTripDecision,
         reason: AutoTripReasonCode,
     ) {
-        assertTrue("Expected ${T::class.simpleName}, got ${decision::class.simpleName}", decision is T)
+        assertTrue(decision is T)
         assertEquals(reason, decision.reason)
     }
 }

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -1,0 +1,182 @@
+package com.evchargebook.autotrip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoTripEligibilityPolicyTest {
+    @Test
+    fun `off mode always ignores`() {
+        val decision = decide(mode = AutoTripMode.OFF)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.OFF)
+    }
+
+    @Test
+    fun `unbound device is ignored`() {
+        val decision = decide(deviceBound = false)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.DEVICE_NOT_BOUND)
+    }
+
+    @Test
+    fun `disconnected target cannot create candidate`() {
+        val decision = decide(bluetoothConnected = false)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.BLUETOOTH_NOT_CONNECTED)
+    }
+
+    @Test
+    fun `active trip blocks another start path`() {
+        val decision = decide(activeTripExists = true)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.ACTIVE_TRIP_EXISTS)
+    }
+
+    @Test
+    fun `ignored session remains suppressed for current epoch`() {
+        val decision = decide(detectionState = AutoTripDetectionState.IGNORED)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.SESSION_IGNORED)
+    }
+
+    @Test
+    fun `expired session is ignored`() {
+        val decision = decide(detectionState = AutoTripDetectionState.EXPIRED)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.SESSION_EXPIRED)
+    }
+
+    @Test
+    fun `recording lifecycle state cannot start again`() {
+        val decision = decide(detectionState = AutoTripDetectionState.RECORDING)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+    }
+
+    @Test
+    fun `cooldown suppresses a new candidate`() {
+        val decision = decide(cooldownActive = true)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.COOLDOWN_ACTIVE)
+    }
+
+    @Test
+    fun `prompt only never auto starts even with trusted movement`() {
+        val decision = decide(
+            mode = AutoTripMode.PROMPT_ONLY,
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Prompt>(decision, AutoTripReasonCode.PROMPT_ONLY)
+    }
+
+    @Test
+    fun `missing notification permission blocks visible automation`() {
+        val decision = decide(notificationPermissionGranted = false)
+
+        assertDecision<AutoTripDecision.Block>(
+            decision,
+            AutoTripReasonCode.NOTIFICATION_PERMISSION_MISSING,
+        )
+    }
+
+    @Test
+    fun `verified auto start requires location permission`() {
+        val decision = decide(locationPermissionGranted = false)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.LOCATION_PERMISSION_MISSING)
+    }
+
+    @Test
+    fun `verified auto start requires location provider`() {
+        val decision = decide(locationProviderAvailable = false)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.PROVIDER_UNAVAILABLE)
+    }
+
+    @Test
+    fun `background FGS denial downgrades to prompt`() {
+        val decision = decide(
+            foregroundServiceStartAllowed = false,
+            hasTrustedMovement = true,
+        )
+
+        assertDecision<AutoTripDecision.Prompt>(decision, AutoTripReasonCode.FGS_START_NOT_ALLOWED)
+    }
+
+    @Test
+    fun `bluetooth alone waits for driving evidence`() {
+        val decision = decide()
+
+        assertDecision<AutoTripDecision.Verify>(decision, AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+    }
+
+    @Test
+    fun `activity recognition alone is not enough to start`() {
+        val decision = decide(inVehicleDetected = true)
+
+        assertDecision<AutoTripDecision.Verify>(decision, AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+    }
+
+    @Test
+    fun `trusted movement can verify start without activity recognition`() {
+        val decision = decide(hasTrustedMovement = true)
+
+        assertDecision<AutoTripDecision.Start>(decision, AutoTripReasonCode.VERIFIED_BY_MOVEMENT)
+    }
+
+    @Test
+    fun `trusted movement plus in vehicle evidence records stronger reason`() {
+        val decision = decide(
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Start>(
+            decision,
+            AutoTripReasonCode.VERIFIED_BY_MOVEMENT_AND_ACTIVITY,
+        )
+    }
+
+    private fun decide(
+        mode: AutoTripMode = AutoTripMode.VERIFIED_AUTO_START,
+        deviceBound: Boolean = true,
+        bluetoothConnected: Boolean = true,
+        detectionState: AutoTripDetectionState = AutoTripDetectionState.VERIFYING_DRIVE,
+        activeTripExists: Boolean = false,
+        cooldownActive: Boolean = false,
+        notificationPermissionGranted: Boolean = true,
+        locationPermissionGranted: Boolean = true,
+        locationProviderAvailable: Boolean = true,
+        foregroundServiceStartAllowed: Boolean = true,
+        hasTrustedMovement: Boolean = false,
+        inVehicleDetected: Boolean = false,
+    ): AutoTripDecision = AutoTripEligibilityPolicy.decide(
+        AutoTripEligibilityInput(
+            mode = mode,
+            deviceBound = deviceBound,
+            detectionState = detectionState,
+            activeTripExists = activeTripExists,
+            cooldownActive = cooldownActive,
+            notificationPermissionGranted = notificationPermissionGranted,
+            locationPermissionGranted = locationPermissionGranted,
+            locationProviderAvailable = locationProviderAvailable,
+            foregroundServiceStartAllowed = foregroundServiceStartAllowed,
+            evidence = DriveEvidenceSummary(
+                bluetoothConnected = bluetoothConnected,
+                hasTrustedMovement = hasTrustedMovement,
+                inVehicleDetected = inVehicleDetected,
+            ),
+        ),
+    )
+
+    private inline fun <reified T : AutoTripDecision> assertDecision(
+        decision: AutoTripDecision,
+        reason: AutoTripReasonCode,
+    ) {
+        assertTrue("Expected ${T::class.simpleName}, got ${decision::class.simpleName}", decision is T)
+        assertEquals(reason, decision.reason)
+    }
+}


### PR DESCRIPTION
## Summary

Implements PR A from #235 as a production-neutral model/policy spike.

Adds:

- `AutoTripMode` (`OFF`, `PROMPT_ONLY`, `VERIFIED_AUTO_START`)
- detection lifecycle states
- stable reason codes for future audit/debug/notification copy
- a pure Kotlin `AutoTripEligibilityPolicy`
- pre-classified drive evidence so policy contains no uncalibrated speed/distance magic numbers
- JVM tests covering OFF, device binding, active Trip guard, ignore/expiry/cooldown, permission/provider gates, FGS fallback, Bluetooth-only insufficiency, verified movement decisions, and failed-session no-retry behavior

## Safety / scope boundary

This PR intentionally does **not**:

- wire the policy into `BluetoothConnectionReceiver`;
- change Manifest declarations or Android permissions;
- add Room/DataStore schema changes;
- create Trips automatically;
- change existing notification behavior;
- add movement thresholds before Phase 0 / shadow-mode calibration.

`PROMPT_ONLY` can never return `Start`. `VERIFIED_AUTO_START` requires trusted movement, and Activity Recognition is only an optional strengthening signal. Background FGS denial degrades to a visible prompt rather than silent automation. `START_FAILED` is terminal for automatic policy evaluation so a failed foreground-service start cannot silently retry itself.

## Validation

- Android CI run #575 / `33357874294`: **success**
- `testDebugUnitTest`: **success**
- `:app:assembleDebug`: **success**
- PR is mergeable and has no review threads/comments blocking it.

## Related

- Design discussion: #235
- Design docs: #236
- This is PR A (`model / policy spike`) from the implementation plan.

Closes no issue.