### PR TITLE
feat(vehicle): enforce nickname-only managed catalog flow

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -310,7 +310,6 @@ fun MainApp(
     SideEffect {
         (context as? Activity)?.window?.let { window ->
             WindowCompat.getInsetsController(window, window.decorView).apply {
-                // Dashboard is always visually dark because the Hero artwork reaches the system bar.
                 isAppearanceLightStatusBars = if (!hasOverlayPage && tab == 0) false else !themeController.darkTheme
                 isAppearanceLightNavigationBars = !themeController.darkTheme
             }
@@ -363,8 +362,6 @@ fun MainApp(
     AppUpdatePrompt()
 
     Scaffold(
-        // Only the Dashboard owns the top system-bar backdrop. Other screens keep the
-        // existing Scaffold safe-drawing insets and therefore retain their current layout.
         contentWindowInsets = if (!hasOverlayPage && tab == 0) {
             WindowInsets(0, 0, 0, 0)
         } else {
@@ -395,9 +392,7 @@ fun MainApp(
                                 Icon(
                                     imageVector = icons[index],
                                     contentDescription = title,
-                                    modifier = Modifier
-                                        .size(26.dp)
-                                        .padding(3.dp)
+                                    modifier = Modifier.size(26.dp).padding(3.dp)
                                 )
                             },
                             label = { Text(title, style = MaterialTheme.typography.labelMedium) },
@@ -438,28 +433,45 @@ fun MainApp(
                 )
                 editVehicle -> state.vehicle?.let { vehicle ->
                     VehicleEditScreen(
-                        initialBrand = vehicle.brand,
-                        initialModel = vehicle.model,
-                        initialBatteryCapacity = vehicle.batteryCapacityKwh.toString(),
-                        initialRange = vehicle.rangeKm.toString(),
-                        onSave = { brand, model, capacity, range -> viewModel.saveVehicle(brand, model, capacity, range); editVehicle = false },
+                        initialNickname = vehicle.nickname.orEmpty(),
+                        brand = vehicle.brand,
+                        model = vehicle.model,
+                        batteryCapacityKwh = vehicle.batteryCapacityKwh,
+                        rangeKm = vehicle.rangeKm,
+                        onSave = { nickname ->
+                            viewModel.saveVehicleNickname(nickname)
+                            editVehicle = false
+                        },
                         onBack = { editVehicle = false }
                     )
                 }
-                addVehicle -> VehicleEditScreen(
-                    initialBrand = catalogSelection?.brand.orEmpty(),
-                    initialModel = catalogSelection?.modelName.orEmpty(),
-                    initialBatteryCapacity = catalogSelection?.batteryCapacityKwh?.toString().orEmpty(),
-                    initialRange = catalogSelection?.rangeKm?.toString().orEmpty(),
-                    title = "添加车辆",
-                    onSave = { brand, model, capacity, range -> viewModel.addVehicle(brand, model, capacity, range, catalogSelection?.catalogId); catalogSelection = null; addVehicle = false },
-                    onBack = { addVehicle = false }
-                )
+                addVehicle -> catalogSelection?.let { catalog ->
+                    VehicleEditScreen(
+                        initialNickname = "",
+                        brand = catalog.brand,
+                        model = listOfNotNull(catalog.modelName, catalog.trimName?.takeIf { it.isNotBlank() }).joinToString(" · "),
+                        batteryCapacityKwh = catalog.batteryCapacityKwh,
+                        rangeKm = catalog.rangeKm,
+                        title = "添加车辆",
+                        onSave = { nickname ->
+                            viewModel.addVehicle(catalog, nickname)
+                            catalogSelection = null
+                            addVehicle = false
+                        },
+                        onBack = {
+                            catalogSelection = null
+                            addVehicle = false
+                        }
+                    )
+                }
                 selectCatalogVehicle -> VehicleCatalogScreen(
-                    state.catalogVehicles,
-                    { selected -> catalogSelection = selected; selectCatalogVehicle = false; addVehicle = true },
-                    { catalogSelection = null; selectCatalogVehicle = false; addVehicle = true },
-                    { selectCatalogVehicle = false }
+                    items = state.catalogVehicles,
+                    onSelect = { selected ->
+                        catalogSelection = selected
+                        selectCatalogVehicle = false
+                        addVehicle = true
+                    },
+                    onBack = { selectCatalogVehicle = false }
                 )
                 bluetoothPrompt -> BluetoothPromptScreen(state.bluetoothSettings, state.pairedBluetoothDevices, viewModel::saveBluetoothPrompt) { bluetoothPrompt = false }
                 else -> when (tab) {

--- a/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
+++ b/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
@@ -20,7 +20,7 @@ data class BackupPayload(
 )
 
 object BackupCodec {
-    const val CURRENT_SCHEMA_VERSION = 7
+    const val CURRENT_SCHEMA_VERSION = 8
 
     fun encode(payload: BackupPayload): String = JSONObject().apply {
         put("schemaVersion", payload.schemaVersion)
@@ -31,6 +31,7 @@ object BackupCodec {
                 put(JSONObject().apply {
                     put("id", vehicle.id)
                     putNullable("catalogVehicleId", vehicle.catalogVehicleId)
+                    putNullable("nickname", vehicle.nickname)
                     put("brand", vehicle.brand)
                     put("model", vehicle.model)
                     put("batteryCapacityKwh", vehicle.batteryCapacityKwh)
@@ -136,6 +137,7 @@ object BackupCodec {
                     VehicleEntity(
                         id = id,
                         catalogVehicleId = item.optNullableString("catalogVehicleId"),
+                        nickname = item.optNullableString("nickname"),
                         brand = item.getString("brand"),
                         model = item.getString("model"),
                         batteryCapacityKwh = item.getDouble("batteryCapacityKwh"),

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleCatalogScreen.kt
@@ -30,7 +30,6 @@ private val CatalogHeroBrush = Brush.linearGradient(
 fun VehicleCatalogScreen(
     items: List<VehicleCatalogEntity>,
     onSelect: (VehicleCatalogEntity) -> Unit,
-    onCustom: () -> Unit,
     onBack: () -> Unit
 ) {
     var query by remember { mutableStateOf("") }
@@ -49,20 +48,12 @@ fun VehicleCatalogScreen(
                 title = {
                     Column {
                         Text("选择车型", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                        Text("VEHICLE CATALOG", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("MANAGED VEHICLE CATALOG", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 },
                 navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
-        },
-        bottomBar = {
-            Surface(color = MaterialTheme.colorScheme.background) {
-                OutlinedButton(
-                    onClick = onCustom,
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm)
-                ) { Text("没有找到？自定义添加车辆") }
-            }
         }
     ) { padding ->
         LazyColumn(
@@ -82,7 +73,11 @@ fun VehicleCatalogScreen(
                             Text("VEHICLE / FIND", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
                         }
                         Text("找到你的车型", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                        Text("车型库保存在本机；有网络时会后台刷新，没有网络也可以正常使用。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(
+                            "车型由 Web 后台统一维护；本机保存最后一次有效车型库，有网络时自动刷新，离线仍可选择已缓存车型。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                         OutlinedTextField(
                             value = query,
                             onValueChange = { query = it },
@@ -92,7 +87,7 @@ fun VehicleCatalogScreen(
                             singleLine = true
                         )
                         Text(
-                            if (query.isBlank()) "车型库 ${activeItems.size} 条" else "找到 ${filtered.size} 条结果",
+                            if (query.isBlank()) "可选车型 ${activeItems.size} 条" else "找到 ${filtered.size} 条结果",
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -103,8 +98,12 @@ fun VehicleCatalogScreen(
             if (filtered.isEmpty()) {
                 item {
                     Column(Modifier.fillMaxWidth().padding(vertical = MaterialTheme.spacing.lg)) {
-                        Text("没有匹配车型", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                        Text("修改关键词，或者使用底部的自定义添加。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("车型库中没有匹配项", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        Text(
+                            "修改搜索关键词；如果车型尚未支持，需要先在 Web 管理端补充并发布车型库。App 不再创建自定义标准车型。",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
             }
@@ -125,7 +124,12 @@ private fun CatalogVehicleRow(item: VehicleCatalogEntity, onSelect: (VehicleCata
         Row(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md), verticalAlignment = Alignment.CenterVertically) {
             Surface(Modifier.size(42.dp), shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .10f)) {
                 Box(contentAlignment = Alignment.Center) {
-                    Text(item.brand.take(1).uppercase(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                    Text(
+                        item.brand.take(1).uppercase(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
                 }
             }
             Spacer(Modifier.width(MaterialTheme.spacing.sm))

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleEditScreen.kt
@@ -14,40 +14,41 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.evchargebook.ui.theme.spacing
+import java.util.Locale
 
 private val VehicleEditHeroBrush = Brush.linearGradient(
     listOf(Color(0xFF06100B), Color(0xFF0B2117), Color(0xFF07120D))
 )
 
+private const val MAX_VEHICLE_NICKNAME_LENGTH = 24
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VehicleEditScreen(
-    initialBrand: String,
-    initialModel: String,
-    initialBatteryCapacity: String,
-    initialRange: String,
-    title: String = "编辑车辆",
-    onSave: (String, String, Double, Int) -> Unit,
+    initialNickname: String,
+    brand: String,
+    model: String,
+    batteryCapacityKwh: Double?,
+    rangeKm: Int?,
+    title: String = "编辑车辆名称",
+    onSave: (String?) -> Unit,
     onBack: () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
-    var brand by remember { mutableStateOf(initialBrand) }
-    var model by remember { mutableStateOf(initialModel) }
-    var battery by remember { mutableStateOf(initialBatteryCapacity) }
-    var range by remember { mutableStateOf(initialRange) }
-    var error by remember { mutableStateOf<String?>(null) }
+    var nickname by remember(initialNickname) { mutableStateOf(initialNickname) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
     val adding = title == "添加车辆"
-    val isDirty = brand != initialBrand || model != initialModel || battery != initialBatteryCapacity || range != initialRange
+    val normalizedInitial = initialNickname.trim()
+    val normalizedNickname = nickname.trim()
+    val isDirty = normalizedNickname != normalizedInitial
+    val fallbackName = model.ifBlank { brand }
 
     fun requestBack() {
         if (isDirty) showDiscardConfirm = true else onBack()
@@ -62,7 +63,11 @@ fun VehicleEditScreen(
                 title = {
                     Column {
                         Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                        Text(if (adding) "VEHICLE SETUP" else "VEHICLE PROFILE", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(
+                            if (adding) "CATALOG VEHICLE" else "PERSONAL VEHICLE NAME",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 },
                 navigationIcon = { IconButton(onClick = ::requestBack) { Icon(Icons.Default.ArrowBack, "返回") } },
@@ -71,77 +76,102 @@ fun VehicleEditScreen(
         }
     ) { padding ->
         Column(
-            Modifier.fillMaxSize().padding(padding).imePadding().verticalScroll(rememberScrollState()).padding(horizontal = MaterialTheme.spacing.md),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)
         ) {
             Spacer(Modifier.height(MaterialTheme.spacing.xs))
-            VehiclePreviewCockpit(brand, model, battery, range, adding)
 
-            FormSection("车辆身份", "VEHICLE IDENTITY", "用于区分账本数据，并作为首页和车辆页的主标题。") {
-                OutlinedTextField(
-                    value = brand,
-                    onValueChange = { brand = it },
-                    label = { Text("品牌") },
-                    placeholder = { Text("例如：零跑") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) })
-                )
-                OutlinedTextField(
-                    value = model,
-                    onValueChange = { model = it },
-                    label = { Text("车型") },
-                    placeholder = { Text("例如：C16 2026款") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                    keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) })
-                )
-            }
-
-            FormSection("电池与续航", "EV SPECS", "用于首页车辆指标与后续能耗统计。") {
-                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                    OutlinedTextField(
-                        value = battery,
-                        onValueChange = { battery = it },
-                        label = { Text("电池容量") },
-                        suffix = { Text("kWh") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
-                        keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) }),
-                        modifier = Modifier.weight(1f),
-                        singleLine = true
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = Color.Transparent,
+                shape = MaterialTheme.shapes.extraLarge
+            ) {
+                Column(
+                    Modifier.background(VehicleEditHeroBrush).padding(MaterialTheme.spacing.lg),
+                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+                        Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                        Text(
+                            if (adding) "VEHICLE / ADD" else "VEHICLE / RENAME",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    Text(
+                        normalizedNickname.ifBlank { fallbackName.ifBlank { "车辆" } },
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.SemiBold
                     )
-                    OutlinedTextField(
-                        value = range,
-                        onValueChange = { range = it.filter(Char::isDigit) },
-                        label = { Text("标称续航") },
-                        suffix = { Text("km") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                        modifier = Modifier.weight(1f),
-                        singleLine = true
+                    Text(
+                        listOf(brand.trim(), model.trim()).filter { it.isNotEmpty() }.joinToString(" "),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
 
-            error?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium) }
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                Text("车辆名称", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "这是你的个人名称，可以修改；留空时显示后台车型名称。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = nickname,
+                    onValueChange = { nickname = it.take(MAX_VEHICLE_NICKNAME_LENGTH) },
+                    label = { Text("车辆名称（可选）") },
+                    placeholder = { Text(fallbackName.ifBlank { "例如：通勤车" }) },
+                    supportingText = {
+                        Text("${nickname.length}/$MAX_VEHICLE_NICKNAME_LENGTH · 只影响显示名称，不修改车型资料")
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() })
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                Text("标准车型资料", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "以下信息由车型库统一维护，在 App 中仅展示，不允许修改。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                ReadOnlyFact("品牌", brand.ifBlank { "--" })
+                ReadOnlyFact("车型", model.ifBlank { "--" })
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    ReadOnlyFact(
+                        "电池容量",
+                        batteryCapacityKwh?.let { "${String.format(Locale.US, "%.1f", it)} kWh" } ?: "--",
+                        Modifier.weight(1f)
+                    )
+                    ReadOnlyFact(
+                        "标称续航",
+                        rangeKm?.let { "$it km" } ?: "--",
+                        Modifier.weight(1f)
+                    )
+                }
+            }
+
             Button(
                 onClick = {
                     focusManager.clearFocus()
-                    val capacity = battery.toDoubleOrNull()
-                    val rangeKm = range.toIntOrNull()
-                    error = when {
-                        brand.isBlank() -> "请输入车辆品牌"
-                        model.isBlank() -> "请输入车型"
-                        capacity == null || capacity <= 0 -> "电池容量需要大于 0"
-                        rangeKm == null || rangeKm <= 0 -> "标称续航需要大于 0"
-                        else -> null
-                    }
-                    if (error == null) onSave(brand.trim(), model.trim(), capacity!!, rangeKm!!)
+                    onSave(normalizedNickname.takeIf { it.isNotEmpty() })
                 },
                 modifier = Modifier.fillMaxWidth()
-            ) { Text(if (adding) "添加车辆" else "保存车辆") }
+            ) {
+                Text(if (adding) "确认添加" else "保存名称")
+            }
+
             Spacer(Modifier.height(MaterialTheme.spacing.lg))
         }
     }
@@ -150,55 +180,30 @@ fun VehicleEditScreen(
         AlertDialog(
             onDismissRequest = { showDiscardConfirm = false },
             title = { Text("放弃未保存修改？") },
-            text = { Text(if (adding) "当前车辆信息还没有保存，返回后这些内容会丢失。" else "车辆信息已经被修改，返回后未保存的修改会丢失。") },
-            confirmButton = { TextButton(onClick = { showDiscardConfirm = false; onBack() }) { Text("放弃", color = MaterialTheme.colorScheme.error) } },
+            text = { Text("车辆名称已经修改，返回后未保存的内容会丢失。") },
+            confirmButton = {
+                TextButton(onClick = { showDiscardConfirm = false; onBack() }) {
+                    Text("放弃", color = MaterialTheme.colorScheme.error)
+                }
+            },
             dismissButton = { TextButton(onClick = { showDiscardConfirm = false }) { Text("继续编辑") } }
         )
     }
 }
 
 @Composable
-private fun VehiclePreviewCockpit(brand: String, model: String, battery: String, range: String, adding: Boolean) {
-    Surface(modifier = Modifier.fillMaxWidth(), color = Color.Transparent, shape = MaterialTheme.shapes.extraLarge) {
+private fun ReadOnlyFact(label: String, value: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
         Column(
-            Modifier.background(VehicleEditHeroBrush).padding(MaterialTheme.spacing.lg),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
+            Modifier.padding(MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
-                Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text(if (adding) "VEHICLE / NEW" else "VEHICLE / EDIT", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-            }
-            Text(
-                listOf(brand.trim(), model.trim()).filter { it.isNotEmpty() }.joinToString(" ").ifBlank { "车辆预览" },
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.SemiBold
-            )
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .28f))
-            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg)) {
-                PreviewMetric("电池", battery.toDoubleOrNull()?.let { "${formatOne(it)} kWh" } ?: "--", Modifier.weight(1f))
-                PreviewMetric("续航", range.toIntOrNull()?.let { "$it km" } ?: "--", Modifier.weight(1f))
-            }
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
         }
     }
 }
-
-@Composable
-private fun PreviewMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-    }
-}
-
-@Composable
-private fun FormSection(title: String, eyebrow: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-        Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        content()
-    }
-}
-
-private fun formatOne(value: Double) = String.format(java.util.Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
@@ -65,7 +65,7 @@ fun VehicleScreen(
                     OutlinedButton(onClick = onEdit, modifier = Modifier.fillMaxWidth()) {
                         Icon(Icons.Default.Edit, null)
                         Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                        Text("编辑当前车辆")
+                        Text("编辑车辆名称")
                     }
                 }
             } else {
@@ -94,7 +94,7 @@ fun VehicleScreen(
     archiveCandidate?.let { candidate ->
         AlertDialog(
             onDismissRequest = { archiveCandidate = null },
-            title = { Text("归档 ${candidate.brand} ${candidate.model}？") },
+            title = { Text("归档 ${candidate.displayName}？") },
             text = { Text("车辆将不再出现在切换列表中，但历史充电记录仍会保留。") },
             confirmButton = { TextButton(onClick = { onArchive(candidate); archiveCandidate = null }) { Text("归档") } },
             dismissButton = { TextButton(onClick = { archiveCandidate = null }) { Text("取消") } }
@@ -105,7 +105,12 @@ fun VehicleScreen(
 @Composable
 private fun VehicleSpecificationCard(vehicle: VehicleEntity) {
     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-        SettingsSectionTitle("车辆规格", "VEHICLE SPECS")
+        SettingsSectionTitle("车辆规格", "VEHICLE SPECS · READ ONLY")
+        Text(
+            "${vehicle.brand} ${vehicle.model} · 标准车型资料由车型库维护",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         Surface(
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.large,
@@ -166,11 +171,11 @@ private fun EmptyGarage(onAdd: () -> Unit) {
                 Text("VEHICLE / EMPTY", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
             }
             Text("添加你的第一辆车", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-            Text("车辆资料会用于首页主视觉、充电统计和行程记录。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("从后台车型库选择标准车型；车型参数只读，添加后可以修改车辆名称。", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Button(onClick = onAdd, modifier = Modifier.fillMaxWidth()) {
                 Icon(Icons.Default.Add, null)
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text("添加车辆")
+                Text("选择车型")
             }
         }
     }
@@ -187,8 +192,8 @@ private fun VehicleRow(vehicle: VehicleEntity, onSelect: () -> Unit, onArchive: 
             }
             Spacer(Modifier.width(MaterialTheme.spacing.sm))
             Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("${vehicle.brand} ${vehicle.model}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                Text("${one(vehicle.batteryCapacityKwh)} kWh · ${vehicle.rangeKm} km", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(vehicle.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("${vehicle.brand} ${vehicle.model}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             TextButton(onClick = onSelect) { Text("切换") }
             IconButton(onClick = onArchive) { Icon(Icons.Default.Archive, "归档车辆", tint = MaterialTheme.colorScheme.onSurfaceVariant) }

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -171,8 +171,41 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
     fun openTripDetail(tripId: Long) { selectedTripId.value = tripId }
     fun closeTripDetail() { selectedTripId.value = null; _uiState.value = _uiState.value.copy(selectedTripId = null, selectedTripPoints = emptyList()) }
     fun deleteTrip(trip: TripSessionEntity) { viewModelScope.launch { runCatching { repository.deleteTrip(trip) }.onSuccess { if (selectedTripId.value == trip.id) closeTripDetail() }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法删除行程") } } }
-    fun saveVehicle(brand: String, model: String, battery: Double, range: Int) { val current = _uiState.value.vehicle ?: return; viewModelScope.launch { runCatching { repository.saveVehicle(current.copy(brand = brand.trim(), model = model.trim(), batteryCapacityKwh = battery, rangeKm = range)) }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
-    fun addVehicle(brand: String, model: String, battery: Double, range: Int, catalogVehicleId: String? = null) { viewModelScope.launch { runCatching { repository.addVehicle(brand, model, battery, range, catalogVehicleId) }.onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆已添加并切换") }.onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) } } }
+
+    fun saveVehicleNickname(nickname: String?) {
+        val current = _uiState.value.vehicle ?: return
+        val normalized = nickname?.trim()?.takeIf { it.isNotEmpty() }
+        viewModelScope.launch {
+            runCatching { repository.saveVehicle(current.copy(nickname = normalized)) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆名称已保存") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法保存车辆名称") }
+        }
+    }
+
+    fun addVehicle(catalogVehicle: VehicleCatalogEntity, nickname: String?) {
+        val normalized = nickname?.trim()?.takeIf { it.isNotEmpty() }
+        viewModelScope.launch {
+            runCatching {
+                require(catalogVehicle.isActive) { "该车型已下架，请刷新车型库后重试" }
+                val battery = catalogVehicle.batteryCapacityKwh ?: error("车型标准电池参数缺失，请先在 Web 管理端补全")
+                val range = catalogVehicle.rangeKm ?: error("车型标准续航参数缺失，请先在 Web 管理端补全")
+                repository.addVehicle(
+                    brand = catalogVehicle.brand,
+                    model = catalogVehicle.modelName,
+                    battery = battery,
+                    range = range,
+                    catalogVehicleId = catalogVehicle.catalogId
+                )
+                if (normalized != null) {
+                    val addedVehicle = repository.vehicles.first().maxByOrNull { it.id }
+                        ?: error("车辆添加后未找到本地车辆记录")
+                    repository.saveVehicle(addedVehicle.copy(nickname = normalized))
+                }
+            }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "车辆已添加并切换") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法添加车辆") }
+        }
+    }
 
     fun selectVehicle(vehicleId: Long) {
         val activeTrip = _uiState.value.activeTrip

--- a/android/app/src/test/java/com/evchargebook/data/backup/BackupNicknameTest.kt
+++ b/android/app/src/test/java/com/evchargebook/data/backup/BackupNicknameTest.kt
@@ -1,0 +1,37 @@
+package com.evchargebook.data.backup
+
+import com.evchargebook.data.entity.VehicleEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BackupNicknameTest {
+    @Test
+    fun `vehicle nickname survives backup round trip`() {
+        val payload = BackupPayload(
+            schemaVersion = BackupCodec.CURRENT_SCHEMA_VERSION,
+            exportedAt = 1234L,
+            appVersion = "test",
+            vehicles = listOf(
+                VehicleEntity(
+                    id = 1L,
+                    catalogVehicleId = "future-brand-model-1",
+                    brand = "Future Brand",
+                    model = "Model One",
+                    batteryCapacityKwh = 80.0,
+                    rangeKm = 600,
+                    nickname = "周末车",
+                    isDefault = true,
+                    createdAtEpochMillis = 100L,
+                    syncId = "vehicle-sync-1",
+                    updatedAtEpochMillis = 200L
+                )
+            ),
+            chargingRecords = emptyList()
+        )
+
+        val restored = BackupCodec.decode(BackupCodec.encode(payload))
+
+        assertEquals("周末车", restored.vehicles.single().nickname)
+        assertEquals("Model One", restored.vehicles.single().model)
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/data/entity/VehicleEntityDisplayNameTest.kt
+++ b/android/app/src/test/java/com/evchargebook/data/entity/VehicleEntityDisplayNameTest.kt
@@ -1,0 +1,34 @@
+package com.evchargebook.data.entity
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VehicleEntityDisplayNameTest {
+    @Test
+    fun `nickname wins over catalog model for display`() {
+        val vehicle = VehicleEntity(
+            catalogVehicleId = "future-brand-model-1",
+            brand = "Future Brand",
+            model = "Model One",
+            batteryCapacityKwh = 80.0,
+            rangeKm = 600,
+            nickname = "通勤车"
+        )
+
+        assertEquals("通勤车", vehicle.displayName)
+    }
+
+    @Test
+    fun `blank nickname falls back to immutable model snapshot`() {
+        val vehicle = VehicleEntity(
+            catalogVehicleId = "future-brand-model-1",
+            brand = "Future Brand",
+            model = "Model One",
+            batteryCapacityKwh = 80.0,
+            rangeKm = 600,
+            nickname = "   "
+        )
+
+        assertEquals("Model One", vehicle.displayName)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the next #244 vehicle-maturity slice after #245/#246.

### User-owned vehicle metadata
- vehicle edit UI is now nickname-only
- standard brand/model/battery/range are rendered read-only
- blank nickname falls back to the immutable model snapshot via `displayName`
- vehicle garage/switcher uses nickname-first display

### Managed model creation boundary
- removes the Android `自定义添加车辆` path from the catalog picker
- adding a vehicle requires selecting an active managed catalog item
- add confirmation shows catalog facts read-only and optionally accepts a nickname
- `MainViewModel` no longer exposes the old standard-field edit API
- missing catalog battery/range blocks local creation and asks for Web Admin data completion

### Persistence
- backup schema moves to v8
- vehicle nickname is exported/restored
- older backups remain accepted

### Tests
- nickname display fallback
- nickname backup round-trip

## Not in this PR

Brand Logo upload/render is intentionally separate. Its runtime contract is already authoritative in `docs/BRAND_LOGO_STANDARD.md` from #246. The next #244 slice will add managed Brand metadata + Logo publishing/cache/rendering.

Related: #244
