### PR TITLE
fix: dedupe update prompt and align dashboard trip status

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Route
@@ -34,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -89,6 +92,11 @@ fun DashboardRecentTripCard(
         isInterrupted -> "已中断"
         else -> "已完成"
     }
+    val statusIcon = when {
+        isActive -> Icons.Default.PlayArrow
+        isInterrupted -> Icons.Default.ErrorOutline
+        else -> Icons.Default.CheckCircle
+    }
     val statusColor = if (isInterrupted) MaterialTheme.colorScheme.error else EVDesignTokens.Energy.green
     val endText = if (isActive) {
         if (trip.endLatitude != null && trip.endLongitude != null) "当前位置 · 持续更新" else "等待当前位置"
@@ -128,17 +136,11 @@ fun DashboardRecentTripCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Surface(
-                        shape = CircleShape,
-                        color = statusColor.copy(alpha = 0.10f)
-                    ) {
-                        Text(
-                            statusText,
-                            modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = statusColor
-                        )
-                    }
+                    TripStatusBadge(
+                        icon = statusIcon,
+                        text = statusText,
+                        color = statusColor
+                    )
                 }
 
                 Row(
@@ -177,6 +179,35 @@ fun DashboardRecentTripCard(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TripStatusBadge(icon: ImageVector, text: String, color: Color) {
+    Surface(
+        shape = CircleShape,
+        color = color.copy(alpha = 0.10f)
+    ) {
+        Row(
+            modifier = Modifier
+                .height(24.dp)
+                .padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(13.dp)
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelSmall,
+                color = color,
+                maxLines = 1
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
@@ -60,11 +60,14 @@ fun AppUpdatePrompt() {
     LaunchedEffect(Unit) {
         runCatching { manager.checkForUpdate() }
             .onSuccess { info ->
-                if (info != null) {
-                    // Move out of IDLE before publishing the update payload so the dialog is
-                    // created only once. IDLE itself never renders a dialog.
+                if (info != null && processUpdatePromptSessionGate.tryClaim(info.versionCode)) {
+                    // The previous fix prevented a double render inside one composition. Keep a
+                    // process-level version claim as well so navigation/activity recreation cannot
+                    // consume the same discovery result again and show a second identical dialog.
                     phase = UpdatePhase.DISCOVERED
                     update = info
+                } else if (info != null) {
+                    Log.d(TAG, "Skip duplicate update prompt for versionCode=${info.versionCode}")
                 }
             }
             .onFailure { error ->
@@ -249,6 +252,16 @@ private fun UpdateDecisionDialog(
         }
     )
 }
+
+internal class UpdatePromptSessionGate {
+    private val claimedVersionCodes = mutableSetOf<Int>()
+
+    fun tryClaim(versionCode: Int): Boolean = synchronized(claimedVersionCodes) {
+        claimedVersionCodes.add(versionCode)
+    }
+}
+
+private val processUpdatePromptSessionGate = UpdatePromptSessionGate()
 
 private enum class UpdatePhase {
     IDLE,

--- a/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
+++ b/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
@@ -1,0 +1,23 @@
+package com.evchargebook.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdatePromptSessionGateTest {
+    @Test
+    fun sameVersionCanOnlyBeClaimedOnce() {
+        val gate = UpdatePromptSessionGate()
+
+        assertTrue(gate.tryClaim(42))
+        assertFalse(gate.tryClaim(42))
+    }
+
+    @Test
+    fun newerVersionCanStillBeClaimed() {
+        val gate = UpdatePromptSessionGate()
+
+        assertTrue(gate.tryClaim(42))
+        assertTrue(gate.tryClaim(43))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two regressions reported on the current Android build:

1. The release update discovery dialog could appear twice again after the updater composable/activity was recreated. The earlier fix only prevented duplicate rendering inside one composition. This change adds a process-level, per-version claim so the same `versionCode` discovery prompt is shown at most once per app process while still allowing a newer version to prompt normally.
2. The Dashboard recent-trip status badge now keeps the status icon and label in one fixed-height centered row, so the active `进行中` icon/text are visually aligned. Interrupted/completed states use the same alignment model for consistency.

## Tests

- Added `UpdatePromptSessionGateTest`
  - same version can only be claimed once
  - newer version can still be claimed

## Scope

Android UI/updater only. No release metadata, trip recording behavior, database schema, or backend contract changes.