### PR TITLE
feat: sessionize Bluetooth trip prompts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,8 +19,12 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <receiver android:name=".bluetooth.BluetoothConnectionReceiver" android:exported="false">
-            <intent-filter><action android:name="android.bluetooth.device.action.ACL_CONNECTED" /></intent-filter>
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+            </intent-filter>
         </receiver>
+        <receiver android:name=".autotrip.AutoTripActionReceiver" android:exported="false" />
         <service
             android:name=".trip.TripTrackingService"
             android:exported="false"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,12 @@
             android:foregroundServiceType="location"
             android:stopWithTask="false" />
         <activity
+            android:name=".autotrip.AutoTripConfirmationActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripConfirmationActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripConfirmationActivity.kt
@@ -1,0 +1,53 @@
+package com.evchargebook.autotrip
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.evchargebook.MainActivity
+import com.evchargebook.data.database.AppDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Direct notification Activity entry point.
+ *
+ * Android 12+ blocks notification trampolines that route notification taps through a
+ * BroadcastReceiver/Service before starting an Activity. This Activity is therefore the direct
+ * PendingIntent target. It validates persisted session state before forwarding to the existing
+ * Trip confirmation flow.
+ */
+class AutoTripConfirmationActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val sessionId = intent.getStringExtra(AutoTripNotificationController.EXTRA_SESSION_ID)
+        if (sessionId == null) {
+            finish()
+            return
+        }
+
+        lifecycleScope.launch {
+            val allowed = withContext(Dispatchers.IO) {
+                val database = AppDatabase.getInstance(applicationContext)
+                val session = database.autoTripDetectionDao().getById(sessionId) ?: return@withContext false
+                session.closedAtEpochMillis == null &&
+                    session.state == AutoTripDetectionState.BLUETOOTH_CANDIDATE.name &&
+                    database.tripDao().getActive() == null
+            }
+
+            if (allowed) {
+                AutoTripNotificationController(applicationContext).cancel(sessionId)
+                startActivity(
+                    Intent(this@AutoTripConfirmationActivity, MainActivity::class.java)
+                        .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                        .putExtra(MainActivity.EXTRA_OPEN_TRIP_CONFIRMATION, true)
+                        .putExtra(AutoTripNotificationController.EXTRA_SESSION_ID, sessionId)
+                )
+            } else {
+                AutoTripNotificationController(applicationContext).cancel(sessionId)
+            }
+            finish()
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
@@ -101,6 +101,7 @@ sealed class AutoTripDecision(open val reason: AutoTripReasonCode) {
  * - PROMPT_ONLY never returns Start.
  * - VERIFIED_AUTO_START fails closed when required capabilities are unavailable.
  * - FGS background-start denial downgrades to a user-visible prompt rather than a silent start.
+ * - Failed/terminal sessions never silently retry themselves.
  * - No Trip is created here; a future TripStartCoordinator owns that authority.
  */
 object AutoTripEligibilityPolicy {
@@ -132,6 +133,7 @@ object AutoTripEligibilityPolicy {
             AutoTripDetectionState.RECORDING,
             AutoTripDetectionState.POSSIBLE_END,
             AutoTripDetectionState.END_CONFIRMATION,
+            AutoTripDetectionState.START_FAILED,
             AutoTripDetectionState.BLOCKED,
             -> return AutoTripDecision.Block(AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
 

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
@@ -1,0 +1,175 @@
+package com.evchargebook.autotrip
+
+/**
+ * User-selected behavior for vehicle Bluetooth automation.
+ *
+ * This model is intentionally pure Kotlin and is not wired into production receivers yet.
+ */
+enum class AutoTripMode {
+    OFF,
+    PROMPT_ONLY,
+    VERIFIED_AUTO_START,
+}
+
+/**
+ * Product-level lifecycle for one Bluetooth detection session.
+ */
+enum class AutoTripDetectionState {
+    IDLE,
+    BLUETOOTH_CANDIDATE,
+    VERIFYING_DRIVE,
+    READY_TO_START,
+    STARTING,
+    RECORDING,
+    POSSIBLE_END,
+    END_CONFIRMATION,
+    IGNORED,
+    EXPIRED,
+    START_FAILED,
+    BLOCKED,
+}
+
+/**
+ * Stable, machine-readable reasons used by policy decisions, tests and future local audit logs.
+ */
+enum class AutoTripReasonCode {
+    OFF,
+    DEVICE_NOT_BOUND,
+    BLUETOOTH_NOT_CONNECTED,
+    ACTIVE_TRIP_EXISTS,
+    SESSION_IGNORED,
+    SESSION_EXPIRED,
+    SESSION_NOT_ELIGIBLE,
+    COOLDOWN_ACTIVE,
+    NOTIFICATION_PERMISSION_MISSING,
+    LOCATION_PERMISSION_MISSING,
+    PROVIDER_UNAVAILABLE,
+    FGS_START_NOT_ALLOWED,
+    PROMPT_ONLY,
+    WAITING_FOR_EVIDENCE,
+    VERIFIED_BY_MOVEMENT,
+    VERIFIED_BY_MOVEMENT_AND_ACTIVITY,
+}
+
+/**
+ * Pre-classified evidence produced by a future bounded evidence collector.
+ *
+ * Thresholds do not live here. The collector is responsible for deciding whether movement is
+ * trusted according to the current location quality rules. This keeps policy free of magic
+ * distance/speed constants and lets Phase 0/Shadow Mode calibrate them separately.
+ */
+data class DriveEvidenceSummary(
+    val bluetoothConnected: Boolean,
+    val hasTrustedMovement: Boolean,
+    val inVehicleDetected: Boolean = false,
+)
+
+/**
+ * Complete policy input. Callers must provide current capability/permission state instead of
+ * allowing the policy to reach into Android framework APIs.
+ */
+data class AutoTripEligibilityInput(
+    val mode: AutoTripMode,
+    val deviceBound: Boolean,
+    val detectionState: AutoTripDetectionState = AutoTripDetectionState.IDLE,
+    val activeTripExists: Boolean = false,
+    val cooldownActive: Boolean = false,
+    val notificationPermissionGranted: Boolean = true,
+    val locationPermissionGranted: Boolean = true,
+    val locationProviderAvailable: Boolean = true,
+    val foregroundServiceStartAllowed: Boolean = true,
+    val evidence: DriveEvidenceSummary,
+)
+
+sealed class AutoTripDecision(open val reason: AutoTripReasonCode) {
+    data class Ignore(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Prompt(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Verify(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Start(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+
+    data class Block(override val reason: AutoTripReasonCode) : AutoTripDecision(reason)
+}
+
+/**
+ * Pure decision policy for #235.
+ *
+ * Important boundaries:
+ * - Bluetooth is a candidate signal, never proof of driving by itself.
+ * - PROMPT_ONLY never returns Start.
+ * - VERIFIED_AUTO_START fails closed when required capabilities are unavailable.
+ * - FGS background-start denial downgrades to a user-visible prompt rather than a silent start.
+ * - No Trip is created here; a future TripStartCoordinator owns that authority.
+ */
+object AutoTripEligibilityPolicy {
+    fun decide(input: AutoTripEligibilityInput): AutoTripDecision {
+        if (input.mode == AutoTripMode.OFF) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.OFF)
+        }
+
+        if (!input.deviceBound) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.DEVICE_NOT_BOUND)
+        }
+
+        if (!input.evidence.bluetoothConnected) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.BLUETOOTH_NOT_CONNECTED)
+        }
+
+        if (input.activeTripExists) {
+            return AutoTripDecision.Block(AutoTripReasonCode.ACTIVE_TRIP_EXISTS)
+        }
+
+        when (input.detectionState) {
+            AutoTripDetectionState.IGNORED ->
+                return AutoTripDecision.Ignore(AutoTripReasonCode.SESSION_IGNORED)
+
+            AutoTripDetectionState.EXPIRED ->
+                return AutoTripDecision.Ignore(AutoTripReasonCode.SESSION_EXPIRED)
+
+            AutoTripDetectionState.STARTING,
+            AutoTripDetectionState.RECORDING,
+            AutoTripDetectionState.POSSIBLE_END,
+            AutoTripDetectionState.END_CONFIRMATION,
+            AutoTripDetectionState.BLOCKED,
+            -> return AutoTripDecision.Block(AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+
+            else -> Unit
+        }
+
+        if (input.cooldownActive) {
+            return AutoTripDecision.Ignore(AutoTripReasonCode.COOLDOWN_ACTIVE)
+        }
+
+        if (!input.notificationPermissionGranted) {
+            return AutoTripDecision.Block(AutoTripReasonCode.NOTIFICATION_PERMISSION_MISSING)
+        }
+
+        if (input.mode == AutoTripMode.PROMPT_ONLY) {
+            return AutoTripDecision.Prompt(AutoTripReasonCode.PROMPT_ONLY)
+        }
+
+        if (!input.locationPermissionGranted) {
+            return AutoTripDecision.Block(AutoTripReasonCode.LOCATION_PERMISSION_MISSING)
+        }
+
+        if (!input.locationProviderAvailable) {
+            return AutoTripDecision.Block(AutoTripReasonCode.PROVIDER_UNAVAILABLE)
+        }
+
+        if (!input.foregroundServiceStartAllowed) {
+            return AutoTripDecision.Prompt(AutoTripReasonCode.FGS_START_NOT_ALLOWED)
+        }
+
+        if (!input.evidence.hasTrustedMovement) {
+            return AutoTripDecision.Verify(AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+        }
+
+        return if (input.evidence.inVehicleDetected) {
+            AutoTripDecision.Start(AutoTripReasonCode.VERIFIED_BY_MOVEMENT_AND_ACTIVITY)
+        } else {
+            AutoTripDecision.Start(AutoTripReasonCode.VERIFIED_BY_MOVEMENT)
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
@@ -1,0 +1,228 @@
+package com.evchargebook.autotrip
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.evchargebook.MainActivity
+import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
+import com.evchargebook.data.database.AppDatabase
+import com.evchargebook.data.entity.AutoTripDetectionSessionEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.security.MessageDigest
+import java.util.UUID
+
+sealed interface AutoTripCandidateResult {
+    data object NotConfigured : AutoTripCandidateResult
+    data object ActiveTripExists : AutoTripCandidateResult
+    data class Existing(val sessionId: String, val state: AutoTripDetectionState) : AutoTripCandidateResult
+    data class Created(val sessionId: String, val notificationVisible: Boolean) : AutoTripCandidateResult
+}
+
+class AutoTripPromptCoordinator(private val context: Context) {
+    private val database = AppDatabase.getInstance(context)
+    private val sessionDao = database.autoTripDetectionDao()
+    private val tripDao = database.tripDao()
+    private val vehicleDao = database.vehicleDao()
+    private val bindingPreferences = VehicleBluetoothBindingPreferences(context)
+    private val notifications = AutoTripNotificationController(context)
+
+    suspend fun onBluetoothConnected(
+        deviceAddress: String,
+        deviceName: String?,
+        now: Long = System.currentTimeMillis(),
+    ): AutoTripCandidateResult = connectionMutex.withLock {
+        val normalizedAddress = VehicleBluetoothBindingPreferences.normalizeAddress(deviceAddress)
+        val binding = bindingPreferences.bindings.first().firstOrNull {
+            it.enabled && it.deviceAddress.equals(normalizedAddress, ignoreCase = true)
+        } ?: return@withLock AutoTripCandidateResult.NotConfigured
+
+        if (tripDao.getActive() != null) {
+            return@withLock AutoTripCandidateResult.ActiveTripExists
+        }
+
+        val deviceHash = hashDeviceAddress(normalizedAddress)
+        val existing = sessionDao.getOpenForDevice(deviceHash)
+        if (existing != null) {
+            return@withLock AutoTripCandidateResult.Existing(
+                sessionId = existing.id,
+                state = existing.state.toDetectionState(),
+            )
+        }
+
+        val session = AutoTripDetectionSessionEntity(
+            id = UUID.randomUUID().toString(),
+            vehicleId = binding.vehicleId,
+            deviceAddressHash = deviceHash,
+            deviceNameSnapshot = binding.deviceName ?: deviceName,
+            connectionEpoch = UUID.randomUUID().toString(),
+            state = AutoTripDetectionState.BLUETOOTH_CANDIDATE.name,
+            connectedAtEpochMillis = now,
+            updatedAtEpochMillis = now,
+        )
+        sessionDao.insert(session)
+
+        val vehicle = vehicleDao.observeActive().first().firstOrNull { it.id == binding.vehicleId }
+        val vehicleLabel = vehicle?.let { "${it.brand} ${it.model}" } ?: binding.deviceName ?: "车辆"
+        val visible = notifications.showCandidate(session, vehicleLabel)
+        if (!visible) {
+            sessionDao.update(
+                session.copy(
+                    state = AutoTripDetectionState.BLOCKED.name,
+                    updatedAtEpochMillis = now,
+                )
+            )
+        }
+
+        AutoTripCandidateResult.Created(session.id, visible)
+    }
+
+    suspend fun onBluetoothDisconnected(
+        deviceAddress: String,
+        now: Long = System.currentTimeMillis(),
+    ) = connectionMutex.withLock {
+        val deviceHash = hashDeviceAddress(deviceAddress)
+        val session = sessionDao.getOpenForDevice(deviceHash) ?: return@withLock
+        sessionDao.closeSession(
+            sessionId = session.id,
+            state = AutoTripDetectionState.EXPIRED.name,
+            closedAtEpochMillis = now,
+            updatedAtEpochMillis = now,
+        )
+        notifications.cancel(session.id)
+    }
+
+    companion object {
+        private val connectionMutex = Mutex()
+
+        fun hashDeviceAddress(address: String): String {
+            val normalized = VehicleBluetoothBindingPreferences.normalizeAddress(address)
+            val digest = MessageDigest.getInstance("SHA-256").digest(normalized.toByteArray(Charsets.UTF_8))
+            return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+        }
+    }
+}
+
+class AutoTripNotificationController(private val context: Context) {
+    private val manager = context.getSystemService(NotificationManager::class.java)
+
+    fun showCandidate(session: AutoTripDetectionSessionEntity, vehicleLabel: String): Boolean {
+        createChannel()
+        if (!canPostNotifications()) return false
+
+        val openIntent = PendingIntent.getBroadcast(
+            context,
+            requestCode(session.id, ACTION_OPEN_CONFIRMATION),
+            Intent(context, AutoTripActionReceiver::class.java)
+                .setAction(ACTION_OPEN_CONFIRMATION)
+                .putExtra(EXTRA_SESSION_ID, session.id),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val ignoreIntent = PendingIntent.getBroadcast(
+            context,
+            requestCode(session.id, ACTION_IGNORE_SESSION),
+            Intent(context, AutoTripActionReceiver::class.java)
+                .setAction(ACTION_IGNORE_SESSION)
+                .putExtra(EXTRA_SESSION_ID, session.id),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        manager.notify(
+            notificationId(session.id),
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
+                .setContentTitle("已连接 $vehicleLabel")
+                .setContentText("是否开始本次行程？")
+                .setContentIntent(openIntent)
+                .addAction(android.R.drawable.ic_media_play, "打开并确认", openIntent)
+                .addAction(android.R.drawable.ic_menu_close_clear_cancel, "本次忽略", ignoreIntent)
+                .setAutoCancel(true)
+                .build(),
+        )
+        return true
+    }
+
+    fun cancel(sessionId: String) {
+        manager.cancel(notificationId(sessionId))
+    }
+
+    private fun createChannel() {
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "车辆检测",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+        )
+    }
+
+    private fun canPostNotifications(): Boolean =
+        Build.VERSION.SDK_INT < 33 ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+
+    companion object {
+        const val CHANNEL_ID = "vehicle_detection"
+        const val ACTION_OPEN_CONFIRMATION = "com.evchargebook.autotrip.OPEN_CONFIRMATION"
+        const val ACTION_IGNORE_SESSION = "com.evchargebook.autotrip.IGNORE_SESSION"
+        const val EXTRA_SESSION_ID = "auto_trip_session_id"
+
+        fun notificationId(sessionId: String): Int = 31_000 + (sessionId.hashCode() and 0x0FFFFFFF) % 100_000
+
+        private fun requestCode(sessionId: String, action: String): Int =
+            41_000 + ((sessionId + action).hashCode() and 0x0FFFFFFF) % 100_000
+    }
+}
+
+class AutoTripActionReceiver : android.content.BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val sessionId = intent.getStringExtra(AutoTripNotificationController.EXTRA_SESSION_ID) ?: return
+        val pending = goAsync()
+        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+            try {
+                val database = AppDatabase.getInstance(context)
+                val dao = database.autoTripDetectionDao()
+                val session = dao.getById(sessionId) ?: return@launch
+                if (session.closedAtEpochMillis != null) return@launch
+
+                when (intent.action) {
+                    AutoTripNotificationController.ACTION_IGNORE_SESSION -> {
+                        val now = System.currentTimeMillis()
+                        dao.markIgnored(
+                            sessionId = session.id,
+                            state = AutoTripDetectionState.IGNORED.name,
+                            ignoredAtEpochMillis = now,
+                            updatedAtEpochMillis = now,
+                        )
+                        AutoTripNotificationController(context).cancel(session.id)
+                    }
+
+                    AutoTripNotificationController.ACTION_OPEN_CONFIRMATION -> {
+                        if (session.state != AutoTripDetectionState.BLUETOOTH_CANDIDATE.name) return@launch
+                        if (database.tripDao().getActive() != null) return@launch
+                        AutoTripNotificationController(context).cancel(session.id)
+                        context.startActivity(
+                            Intent(context, MainActivity::class.java)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                                .putExtra(MainActivity.EXTRA_OPEN_TRIP_CONFIRMATION, true)
+                                .putExtra(AutoTripNotificationController.EXTRA_SESSION_ID, session.id)
+                        )
+                    }
+                }
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+}
+
+private fun String.toDetectionState(): AutoTripDetectionState =
+    runCatching { AutoTripDetectionState.valueOf(this) }.getOrDefault(AutoTripDetectionState.BLOCKED)

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
@@ -11,10 +11,13 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.evchargebook.MainActivity
+import com.evchargebook.bluetooth.BluetoothPromptPreferences
+import com.evchargebook.bluetooth.VehicleBluetoothBinding
 import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.AutoTripDetectionSessionEntity
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.security.MessageDigest
@@ -33,6 +36,7 @@ class AutoTripPromptCoordinator(private val context: Context) {
     private val tripDao = database.tripDao()
     private val vehicleDao = database.vehicleDao()
     private val bindingPreferences = VehicleBluetoothBindingPreferences(context)
+    private val legacyPreferences = BluetoothPromptPreferences(context)
     private val notifications = AutoTripNotificationController(context)
 
     suspend fun onBluetoothConnected(
@@ -40,6 +44,8 @@ class AutoTripPromptCoordinator(private val context: Context) {
         deviceName: String?,
         now: Long = System.currentTimeMillis(),
     ): AutoTripCandidateResult = connectionMutex.withLock {
+        synchronizeSingleVehicleLegacyBinding()
+
         val normalizedAddress = VehicleBluetoothBindingPreferences.normalizeAddress(deviceAddress)
         val binding = bindingPreferences.bindings.first().firstOrNull {
             it.enabled && it.deviceAddress.equals(normalizedAddress, ignoreCase = true)
@@ -98,6 +104,21 @@ class AutoTripPromptCoordinator(private val context: Context) {
             updatedAtEpochMillis = now,
         )
         notifications.cancel(session.id)
+    }
+
+    private suspend fun synchronizeSingleVehicleLegacyBinding() {
+        val activeVehicles = vehicleDao.observeActive().first()
+        if (activeVehicles.size != 1) return
+        val legacy = legacyPreferences.settings.first()
+        val address = legacy.deviceAddress?.takeIf { it.isNotBlank() } ?: return
+        bindingPreferences.save(
+            VehicleBluetoothBinding(
+                vehicleId = activeVehicles.single().id,
+                enabled = legacy.enabled,
+                deviceAddress = address,
+                deviceName = legacy.deviceName,
+            )
+        )
     }
 
     companion object {

--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPromptCoordinator.kt
@@ -10,7 +10,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
-import com.evchargebook.MainActivity
 import com.evchargebook.bluetooth.BluetoothPromptPreferences
 import com.evchargebook.bluetooth.VehicleBluetoothBinding
 import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
@@ -139,10 +138,10 @@ class AutoTripNotificationController(private val context: Context) {
         createChannel()
         if (!canPostNotifications()) return false
 
-        val openIntent = PendingIntent.getBroadcast(
+        val openIntent = PendingIntent.getActivity(
             context,
             requestCode(session.id, ACTION_OPEN_CONFIRMATION),
-            Intent(context, AutoTripActionReceiver::class.java)
+            Intent(context, AutoTripConfirmationActivity::class.java)
                 .setAction(ACTION_OPEN_CONFIRMATION)
                 .putExtra(EXTRA_SESSION_ID, session.id),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
@@ -205,39 +204,26 @@ class AutoTripNotificationController(private val context: Context) {
 
 class AutoTripActionReceiver : android.content.BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != AutoTripNotificationController.ACTION_IGNORE_SESSION) return
         val sessionId = intent.getStringExtra(AutoTripNotificationController.EXTRA_SESSION_ID) ?: return
         val pending = goAsync()
         kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
             try {
-                val database = AppDatabase.getInstance(context)
-                val dao = database.autoTripDetectionDao()
+                val dao = AppDatabase.getInstance(context).autoTripDetectionDao()
                 val session = dao.getById(sessionId) ?: return@launch
-                if (session.closedAtEpochMillis != null) return@launch
+                if (
+                    session.closedAtEpochMillis != null ||
+                    session.state != AutoTripDetectionState.BLUETOOTH_CANDIDATE.name
+                ) return@launch
 
-                when (intent.action) {
-                    AutoTripNotificationController.ACTION_IGNORE_SESSION -> {
-                        val now = System.currentTimeMillis()
-                        dao.markIgnored(
-                            sessionId = session.id,
-                            state = AutoTripDetectionState.IGNORED.name,
-                            ignoredAtEpochMillis = now,
-                            updatedAtEpochMillis = now,
-                        )
-                        AutoTripNotificationController(context).cancel(session.id)
-                    }
-
-                    AutoTripNotificationController.ACTION_OPEN_CONFIRMATION -> {
-                        if (session.state != AutoTripDetectionState.BLUETOOTH_CANDIDATE.name) return@launch
-                        if (database.tripDao().getActive() != null) return@launch
-                        AutoTripNotificationController(context).cancel(session.id)
-                        context.startActivity(
-                            Intent(context, MainActivity::class.java)
-                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                                .putExtra(MainActivity.EXTRA_OPEN_TRIP_CONFIRMATION, true)
-                                .putExtra(AutoTripNotificationController.EXTRA_SESSION_ID, session.id)
-                        )
-                    }
-                }
+                val now = System.currentTimeMillis()
+                dao.markIgnored(
+                    sessionId = session.id,
+                    state = AutoTripDetectionState.IGNORED.name,
+                    ignoredAtEpochMillis = now,
+                    updatedAtEpochMillis = now,
+                )
+                AutoTripNotificationController(context).cancel(session.id)
             } finally {
                 pending.finish()
             }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionReceiver.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionReceiver.kt
@@ -1,33 +1,38 @@
 package com.evchargebook.bluetooth
 
 import android.Manifest
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.bluetooth.BluetoothDevice
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
-import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
-import com.evchargebook.MainActivity
+import com.evchargebook.autotrip.AutoTripPromptCoordinator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class BluetoothConnectionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != BluetoothDevice.ACTION_ACL_CONNECTED || !hasBluetoothPermission(context)) return
+        if (
+            intent.action !in setOf(
+                BluetoothDevice.ACTION_ACL_CONNECTED,
+                BluetoothDevice.ACTION_ACL_DISCONNECTED,
+            ) || !hasBluetoothPermission(context)
+        ) return
+
         val device = intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE) ?: return
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val settings = BluetoothPromptPreferences(context).settings.first()
-                if (settings.enabled && settings.deviceAddress.equals(device.address, ignoreCase = true)) {
-                    showNotification(context, settings.deviceName ?: device.name ?: "车辆")
+                val coordinator = AutoTripPromptCoordinator(context.applicationContext)
+                when (intent.action) {
+                    BluetoothDevice.ACTION_ACL_CONNECTED ->
+                        coordinator.onBluetoothConnected(device.address, device.name)
+
+                    BluetoothDevice.ACTION_ACL_DISCONNECTED ->
+                        coordinator.onBluetoothDisconnected(device.address)
                 }
             } finally {
                 pending.finish()
@@ -35,35 +40,8 @@ class BluetoothConnectionReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun showNotification(context: Context, name: String) {
-        val manager = context.getSystemService(NotificationManager::class.java)
-        val channelId = "vehicle_connection"
-        manager.createNotificationChannel(NotificationChannel(channelId, "车辆连接提示", NotificationManager.IMPORTANCE_DEFAULT))
-        if (Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) return
-
-        val openTripIntent = Intent(context, MainActivity::class.java)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            .putExtra(MainActivity.EXTRA_OPEN_TRIP_CONFIRMATION, true)
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            2101,
-            openTripIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        manager.notify(
-            2101,
-            NotificationCompat.Builder(context, channelId)
-                .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
-                .setContentTitle("已连接 $name")
-                .setContentText("点击打开行程页，确认后开始记录。")
-                .setContentIntent(pendingIntent)
-                .addAction(android.R.drawable.ic_media_play, "打开并确认", pendingIntent)
-                .setAutoCancel(true)
-                .build()
-        )
-    }
-
-    private fun hasBluetoothPermission(context: Context) =
-        Build.VERSION.SDK_INT < 31 || ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+    private fun hasBluetoothPermission(context: Context): Boolean =
+        Build.VERSION.SDK_INT < 31 ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) ==
+            PackageManager.PERMISSION_GRANTED
 }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionStateChecker.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionStateChecker.kt
@@ -7,6 +7,11 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import com.evchargebook.autotrip.AutoTripCandidateResult
+import com.evchargebook.autotrip.AutoTripPromptCoordinator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 object BluetoothConnectionStateChecker {
     fun check(context: Context, deviceAddress: String?, onResult: (Boolean) -> Unit) {
@@ -26,7 +31,7 @@ object BluetoothConnectionStateChecker {
             if (matched) return
             if (found) {
                 matched = true
-                onResult(true)
+                resolveCandidate(context, deviceAddress, onResult)
                 return
             }
             remaining -= 1
@@ -47,14 +52,33 @@ object BluetoothConnectionStateChecker {
                     finishOne(false)
                 }
             }
-            val requested = runCatching { adapter.getProfileProxy(context.applicationContext, listener, profile) }.getOrDefault(false)
+            val requested = runCatching {
+                adapter.getProfileProxy(context.applicationContext, listener, profile)
+            }.getOrDefault(false)
             if (!requested) finishOne(false)
+        }
+    }
+
+    private fun resolveCandidate(
+        context: Context,
+        deviceAddress: String,
+        onResult: (Boolean) -> Unit,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val result = runCatching {
+                AutoTripPromptCoordinator(context.applicationContext)
+                    .onBluetoothConnected(deviceAddress, deviceName = null)
+            }.getOrNull()
+            val shouldShowForegroundPrompt = result is AutoTripCandidateResult.Created && result.notificationVisible
+            ContextCompat.getMainExecutor(context).execute {
+                onResult(shouldShowForegroundPrompt)
+            }
         }
     }
 
     private fun hasPermission(context: Context): Boolean =
         Build.VERSION.SDK_INT < 31 || ContextCompat.checkSelfPermission(
             context,
-            Manifest.permission.BLUETOOTH_CONNECT
+            Manifest.permission.BLUETOOTH_CONNECT,
         ) == PackageManager.PERMISSION_GRANTED
 }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothPromptPreferences.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothPromptPreferences.kt
@@ -5,10 +5,18 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.evchargebook.data.database.AppDatabase
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
-data class BluetoothPromptSettings(val enabled: Boolean = false, val deviceAddress: String? = null, val deviceName: String? = null)
+data class BluetoothPromptSettings(
+    val enabled: Boolean = false,
+    val deviceAddress: String? = null,
+    val deviceName: String? = null,
+)
+
 data class PairedBluetoothDevice(val address: String, val name: String)
 
 private val Context.bluetoothPromptDataStore by preferencesDataStore("bluetooth_prompt")
@@ -16,16 +24,77 @@ private val enabledKey = booleanPreferencesKey("enabled")
 private val addressKey = stringPreferencesKey("device_address")
 private val nameKey = stringPreferencesKey("device_name")
 
+/**
+ * Compatibility facade for the existing UI/repository API.
+ *
+ * New settings are stored per vehicle. The old global DataStore remains only as a safe migration
+ * source for installations that previously configured one vehicle Bluetooth target.
+ */
 class BluetoothPromptPreferences(private val context: Context) {
-    val settings: Flow<BluetoothPromptSettings> = context.bluetoothPromptDataStore.data.map { prefs ->
-        BluetoothPromptSettings(prefs[enabledKey] == true, prefs[addressKey], prefs[nameKey])
+    private val database = AppDatabase.getInstance(context)
+    private val bindingPreferences = VehicleBluetoothBindingPreferences(context)
+    private val legacySettings: Flow<BluetoothPromptSettings> =
+        context.bluetoothPromptDataStore.data.map { prefs ->
+            BluetoothPromptSettings(
+                enabled = prefs[enabledKey] == true,
+                deviceAddress = prefs[addressKey],
+                deviceName = prefs[nameKey],
+            )
+        }
+
+    val settings: Flow<BluetoothPromptSettings> = combine(
+        database.vehicleDao().observeActive(),
+        bindingPreferences.bindings,
+        legacySettings,
+    ) { vehicles, bindings, legacy ->
+        val selectedVehicle = vehicles.firstOrNull { it.isDefault } ?: vehicles.firstOrNull()
+        val binding = selectedVehicle?.let { vehicle ->
+            bindings.firstOrNull { it.vehicleId == vehicle.id }
+        }
+
+        when {
+            binding != null -> BluetoothPromptSettings(
+                enabled = binding.enabled,
+                deviceAddress = binding.deviceAddress,
+                deviceName = binding.deviceName,
+            )
+
+            // Only inherit an old global binding when vehicle ownership is unambiguous.
+            vehicles.size == 1 && !legacy.deviceAddress.isNullOrBlank() -> legacy
+            else -> BluetoothPromptSettings()
+        }
     }
 
     suspend fun save(enabled: Boolean, address: String?, name: String?) {
+        val vehicles = database.vehicleDao().observeActive().first()
+        val selectedVehicle = vehicles.firstOrNull { it.isDefault } ?: vehicles.firstOrNull()
+
+        if (selectedVehicle != null) {
+            if (address.isNullOrBlank()) {
+                bindingPreferences.remove(selectedVehicle.id)
+            } else {
+                bindingPreferences.save(
+                    VehicleBluetoothBinding(
+                        vehicleId = selectedVehicle.id,
+                        enabled = enabled,
+                        deviceAddress = address,
+                        deviceName = name,
+                    )
+                )
+            }
+        }
+
+        // Keep the legacy value synchronized for downgrade compatibility. It is never used to
+        // guess ownership when multiple active vehicles exist.
         context.bluetoothPromptDataStore.edit { prefs ->
             prefs[enabledKey] = enabled
-            if (address == null) { prefs.remove(addressKey); prefs.remove(nameKey) }
-            else { prefs[addressKey] = address; prefs[nameKey] = name.orEmpty() }
+            if (address.isNullOrBlank()) {
+                prefs.remove(addressKey)
+                prefs.remove(nameKey)
+            } else {
+                prefs[addressKey] = VehicleBluetoothBindingPreferences.normalizeAddress(address)
+                prefs[nameKey] = name.orEmpty()
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
@@ -27,15 +27,16 @@ class VehicleBluetoothBindingPreferences(private val context: Context) {
 
     suspend fun save(binding: VehicleBluetoothBinding) {
         context.vehicleBluetoothBindingDataStore.edit { prefs ->
+            val normalizedAddress = normalizeAddress(binding.deviceAddress)
             val current = decode(prefs[bindingsJsonKey]).toMutableList()
-            val duplicateDevice = current.firstOrNull {
-                it.vehicleId != binding.vehicleId &&
-                    it.deviceAddress.equals(binding.deviceAddress, ignoreCase = true)
-            }
-            require(duplicateDevice == null) { "该蓝牙设备已绑定到另一辆车" }
 
-            current.removeAll { it.vehicleId == binding.vehicleId }
-            current += binding.copy(deviceAddress = normalizeAddress(binding.deviceAddress))
+            // Selecting a device while editing the current vehicle is an explicit rebind action.
+            // Keep one owner per physical Bluetooth address so connection events stay unambiguous.
+            current.removeAll {
+                it.vehicleId == binding.vehicleId ||
+                    it.deviceAddress.equals(normalizedAddress, ignoreCase = true)
+            }
+            current += binding.copy(deviceAddress = normalizedAddress)
             prefs[bindingsJsonKey] = encode(current)
         }
     }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
@@ -1,0 +1,108 @@
+package com.evchargebook.bluetooth
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class VehicleBluetoothBinding(
+    val vehicleId: Long,
+    val enabled: Boolean,
+    val deviceAddress: String,
+    val deviceName: String?,
+)
+
+private val Context.vehicleBluetoothBindingDataStore by preferencesDataStore("vehicle_bluetooth_bindings")
+private val bindingsJsonKey = stringPreferencesKey("bindings_json_v1")
+
+class VehicleBluetoothBindingPreferences(private val context: Context) {
+    val bindings: Flow<List<VehicleBluetoothBinding>> =
+        context.vehicleBluetoothBindingDataStore.data.map { prefs ->
+            decode(prefs[bindingsJsonKey])
+        }
+
+    suspend fun save(binding: VehicleBluetoothBinding) {
+        context.vehicleBluetoothBindingDataStore.edit { prefs ->
+            val current = decode(prefs[bindingsJsonKey]).toMutableList()
+            val duplicateDevice = current.firstOrNull {
+                it.vehicleId != binding.vehicleId &&
+                    it.deviceAddress.equals(binding.deviceAddress, ignoreCase = true)
+            }
+            require(duplicateDevice == null) { "该蓝牙设备已绑定到另一辆车" }
+
+            current.removeAll { it.vehicleId == binding.vehicleId }
+            current += binding.copy(deviceAddress = normalizeAddress(binding.deviceAddress))
+            prefs[bindingsJsonKey] = encode(current)
+        }
+    }
+
+    suspend fun remove(vehicleId: Long) {
+        context.vehicleBluetoothBindingDataStore.edit { prefs ->
+            val current = decode(prefs[bindingsJsonKey]).filterNot { it.vehicleId == vehicleId }
+            prefs[bindingsJsonKey] = encode(current)
+        }
+    }
+
+    suspend fun migrateLegacyIfUnambiguous(
+        legacy: BluetoothPromptSettings,
+        activeVehicleIds: List<Long>,
+    ) {
+        if (activeVehicleIds.size != 1 || legacy.deviceAddress.isNullOrBlank()) return
+        context.vehicleBluetoothBindingDataStore.edit { prefs ->
+            if (decode(prefs[bindingsJsonKey]).isNotEmpty()) return@edit
+            prefs[bindingsJsonKey] = encode(
+                listOf(
+                    VehicleBluetoothBinding(
+                        vehicleId = activeVehicleIds.single(),
+                        enabled = legacy.enabled,
+                        deviceAddress = normalizeAddress(legacy.deviceAddress),
+                        deviceName = legacy.deviceName,
+                    )
+                )
+            )
+        }
+    }
+
+    companion object {
+        fun normalizeAddress(address: String): String = address.trim().uppercase()
+
+        private fun decode(raw: String?): List<VehicleBluetoothBinding> {
+            if (raw.isNullOrBlank()) return emptyList()
+            return runCatching {
+                val array = JSONArray(raw)
+                buildList {
+                    for (index in 0 until array.length()) {
+                        val item = array.getJSONObject(index)
+                        val address = item.optString("deviceAddress").takeIf { it.isNotBlank() } ?: continue
+                        add(
+                            VehicleBluetoothBinding(
+                                vehicleId = item.getLong("vehicleId"),
+                                enabled = item.optBoolean("enabled", false),
+                                deviceAddress = normalizeAddress(address),
+                                deviceName = item.optString("deviceName").takeIf { it.isNotBlank() },
+                            )
+                        )
+                    }
+                }
+            }.getOrDefault(emptyList())
+        }
+
+        private fun encode(bindings: List<VehicleBluetoothBinding>): String {
+            val array = JSONArray()
+            bindings.sortedBy { it.vehicleId }.forEach { binding ->
+                array.put(
+                    JSONObject()
+                        .put("vehicleId", binding.vehicleId)
+                        .put("enabled", binding.enabled)
+                        .put("deviceAddress", normalizeAddress(binding.deviceAddress))
+                        .put("deviceName", binding.deviceName ?: JSONObject.NULL)
+                )
+            }
+            return array.toString()
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/VehicleBluetoothBindingPreferences.kt
@@ -78,12 +78,17 @@ class VehicleBluetoothBindingPreferences(private val context: Context) {
                     for (index in 0 until array.length()) {
                         val item = array.getJSONObject(index)
                         val address = item.optString("deviceAddress").takeIf { it.isNotBlank() } ?: continue
+                        val deviceName = if (item.isNull("deviceName")) {
+                            null
+                        } else {
+                            item.optString("deviceName").takeIf { it.isNotBlank() }
+                        }
                         add(
                             VehicleBluetoothBinding(
                                 vehicleId = item.getLong("vehicleId"),
                                 enabled = item.optBoolean("enabled", false),
                                 deviceAddress = normalizeAddress(address),
-                                deviceName = item.optString("deviceName").takeIf { it.isNotBlank() },
+                                deviceName = deviceName,
                             )
                         )
                     }

--- a/android/app/src/main/java/com/evchargebook/data/dao/AutoTripDetectionDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/AutoTripDetectionDao.kt
@@ -1,0 +1,64 @@
+package com.evchargebook.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import com.evchargebook.data.entity.AutoTripDetectionSessionEntity
+
+@Dao
+interface AutoTripDetectionDao {
+    @Query("SELECT * FROM auto_trip_detection_sessions WHERE id = :sessionId LIMIT 1")
+    suspend fun getById(sessionId: String): AutoTripDetectionSessionEntity?
+
+    @Query(
+        """
+        SELECT * FROM auto_trip_detection_sessions
+        WHERE deviceAddressHash = :deviceAddressHash
+          AND closedAtEpochMillis IS NULL
+        ORDER BY connectedAtEpochMillis DESC
+        LIMIT 1
+        """
+    )
+    suspend fun getOpenForDevice(deviceAddressHash: String): AutoTripDetectionSessionEntity?
+
+    @Insert
+    suspend fun insert(session: AutoTripDetectionSessionEntity)
+
+    @Update
+    suspend fun update(session: AutoTripDetectionSessionEntity)
+
+    @Query(
+        """
+        UPDATE auto_trip_detection_sessions
+        SET state = :state,
+            ignoredAtEpochMillis = :ignoredAtEpochMillis,
+            updatedAtEpochMillis = :updatedAtEpochMillis
+        WHERE id = :sessionId
+          AND closedAtEpochMillis IS NULL
+        """
+    )
+    suspend fun markIgnored(
+        sessionId: String,
+        state: String,
+        ignoredAtEpochMillis: Long,
+        updatedAtEpochMillis: Long,
+    ): Int
+
+    @Query(
+        """
+        UPDATE auto_trip_detection_sessions
+        SET state = :state,
+            closedAtEpochMillis = :closedAtEpochMillis,
+            updatedAtEpochMillis = :updatedAtEpochMillis
+        WHERE id = :sessionId
+          AND closedAtEpochMillis IS NULL
+        """
+    )
+    suspend fun closeSession(
+        sessionId: String,
+        state: String,
+        closedAtEpochMillis: Long,
+        updatedAtEpochMillis: Long,
+    ): Int
+}

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -6,11 +6,13 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.evchargebook.data.dao.AutoTripDetectionDao
 import com.evchargebook.data.dao.ChargingRecordDao
 import com.evchargebook.data.dao.TripDao
-import com.evchargebook.data.dao.VehicleDao
 import com.evchargebook.data.dao.VehicleCatalogDao
+import com.evchargebook.data.dao.VehicleDao
 import com.evchargebook.data.dao.VehicleStateDao
+import com.evchargebook.data.entity.AutoTripDetectionSessionEntity
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.TripDiagnosticEventEntity
 import com.evchargebook.data.entity.TripPointEntity
@@ -27,10 +29,11 @@ import com.evchargebook.data.entity.VehicleStateEntity
         TripSessionEntity::class,
         TripPointEntity::class,
         TripDiagnosticEventEntity::class,
-        VehicleStateEntity::class
+        VehicleStateEntity::class,
+        AutoTripDetectionSessionEntity::class,
     ],
-    version = 12,
-    exportSchema = false
+    version = 13,
+    exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun vehicleDao(): VehicleDao
@@ -38,6 +41,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun chargingRecordDao(): ChargingRecordDao
     abstract fun tripDao(): TripDao
     abstract fun vehicleStateDao(): VehicleStateDao
+    abstract fun autoTripDetectionDao(): AutoTripDetectionDao
 
     companion object {
         private val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -166,6 +170,33 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS auto_trip_detection_sessions (
+                        id TEXT NOT NULL,
+                        vehicleId INTEGER NOT NULL,
+                        deviceAddressHash TEXT NOT NULL,
+                        deviceNameSnapshot TEXT,
+                        connectionEpoch TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        connectedAtEpochMillis INTEGER NOT NULL,
+                        ignoredAtEpochMillis INTEGER,
+                        closedAtEpochMillis INTEGER,
+                        tripId INTEGER,
+                        updatedAtEpochMillis INTEGER NOT NULL,
+                        PRIMARY KEY(id)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_auto_trip_detection_sessions_vehicleId ON auto_trip_detection_sessions(vehicleId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_auto_trip_detection_sessions_deviceAddressHash ON auto_trip_detection_sessions(deviceAddressHash)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_auto_trip_detection_sessions_state ON auto_trip_detection_sessions(state)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_auto_trip_detection_sessions_deviceAddressHash_connectionEpoch ON auto_trip_detection_sessions(deviceAddressHash, connectionEpoch)")
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -187,7 +218,8 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_8_9,
                         MIGRATION_9_10,
                         MIGRATION_10_11,
-                        MIGRATION_11_12
+                        MIGRATION_11_12,
+                        MIGRATION_12_13,
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/entity/AutoTripDetectionSessionEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/AutoTripDetectionSessionEntity.kt
@@ -1,0 +1,28 @@
+package com.evchargebook.data.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "auto_trip_detection_sessions",
+    indices = [
+        Index("vehicleId"),
+        Index("deviceAddressHash"),
+        Index("state"),
+        Index(value = ["deviceAddressHash", "connectionEpoch"], unique = true),
+    ],
+)
+data class AutoTripDetectionSessionEntity(
+    @PrimaryKey val id: String,
+    val vehicleId: Long,
+    val deviceAddressHash: String,
+    val deviceNameSnapshot: String?,
+    val connectionEpoch: String,
+    val state: String,
+    val connectedAtEpochMillis: Long,
+    val ignoredAtEpochMillis: Long? = null,
+    val closedAtEpochMillis: Long? = null,
+    val tripId: Long? = null,
+    val updatedAtEpochMillis: Long,
+)

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -55,6 +55,17 @@ class AutoTripEligibilityPolicyTest {
     }
 
     @Test
+    fun `start failed session cannot silently retry`() {
+        val decision = decide(
+            detectionState = AutoTripDetectionState.START_FAILED,
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+    }
+
+    @Test
     fun `cooldown suppresses a new candidate`() {
         val decision = decide(cooldownActive = true)
 

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -176,7 +176,7 @@ class AutoTripEligibilityPolicyTest {
         decision: AutoTripDecision,
         reason: AutoTripReasonCode,
     ) {
-        assertTrue("Expected ${T::class.simpleName}, got ${decision::class.simpleName}", decision is T)
+        assertTrue(decision is T)
         assertEquals(reason, decision.reason)
     }
 }

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripEligibilityPolicyTest.kt
@@ -1,0 +1,182 @@
+package com.evchargebook.autotrip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoTripEligibilityPolicyTest {
+    @Test
+    fun `off mode always ignores`() {
+        val decision = decide(mode = AutoTripMode.OFF)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.OFF)
+    }
+
+    @Test
+    fun `unbound device is ignored`() {
+        val decision = decide(deviceBound = false)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.DEVICE_NOT_BOUND)
+    }
+
+    @Test
+    fun `disconnected target cannot create candidate`() {
+        val decision = decide(bluetoothConnected = false)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.BLUETOOTH_NOT_CONNECTED)
+    }
+
+    @Test
+    fun `active trip blocks another start path`() {
+        val decision = decide(activeTripExists = true)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.ACTIVE_TRIP_EXISTS)
+    }
+
+    @Test
+    fun `ignored session remains suppressed for current epoch`() {
+        val decision = decide(detectionState = AutoTripDetectionState.IGNORED)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.SESSION_IGNORED)
+    }
+
+    @Test
+    fun `expired session is ignored`() {
+        val decision = decide(detectionState = AutoTripDetectionState.EXPIRED)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.SESSION_EXPIRED)
+    }
+
+    @Test
+    fun `recording lifecycle state cannot start again`() {
+        val decision = decide(detectionState = AutoTripDetectionState.RECORDING)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.SESSION_NOT_ELIGIBLE)
+    }
+
+    @Test
+    fun `cooldown suppresses a new candidate`() {
+        val decision = decide(cooldownActive = true)
+
+        assertDecision<AutoTripDecision.Ignore>(decision, AutoTripReasonCode.COOLDOWN_ACTIVE)
+    }
+
+    @Test
+    fun `prompt only never auto starts even with trusted movement`() {
+        val decision = decide(
+            mode = AutoTripMode.PROMPT_ONLY,
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Prompt>(decision, AutoTripReasonCode.PROMPT_ONLY)
+    }
+
+    @Test
+    fun `missing notification permission blocks visible automation`() {
+        val decision = decide(notificationPermissionGranted = false)
+
+        assertDecision<AutoTripDecision.Block>(
+            decision,
+            AutoTripReasonCode.NOTIFICATION_PERMISSION_MISSING,
+        )
+    }
+
+    @Test
+    fun `verified auto start requires location permission`() {
+        val decision = decide(locationPermissionGranted = false)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.LOCATION_PERMISSION_MISSING)
+    }
+
+    @Test
+    fun `verified auto start requires location provider`() {
+        val decision = decide(locationProviderAvailable = false)
+
+        assertDecision<AutoTripDecision.Block>(decision, AutoTripReasonCode.PROVIDER_UNAVAILABLE)
+    }
+
+    @Test
+    fun `background FGS denial downgrades to prompt`() {
+        val decision = decide(
+            foregroundServiceStartAllowed = false,
+            hasTrustedMovement = true,
+        )
+
+        assertDecision<AutoTripDecision.Prompt>(decision, AutoTripReasonCode.FGS_START_NOT_ALLOWED)
+    }
+
+    @Test
+    fun `bluetooth alone waits for driving evidence`() {
+        val decision = decide()
+
+        assertDecision<AutoTripDecision.Verify>(decision, AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+    }
+
+    @Test
+    fun `activity recognition alone is not enough to start`() {
+        val decision = decide(inVehicleDetected = true)
+
+        assertDecision<AutoTripDecision.Verify>(decision, AutoTripReasonCode.WAITING_FOR_EVIDENCE)
+    }
+
+    @Test
+    fun `trusted movement can verify start without activity recognition`() {
+        val decision = decide(hasTrustedMovement = true)
+
+        assertDecision<AutoTripDecision.Start>(decision, AutoTripReasonCode.VERIFIED_BY_MOVEMENT)
+    }
+
+    @Test
+    fun `trusted movement plus in vehicle evidence records stronger reason`() {
+        val decision = decide(
+            hasTrustedMovement = true,
+            inVehicleDetected = true,
+        )
+
+        assertDecision<AutoTripDecision.Start>(
+            decision,
+            AutoTripReasonCode.VERIFIED_BY_MOVEMENT_AND_ACTIVITY,
+        )
+    }
+
+    private fun decide(
+        mode: AutoTripMode = AutoTripMode.VERIFIED_AUTO_START,
+        deviceBound: Boolean = true,
+        bluetoothConnected: Boolean = true,
+        detectionState: AutoTripDetectionState = AutoTripDetectionState.VERIFYING_DRIVE,
+        activeTripExists: Boolean = false,
+        cooldownActive: Boolean = false,
+        notificationPermissionGranted: Boolean = true,
+        locationPermissionGranted: Boolean = true,
+        locationProviderAvailable: Boolean = true,
+        foregroundServiceStartAllowed: Boolean = true,
+        hasTrustedMovement: Boolean = false,
+        inVehicleDetected: Boolean = false,
+    ): AutoTripDecision = AutoTripEligibilityPolicy.decide(
+        AutoTripEligibilityInput(
+            mode = mode,
+            deviceBound = deviceBound,
+            detectionState = detectionState,
+            activeTripExists = activeTripExists,
+            cooldownActive = cooldownActive,
+            notificationPermissionGranted = notificationPermissionGranted,
+            locationPermissionGranted = locationPermissionGranted,
+            locationProviderAvailable = locationProviderAvailable,
+            foregroundServiceStartAllowed = foregroundServiceStartAllowed,
+            evidence = DriveEvidenceSummary(
+                bluetoothConnected = bluetoothConnected,
+                hasTrustedMovement = hasTrustedMovement,
+                inVehicleDetected = inVehicleDetected,
+            ),
+        ),
+    )
+
+    private inline fun <reified T : AutoTripDecision> assertDecision(
+        decision: AutoTripDecision,
+        reason: AutoTripReasonCode,
+    ) {
+        assertTrue("Expected ${T::class.simpleName}, got ${decision::class.simpleName}", decision is T)
+        assertEquals(reason, decision.reason)
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/autotrip/AutoTripPromptCoordinatorTest.kt
+++ b/android/app/src/test/java/com/evchargebook/autotrip/AutoTripPromptCoordinatorTest.kt
@@ -1,0 +1,27 @@
+package com.evchargebook.autotrip
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoTripPromptCoordinatorTest {
+    @Test
+    fun `device address hash is normalized before persistence`() {
+        val lower = AutoTripPromptCoordinator.hashDeviceAddress("aa:bb:cc:dd:ee:ff")
+        val upper = AutoTripPromptCoordinator.hashDeviceAddress("AA:BB:CC:DD:EE:FF")
+
+        assertEquals(lower, upper)
+        assertFalse(lower.contains("AA:BB"))
+        assertEquals(64, lower.length)
+    }
+
+    @Test
+    fun `notification id is stable for same session`() {
+        val first = AutoTripNotificationController.notificationId("session-123")
+        val second = AutoTripNotificationController.notificationId("session-123")
+
+        assertEquals(first, second)
+        assertTrue(first >= 31_000)
+    }
+}


### PR DESCRIPTION
## Summary

Main-target replacement for stacked PR #238 after PR A merged as #239. Uses the exact same reviewed head SHA as #238; replacement is needed because the connector cannot retarget an existing PR base.

Keeps Phase 1 in `PROMPT_ONLY` and adds:

- persisted Room detection sessions with DB migration 12 -> 13;
- connection epochs closed by `ACL_DISCONNECTED`;
- vehicle-aware Bluetooth binding storage keyed by `vehicleId`;
- backward-compatible migration/read behavior for the previous global Bluetooth setting without guessing ownership in ambiguous multi-vehicle state;
- existing Bluetooth settings UI remains API-compatible but now reads/writes the selected/default vehicle binding;
- one coordinator shared by background ACL events and foreground A2DP/HEADSET reconciliation;
- stable per-session notifications rather than fixed notification ID 2101;
- `打开并确认` and `本次忽略` actions validated against persisted session state;
- direct Activity PendingIntent validation for Android 12+ (no notification trampoline through a BroadcastReceiver);
- stale-action no-op behavior and active-Trip guards;
- SHA-256 device-address hash in persisted detection sessions instead of raw MAC;
- foreground dedupe so app resume does not re-prompt an existing/ignored session.

## Scope boundary

This PR does **not** automatically create a Trip. `打开并确认` still enters the existing user-confirmed start flow. `TripStartCoordinator` remains PR C.

No Activity Recognition, movement thresholds, background location verification, or automatic end behavior are introduced.

## Multi-vehicle behavior

Bindings are keyed by vehicle ID and the existing screen follows the selected/default vehicle. Selecting a Bluetooth device for another vehicle explicitly rebinds that physical address to the new vehicle so a connection event has one owner. The old global value is inherited automatically only when exactly one active vehicle exists.

## Validation

Same head SHA as #238: `4de011335e68383f6c7c3cdeb21ec3b364bcd9c2`.

Android CI #581 / run `33358511243`: **success**
- `testDebugUnitTest`: success
- `:app:assembleDebug`: success
- Debug APK upload: success

Code is ready for review. Real-device lockscreen/background/reconnect acceptance remains a release/acceptance gate and is not claimed by CI.

## Related

- #235
- #236
- PR A merged: #239
- Supersedes stacked #238 only because base retarget is unavailable through the connector.

Closes no issue.