### PR TITLE
fix: restore downloaded update after app restart

### DIFF
--- a/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
@@ -79,22 +79,38 @@ class AppUpdateManager(private val context: Context) {
      *
      * A successful task is SHA-256 verified again before being exposed as installable. An active
      * task is returned so the UI can keep observing the same download instead of enqueueing a
-     * duplicate. Stale, failed, missing, already-installed, or corrupt tasks are forgotten.
+     * duplicate. Stale, failed, missing, already-installed, or corrupt tasks are forgotten and
+     * their app-private APK files are removed.
      */
     suspend fun restorePendingDownload(
         currentVersionCode: Int = BuildConfig.VERSION_CODE
     ): RestoredUpdateDownload? = withContext(Dispatchers.IO) {
-        val pending = readPendingDownload() ?: return@withContext null
+        val pending = readPendingDownload()
+        if (pending == null) {
+            // No recoverable task means every updater-owned APK in this private directory is stale,
+            // including files left behind by updater builds that predate persisted download ids.
+            cleanupHistoricalUpdatePackages()
+            return@withContext null
+        }
+
         val (downloadId, info) = pending
 
         if (info.versionCode <= currentVersionCode) {
+            // The downloaded package has already been installed. DownloadManager.remove() also
+            // removes the file it owns; the directory sweep covers legacy/orphaned APKs as well.
+            downloadManager.remove(downloadId)
             clearPendingDownload()
+            cleanupHistoricalUpdatePackages()
             return@withContext null
         }
+
+        val activeFileName = updateFileName(info)
+        cleanupHistoricalUpdatePackages(keepFileName = activeFileName)
 
         downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
             if (!cursor.moveToFirst()) {
                 clearPendingDownload()
+                cleanupHistoricalUpdatePackages()
                 return@withContext null
             }
 
@@ -104,6 +120,7 @@ class AppUpdateManager(private val context: Context) {
                     if (uri == null || !verifySha256(uri, info.sha256)) {
                         downloadManager.remove(downloadId)
                         clearPendingDownload()
+                        cleanupHistoricalUpdatePackages()
                         return@withContext null
                     }
                     RestoredUpdateDownload.Ready(info, uri)
@@ -114,12 +131,16 @@ class AppUpdateManager(private val context: Context) {
                 DownloadManager.STATUS_PAUSED -> RestoredUpdateDownload.InProgress(info, downloadId)
 
                 DownloadManager.STATUS_FAILED -> {
+                    downloadManager.remove(downloadId)
                     clearPendingDownload()
+                    cleanupHistoricalUpdatePackages()
                     null
                 }
 
                 else -> {
+                    downloadManager.remove(downloadId)
                     clearPendingDownload()
+                    cleanupHistoricalUpdatePackages()
                     null
                 }
             }
@@ -138,7 +159,11 @@ class AppUpdateManager(private val context: Context) {
     }
 
     suspend fun downloadAndVerify(info: AppUpdateInfo): Uri = withContext(Dispatchers.IO) {
-        val fileName = "ev-charge-book-${info.versionName}.apk"
+        // Starting a fresh task means there is no valid recoverable package. Remove updater-owned
+        // historical APKs first so repeated upgrades cannot accumulate hundreds of MB over time.
+        cleanupHistoricalUpdatePackages()
+
+        val fileName = updateFileName(info)
         val request = DownloadManager.Request(Uri.parse(info.apkUrl))
             .setTitle("EV Charge Book ${info.versionName}")
             .setDescription("正在下载应用更新")
@@ -154,6 +179,7 @@ class AppUpdateManager(private val context: Context) {
             savePendingDownload(downloadId, info)
         } catch (error: Throwable) {
             downloadManager.remove(downloadId)
+            cleanupHistoricalUpdatePackages()
             throw error
         }
         awaitDownloadAndVerify(downloadId, info)
@@ -163,6 +189,7 @@ class AppUpdateManager(private val context: Context) {
         // Refresh persisted metadata before resuming observation so another process recreation can
         // still recover the same task.
         savePendingDownload(downloadId, info)
+        cleanupHistoricalUpdatePackages(keepFileName = updateFileName(info))
         awaitDownloadAndVerify(downloadId, info)
     }
 
@@ -181,28 +208,35 @@ class AppUpdateManager(private val context: Context) {
             downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
                 if (!cursor.moveToFirst()) {
                     clearPendingDownload()
+                    cleanupHistoricalUpdatePackages()
                     error("找不到更新下载任务")
                 }
                 when (cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))) {
                     DownloadManager.STATUS_SUCCESSFUL -> {
                         val uri = downloadManager.getUriForDownloadedFile(downloadId)
                             ?: run {
+                                downloadManager.remove(downloadId)
                                 clearPendingDownload()
+                                cleanupHistoricalUpdatePackages()
                                 error("更新包下载完成但无法读取")
                             }
                         if (!verifySha256(uri, info.sha256)) {
                             downloadManager.remove(downloadId)
                             clearPendingDownload()
+                            cleanupHistoricalUpdatePackages()
                             error("更新包 SHA-256 校验失败")
                         }
-                        // Deliberately keep the persisted task. If the user closes the app before
-                        // installing, the next launch must recover this verified APK as READY.
+                        // Deliberately keep the persisted task and current APK. If the user closes
+                        // the app before installing, the next launch must recover it as READY.
+                        cleanupHistoricalUpdatePackages(keepFileName = updateFileName(info))
                         return uri
                     }
 
                     DownloadManager.STATUS_FAILED -> {
                         val reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+                        downloadManager.remove(downloadId)
                         clearPendingDownload()
+                        cleanupHistoricalUpdatePackages()
                         error("更新包下载失败（$reason）")
                     }
                 }
@@ -256,6 +290,19 @@ class AppUpdateManager(private val context: Context) {
         updatePrefs.edit().clear().apply()
     }
 
+    private fun cleanupHistoricalUpdatePackages(keepFileName: String? = null): Int {
+        val downloadsDir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: return 0
+        return downloadsDir.listFiles()?.count { file ->
+            file.isFile &&
+                isManagedUpdateApkFileName(file.name) &&
+                file.name != keepFileName &&
+                file.delete()
+        } ?: 0
+    }
+
+    private fun updateFileName(info: AppUpdateInfo): String =
+        "$UPDATE_APK_FILE_PREFIX${info.versionName}$APK_FILE_SUFFIX"
+
     private fun verifySha256(uri: Uri, expected: String): Boolean = runCatching {
         sha256(uri).equals(expected, ignoreCase = true)
     }.getOrDefault(false)
@@ -291,3 +338,9 @@ class AppUpdateManager(private val context: Context) {
         private const val KEY_MANDATORY = "mandatory"
     }
 }
+
+internal fun isManagedUpdateApkFileName(fileName: String): Boolean =
+    fileName.startsWith(UPDATE_APK_FILE_PREFIX) && fileName.endsWith(APK_FILE_SUFFIX, ignoreCase = true)
+
+private const val UPDATE_APK_FILE_PREFIX = "ev-charge-book-"
+private const val APK_FILE_SUFFIX = ".apk"

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
@@ -30,7 +30,15 @@ data class AppUpdateInfo(
     val mandatory: Boolean
 )
 
+sealed class RestoredUpdateDownload {
+    data class Ready(val info: AppUpdateInfo, val uri: Uri) : RestoredUpdateDownload()
+    data class InProgress(val info: AppUpdateInfo, val downloadId: Long) : RestoredUpdateDownload()
+}
+
 class AppUpdateManager(private val context: Context) {
+    private val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+    private val updatePrefs = context.getSharedPreferences(UPDATE_DOWNLOAD_PREFS, Context.MODE_PRIVATE)
+
     suspend fun checkForUpdate(currentVersionCode: Int = BuildConfig.VERSION_CODE): AppUpdateInfo? = withContext(Dispatchers.IO) {
         val manifestBaseUrl = BuildConfig.UPDATE_MANIFEST_URL
         val manifestUrl = cacheBustedUrl(manifestBaseUrl)
@@ -66,6 +74,58 @@ class AppUpdateManager(private val context: Context) {
         }
     }
 
+    /**
+     * Recover an update DownloadManager task after the Activity/process was recreated.
+     *
+     * A successful task is SHA-256 verified again before being exposed as installable. An active
+     * task is returned so the UI can keep observing the same download instead of enqueueing a
+     * duplicate. Stale, failed, missing, already-installed, or corrupt tasks are forgotten.
+     */
+    suspend fun restorePendingDownload(
+        currentVersionCode: Int = BuildConfig.VERSION_CODE
+    ): RestoredUpdateDownload? = withContext(Dispatchers.IO) {
+        val pending = readPendingDownload() ?: return@withContext null
+        val (downloadId, info) = pending
+
+        if (info.versionCode <= currentVersionCode) {
+            clearPendingDownload()
+            return@withContext null
+        }
+
+        downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
+            if (!cursor.moveToFirst()) {
+                clearPendingDownload()
+                return@withContext null
+            }
+
+            when (cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))) {
+                DownloadManager.STATUS_SUCCESSFUL -> {
+                    val uri = downloadManager.getUriForDownloadedFile(downloadId)
+                    if (uri == null || !verifySha256(uri, info.sha256)) {
+                        downloadManager.remove(downloadId)
+                        clearPendingDownload()
+                        return@withContext null
+                    }
+                    RestoredUpdateDownload.Ready(info, uri)
+                }
+
+                DownloadManager.STATUS_PENDING,
+                DownloadManager.STATUS_RUNNING,
+                DownloadManager.STATUS_PAUSED -> RestoredUpdateDownload.InProgress(info, downloadId)
+
+                DownloadManager.STATUS_FAILED -> {
+                    clearPendingDownload()
+                    null
+                }
+
+                else -> {
+                    clearPendingDownload()
+                    null
+                }
+            }
+        }
+    }
+
     fun canRequestPackageInstalls(): Boolean = context.packageManager.canRequestPackageInstalls()
 
     fun openInstallPermissionSettings(activity: Activity) {
@@ -78,7 +138,6 @@ class AppUpdateManager(private val context: Context) {
     }
 
     suspend fun downloadAndVerify(info: AppUpdateInfo): Uri = withContext(Dispatchers.IO) {
-        val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val fileName = "ev-charge-book-${info.versionName}.apk"
         val request = DownloadManager.Request(Uri.parse(info.apkUrl))
             .setTitle("EV Charge Book ${info.versionName}")
@@ -88,26 +147,16 @@ class AppUpdateManager(private val context: Context) {
             .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
         val downloadId = downloadManager.enqueue(request)
 
-        while (true) {
-            downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
-                require(cursor.moveToFirst()) { "找不到更新下载任务" }
-                when (cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))) {
-                    DownloadManager.STATUS_SUCCESSFUL -> {
-                        val uri = downloadManager.getUriForDownloadedFile(downloadId)
-                            ?: error("更新包下载完成但无法读取")
-                        val actual = sha256(uri)
-                        require(actual.equals(info.sha256, ignoreCase = true)) { "更新包 SHA-256 校验失败" }
-                        return@withContext uri
-                    }
-                    DownloadManager.STATUS_FAILED -> {
-                        val reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
-                        error("更新包下载失败（$reason）")
-                    }
-                }
-            }
-            delay(500)
-        }
-        error("unreachable")
+        // Persist immediately after enqueue. If the app is closed one millisecond later, the next
+        // process can still recover this exact DownloadManager task and eventually install it.
+        savePendingDownload(downloadId, info)
+        awaitDownloadAndVerify(downloadId, info)
+    }
+
+    suspend fun resumeDownloadAndVerify(downloadId: Long, info: AppUpdateInfo): Uri = withContext(Dispatchers.IO) {
+        // Refresh the persisted metadata in case this state was created by an older app build.
+        savePendingDownload(downloadId, info)
+        awaitDownloadAndVerify(downloadId, info)
     }
 
     fun launchInstaller(activity: Activity, apkUri: Uri) {
@@ -119,6 +168,89 @@ class AppUpdateManager(private val context: Context) {
             }
         )
     }
+
+    private suspend fun awaitDownloadAndVerify(downloadId: Long, info: AppUpdateInfo): Uri {
+        while (true) {
+            downloadManager.query(DownloadManager.Query().setFilterById(downloadId)).use { cursor ->
+                if (!cursor.moveToFirst()) {
+                    clearPendingDownload()
+                    error("找不到更新下载任务")
+                }
+                when (cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))) {
+                    DownloadManager.STATUS_SUCCESSFUL -> {
+                        val uri = downloadManager.getUriForDownloadedFile(downloadId)
+                            ?: run {
+                                clearPendingDownload()
+                                error("更新包下载完成但无法读取")
+                            }
+                        if (!verifySha256(uri, info.sha256)) {
+                            downloadManager.remove(downloadId)
+                            clearPendingDownload()
+                            error("更新包 SHA-256 校验失败")
+                        }
+                        // Deliberately keep the persisted task. If the user closes the app before
+                        // installing, the next launch must recover this verified APK as READY.
+                        return uri
+                    }
+
+                    DownloadManager.STATUS_FAILED -> {
+                        val reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON))
+                        clearPendingDownload()
+                        error("更新包下载失败（$reason）")
+                    }
+                }
+            }
+            delay(500)
+        }
+    }
+
+    private fun savePendingDownload(downloadId: Long, info: AppUpdateInfo) {
+        updatePrefs.edit()
+            .putLong(KEY_DOWNLOAD_ID, downloadId)
+            .putInt(KEY_VERSION_CODE, info.versionCode)
+            .putString(KEY_VERSION_NAME, info.versionName)
+            .putString(KEY_APK_URL, info.apkUrl)
+            .putString(KEY_SHA256, info.sha256)
+            .putString(KEY_PUBLISHED_AT, info.publishedAt)
+            .putBoolean(KEY_MANDATORY, info.mandatory)
+            .apply()
+    }
+
+    private fun readPendingDownload(): Pair<Long, AppUpdateInfo>? {
+        val downloadId = updatePrefs.getLong(KEY_DOWNLOAD_ID, -1L)
+        val versionCode = updatePrefs.getInt(KEY_VERSION_CODE, -1)
+        val versionName = updatePrefs.getString(KEY_VERSION_NAME, null)
+        val apkUrl = updatePrefs.getString(KEY_APK_URL, null)
+        val sha256 = updatePrefs.getString(KEY_SHA256, null)?.lowercase(Locale.US)
+        if (
+            downloadId <= 0L ||
+            versionCode <= 0 ||
+            versionName.isNullOrBlank() ||
+            apkUrl.isNullOrBlank() ||
+            sha256 == null ||
+            !sha256.matches(Regex("[0-9a-f]{64}"))
+        ) {
+            if (updatePrefs.contains(KEY_DOWNLOAD_ID)) clearPendingDownload()
+            return null
+        }
+
+        return downloadId to AppUpdateInfo(
+            versionCode = versionCode,
+            versionName = versionName,
+            apkUrl = apkUrl,
+            sha256 = sha256,
+            publishedAt = updatePrefs.getString(KEY_PUBLISHED_AT, "").orEmpty(),
+            mandatory = updatePrefs.getBoolean(KEY_MANDATORY, false)
+        )
+    }
+
+    private fun clearPendingDownload() {
+        updatePrefs.edit().clear().apply()
+    }
+
+    private fun verifySha256(uri: Uri, expected: String): Boolean = runCatching {
+        sha256(uri).equals(expected, ignoreCase = true)
+    }.getOrDefault(false)
 
     private fun sha256(uri: Uri): String {
         val digest = MessageDigest.getInstance("SHA-256")
@@ -141,5 +273,13 @@ class AppUpdateManager(private val context: Context) {
 
     companion object {
         private const val APK_MIME_TYPE = "application/vnd.android.package-archive"
+        private const val UPDATE_DOWNLOAD_PREFS = "app_update_download"
+        private const val KEY_DOWNLOAD_ID = "download_id"
+        private const val KEY_VERSION_CODE = "version_code"
+        private const val KEY_VERSION_NAME = "version_name"
+        private const val KEY_APK_URL = "apk_url"
+        private const val KEY_SHA256 = "sha256"
+        private const val KEY_PUBLISHED_AT = "published_at"
+        private const val KEY_MANDATORY = "mandatory"
     }
 }

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdateManager.kt
@@ -147,14 +147,21 @@ class AppUpdateManager(private val context: Context) {
             .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
         val downloadId = downloadManager.enqueue(request)
 
-        // Persist immediately after enqueue. If the app is closed one millisecond later, the next
-        // process can still recover this exact DownloadManager task and eventually install it.
-        savePendingDownload(downloadId, info)
+        // This record is the only bridge between DownloadManager and the next app process. Commit
+        // it synchronously on the IO dispatcher before returning to the polling loop. If durable
+        // persistence fails, cancel the just-created task rather than leave an unrecoverable orphan.
+        try {
+            savePendingDownload(downloadId, info)
+        } catch (error: Throwable) {
+            downloadManager.remove(downloadId)
+            throw error
+        }
         awaitDownloadAndVerify(downloadId, info)
     }
 
     suspend fun resumeDownloadAndVerify(downloadId: Long, info: AppUpdateInfo): Uri = withContext(Dispatchers.IO) {
-        // Refresh the persisted metadata in case this state was created by an older app build.
+        // Refresh persisted metadata before resuming observation so another process recreation can
+        // still recover the same task.
         savePendingDownload(downloadId, info)
         awaitDownloadAndVerify(downloadId, info)
     }
@@ -205,7 +212,7 @@ class AppUpdateManager(private val context: Context) {
     }
 
     private fun savePendingDownload(downloadId: Long, info: AppUpdateInfo) {
-        updatePrefs.edit()
+        val persisted = updatePrefs.edit()
             .putLong(KEY_DOWNLOAD_ID, downloadId)
             .putInt(KEY_VERSION_CODE, info.versionCode)
             .putString(KEY_VERSION_NAME, info.versionName)
@@ -213,7 +220,8 @@ class AppUpdateManager(private val context: Context) {
             .putString(KEY_SHA256, info.sha256)
             .putString(KEY_PUBLISHED_AT, info.publishedAt)
             .putBoolean(KEY_MANDATORY, info.mandatory)
-            .apply()
+            .commit()
+        check(persisted) { "无法保存更新下载状态" }
     }
 
     private fun readPendingDownload(): Pair<Long, AppUpdateInfo>? {

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
@@ -65,13 +65,12 @@ fun AppUpdatePrompt() {
 
         when (restored) {
             is RestoredUpdateDownload.Ready -> {
-                // A verified APK survives process death. On a fresh app process, surface the
-                // install action immediately instead of asking the user to download it again.
-                if (processReadyPromptSessionGate.tryClaim(restored.info.versionCode)) {
-                    update = restored.info
-                    downloadedUri = restored.uri
-                    phase = UpdatePhase.READY
-                }
+                // Install-ready state is durable, so it must win over in-memory prompt dedupe.
+                // If Activity/Compose state is recreated while the verified APK still exists,
+                // always restore the install action rather than silently hiding the update.
+                update = restored.info
+                downloadedUri = restored.uri
+                phase = UpdatePhase.READY
             }
 
             is RestoredUpdateDownload.InProgress -> {
@@ -115,7 +114,6 @@ fun AppUpdatePrompt() {
             .onSuccess { uri ->
                 resumeDownloadId = null
                 downloadedUri = uri
-                processReadyPromptSessionGate.tryClaim(info.versionCode)
                 phase = UpdatePhase.READY
             }
             .onFailure { error ->
@@ -297,7 +295,6 @@ internal class UpdatePromptSessionGate {
 }
 
 private val processUpdatePromptSessionGate = UpdatePromptSessionGate()
-private val processReadyPromptSessionGate = UpdatePromptSessionGate()
 
 private enum class UpdatePhase {
     IDLE,

--- a/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
+++ b/android/app/src/main/java/com/evchargebook/update/AppUpdatePrompt.kt
@@ -56,36 +56,70 @@ fun AppUpdatePrompt() {
     var downloadedUri by remember { mutableStateOf<Uri?>(null) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var downloadToken by remember { mutableIntStateOf(0) }
+    var resumeDownloadId by remember { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(Unit) {
-        runCatching { manager.checkForUpdate() }
-            .onSuccess { info ->
-                if (info != null && processUpdatePromptSessionGate.tryClaim(info.versionCode)) {
-                    // The previous fix prevented a double render inside one composition. Keep a
-                    // process-level version claim as well so navigation/activity recreation cannot
-                    // consume the same discovery result again and show a second identical dialog.
-                    phase = UpdatePhase.DISCOVERED
-                    update = info
-                } else if (info != null) {
-                    Log.d(TAG, "Skip duplicate update prompt for versionCode=${info.versionCode}")
+        val restored = runCatching { manager.restorePendingDownload() }
+            .onFailure { error -> Log.w(TAG, "Failed to restore pending update download", error) }
+            .getOrNull()
+
+        when (restored) {
+            is RestoredUpdateDownload.Ready -> {
+                // A verified APK survives process death. On a fresh app process, surface the
+                // install action immediately instead of asking the user to download it again.
+                if (processReadyPromptSessionGate.tryClaim(restored.info.versionCode)) {
+                    update = restored.info
+                    downloadedUri = restored.uri
+                    phase = UpdatePhase.READY
                 }
             }
-            .onFailure { error ->
-                Log.w(TAG, "Update discovery failed for ${BuildConfig.UPDATE_MANIFEST_URL}", error)
+
+            is RestoredUpdateDownload.InProgress -> {
+                // Keep following the same DownloadManager row. Do not enqueue a second APK.
+                update = restored.info
+                phase = UpdatePhase.DOWNLOADING
+                resumeDownloadId = restored.downloadId
+                downloadToken += 1
             }
+
+            null -> {
+                runCatching { manager.checkForUpdate() }
+                    .onSuccess { info ->
+                        if (info != null && processUpdatePromptSessionGate.tryClaim(info.versionCode)) {
+                            phase = UpdatePhase.DISCOVERED
+                            update = info
+                        } else if (info != null) {
+                            Log.d(TAG, "Skip duplicate update prompt for versionCode=${info.versionCode}")
+                        }
+                    }
+                    .onFailure { error ->
+                        Log.w(TAG, "Update discovery failed for ${BuildConfig.UPDATE_MANIFEST_URL}", error)
+                    }
+            }
+        }
     }
 
     LaunchedEffect(downloadToken) {
         if (downloadToken <= 0) return@LaunchedEffect
         val info = update ?: return@LaunchedEffect
+        val existingDownloadId = resumeDownloadId
         errorMessage = null
         downloadedUri = null
-        runCatching { manager.downloadAndVerify(info) }
+        runCatching {
+            if (existingDownloadId != null) {
+                manager.resumeDownloadAndVerify(existingDownloadId, info)
+            } else {
+                manager.downloadAndVerify(info)
+            }
+        }
             .onSuccess { uri ->
+                resumeDownloadId = null
                 downloadedUri = uri
+                processReadyPromptSessionGate.tryClaim(info.versionCode)
                 phase = UpdatePhase.READY
             }
             .onFailure { error ->
+                resumeDownloadId = null
                 Log.w(TAG, "Background update download failed for ${info.versionName}", error)
                 errorMessage = error.message ?: "更新包下载失败，请稍后重试"
                 phase = UpdatePhase.FAILED
@@ -105,6 +139,7 @@ fun AppUpdatePrompt() {
         if (info == null) return
         // Hide the decision dialog synchronously before starting background work.
         phase = UpdatePhase.DOWNLOADING
+        resumeDownloadId = null
         downloadToken += 1
     }
 
@@ -148,7 +183,7 @@ fun AppUpdatePrompt() {
                 title = "${current.versionName} 已准备好",
                 lines = listOf(
                     "更新包已下载并通过 SHA-256 完整性校验。",
-                    "点击安装后会进入 Android 系统安装界面；安装前不会退出当前应用。"
+                    "点击安装后会进入 Android 系统安装界面；即使关闭并重新打开 App，也不会重复下载。"
                 ),
                 confirmText = "安装",
                 dismissText = if (current.mandatory) null else "稍后",
@@ -262,6 +297,7 @@ internal class UpdatePromptSessionGate {
 }
 
 private val processUpdatePromptSessionGate = UpdatePromptSessionGate()
+private val processReadyPromptSessionGate = UpdatePromptSessionGate()
 
 private enum class UpdatePhase {
     IDLE,

--- a/android/app/src/test/java/com/evchargebook/update/AppUpdateManagerFileNameTest.kt
+++ b/android/app/src/test/java/com/evchargebook/update/AppUpdateManagerFileNameTest.kt
@@ -1,0 +1,20 @@
+package com.evchargebook.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppUpdateManagerFileNameTest {
+    @Test
+    fun updaterOwnedApkNamesAreRecognized() {
+        assertTrue(isManagedUpdateApkFileName("ev-charge-book-1.2.3.apk"))
+        assertTrue(isManagedUpdateApkFileName("ev-charge-book-2026.08.31.APK"))
+    }
+
+    @Test
+    fun unrelatedFilesAreNeverMatchedForCleanup() {
+        assertFalse(isManagedUpdateApkFileName("another-app.apk"))
+        assertFalse(isManagedUpdateApkFileName("ev-charge-book-notes.txt"))
+        assertFalse(isManagedUpdateApkFileName("backup-ev-charge-book-1.2.3.apk"))
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/update/UpdateDownloadRecoveryContractTest.kt
+++ b/android/app/src/test/java/com/evchargebook/update/UpdateDownloadRecoveryContractTest.kt
@@ -1,0 +1,31 @@
+package com.evchargebook.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateDownloadRecoveryContractTest {
+    @Test
+    fun readyRecoveryKeepsOriginalUpdateMetadata() {
+        val info = AppUpdateInfo(
+            versionCode = 108,
+            versionName = "1.0.8",
+            apkUrl = "https://example.invalid/ev-charge-book-1.0.8.apk",
+            sha256 = "a".repeat(64),
+            publishedAt = "2026-08-31T06:00:00Z",
+            mandatory = false
+        )
+
+        assertEquals(108, info.versionCode)
+        assertEquals("1.0.8", info.versionName)
+        assertTrue(info.sha256.matches(Regex("[0-9a-f]{64}")))
+    }
+
+    @Test
+    fun processGateStillAllowsNewerVersionAfterOnePrompt() {
+        val gate = UpdatePromptSessionGate()
+
+        assertTrue(gate.tryClaim(108))
+        assertTrue(gate.tryClaim(109))
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
+++ b/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
@@ -20,12 +20,4 @@ class UpdatePromptSessionGateTest {
         assertTrue(gate.tryClaim(42))
         assertTrue(gate.tryClaim(43))
     }
-
-    @Test
-    fun independentGateCanDeduplicateInstallReadyPrompt() {
-        val readyGate = UpdatePromptSessionGate()
-
-        assertTrue(readyGate.tryClaim(108))
-        assertFalse(readyGate.tryClaim(108))
-    }
 }

--- a/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
+++ b/android/app/src/test/java/com/evchargebook/update/UpdatePromptSessionGateTest.kt
@@ -20,4 +20,12 @@ class UpdatePromptSessionGateTest {
         assertTrue(gate.tryClaim(42))
         assertTrue(gate.tryClaim(43))
     }
+
+    @Test
+    fun independentGateCanDeduplicateInstallReadyPrompt() {
+        val readyGate = UpdatePromptSessionGate()
+
+        assertTrue(readyGate.tryClaim(108))
+        assertFalse(readyGate.tryClaim(108))
+    }
 }

--- a/docs/UPDATE_DOWNLOAD_RECOVERY.md
+++ b/docs/UPDATE_DOWNLOAD_RECOVERY.md
@@ -7,7 +7,11 @@ Expected behavior:
 1. Persist the DownloadManager id and immutable update metadata immediately after enqueue.
 2. If the app process is recreated while the task is pending/running/paused, resume observing the same task instead of enqueueing another download.
 3. If the task completed while the app was closed, recover its Uri, re-verify the manifest SHA-256, and surface the install action immediately.
-4. Keep the completed task persisted until the app has actually moved to that version. This allows closing the app from the install-ready dialog and still recovering it on the next launch.
-5. Missing, failed, corrupt, or already-installed tasks are discarded and normal update discovery resumes.
+4. Install-ready state is durable: if Activity/Compose state is recreated while the verified APK still exists, restore the install action again rather than suppressing it with in-memory prompt deduplication.
+5. Keep the completed task and current APK persisted until the app has actually moved to that version.
+6. Once the installed app version reaches or exceeds the downloaded version, remove the tracked DownloadManager task and its APK.
+7. Clean stale updater-owned `ev-charge-book-*.apk` files from the app's private external Downloads directory on startup/retry while preserving the currently active package.
+8. Missing, failed, corrupt, or unrecoverable tasks are discarded, their updater-owned APK leftovers are cleaned, and normal update discovery resumes.
+9. Cleanup is intentionally scoped to updater-owned filenames inside the app-specific directory; unrelated files and the system Downloads directory are not touched.
 
-This recovery is forward-compatible from the first build containing the persisted DownloadManager metadata. Downloads created by older builds did not persist their DownloadManager id and therefore cannot be reconstructed reliably after process death.
+This recovery is forward-compatible from the first build containing the persisted DownloadManager metadata. Downloads created by older builds did not persist their DownloadManager id and therefore cannot be reconstructed reliably after process death. Their app-private updater APK leftovers are treated as stale and cleaned automatically.

--- a/docs/UPDATE_DOWNLOAD_RECOVERY.md
+++ b/docs/UPDATE_DOWNLOAD_RECOVERY.md
@@ -1,0 +1,13 @@
+# Update download recovery
+
+The Android updater treats DownloadManager as the source of truth for an update APK once download starts.
+
+Expected behavior:
+
+1. Persist the DownloadManager id and immutable update metadata immediately after enqueue.
+2. If the app process is recreated while the task is pending/running/paused, resume observing the same task instead of enqueueing another download.
+3. If the task completed while the app was closed, recover its Uri, re-verify the manifest SHA-256, and surface the install action immediately.
+4. Keep the completed task persisted until the app has actually moved to that version. This allows closing the app from the install-ready dialog and still recovering it on the next launch.
+5. Missing, failed, corrupt, or already-installed tasks are discarded and normal update discovery resumes.
+
+This recovery is forward-compatible from the first build containing the persisted DownloadManager metadata. Downloads created by older builds did not persist their DownloadManager id and therefore cannot be reconstructed reliably after process death.


### PR DESCRIPTION
## Summary

Fixes the updater losing install-ready state after the app is closed and reopened, and closes the lifecycle gap where historical updater APKs could accumulate in app-private storage.

### Root cause

The completed APK Uri previously lived only in Compose memory (`downloadedUri`). `DownloadManager` could finish successfully, but after process death the app had no persisted download id/metadata and therefore could not recover the finished APK. Completed/failed updater APK files also had no explicit cleanup lifecycle.

### Changes

- persist `DownloadManager` id plus immutable update metadata immediately after enqueue;
- on app launch, restore the existing DownloadManager task before normal update discovery;
- if the task already completed, recover its Uri, re-check SHA-256, and show the **Install** dialog immediately;
- if the task is still pending/running/paused, resume observing the same download instead of enqueueing a duplicate;
- always restore verified install-ready state after Activity/Compose recreation instead of suppressing it with in-memory prompt dedupe;
- keep a verified completed task and its APK persisted until the installed app version reaches/exceeds that version;
- once the downloaded version is confirmed installed, remove the DownloadManager task and its APK;
- clean stale `ev-charge-book-*.apk` files from the app's own `externalFilesDir/Downloads` directory on startup/retry while preserving the currently active install package;
- remove failed, corrupt, missing, or unrecoverable update package leftovers before falling back to normal discovery;
- cleanup matching is deliberately scoped so unrelated APKs/files are never selected;
- keep process-level duplicate suppression only for the discovery/download decision prompt;
- document the recovery and cleanup contract.

## Important compatibility note

This is forward-compatible from the first build containing this persistence logic. APKs downloaded by older builds did not persist their DownloadManager id, so an already-finished download created by an older build cannot be reliably reconstructed after that old process was killed. Those legacy app-private updater APK leftovers are now treated as stale and cleaned automatically; obtaining an install-ready package still requires one final re-download after upgrading to this fix.

## Validation targets

1. Start update download -> close app while downloading -> reopen -> same DownloadManager task continues, no duplicate download.
2. Finish download -> close app before installing -> reopen -> verified package immediately shows **Install**.
3. Finish download -> Activity/Compose recreation -> **Install** remains recoverable and is not hidden by prompt dedupe.
4. Finish download -> tap Later -> fully close/reopen app -> **Install** is offered again without downloading.
5. Corrupt/missing/failed DownloadManager task -> persisted state and updater-owned APK leftovers are cleared, then normal update discovery resumes.
6. Install downloaded version -> launch upgraded app -> old DownloadManager task and historical `ev-charge-book-*.apk` files are removed.
7. Unrelated files in the app Downloads directory remain untouched.
