### PR TITLE
fix(deploy): prevent Hero Admin releases from filling server disk

### DIFF
--- a/.github/workflows/hero-admin-deploy.yml
+++ b/.github/workflows/hero-admin-deploy.yml
@@ -76,7 +76,7 @@ jobs:
           gzip -t hero-admin-image.tar.gz
           ls -lh hero-admin-image.tar.gz
 
-      - name: Prepare remote staging directory
+      - name: Prepare remote staging and reclaim safe disk space
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.COMMON_SERVER_HOST }}
@@ -84,9 +84,29 @@ jobs:
           key: ${{ secrets.COMMON_SSH_PRIVATE_KEY }}
           script: |
             set -eu
-            rm -rf /opt/ev-charge-book/hero-admin-deploy
-            mkdir -p /opt/ev-charge-book/hero-admin-deploy
-            test -w /opt/ev-charge-book
+            ROOT=/opt/ev-charge-book
+            STAGING="$ROOT/hero-admin-deploy"
+            REQUIRED_KB=$((512 * 1024))
+
+            # Deployment staging is disposable. Persistent Hero/Logo/catalog data lives
+            # under $ROOT/releases and $ROOT/release-meta and is intentionally untouched.
+            rm -rf "$STAGING"
+
+            # Reclaim only Docker data that is not referenced by running containers.
+            docker image prune -f >/dev/null 2>&1 || true
+            docker builder prune -af >/dev/null 2>&1 || true
+
+            mkdir -p "$STAGING"
+            test -w "$ROOT"
+
+            AVAILABLE_KB="$(df -Pk "$ROOT" | awk 'NR==2 {print $4}')"
+            echo "EV Admin deploy free space: $((AVAILABLE_KB / 1024)) MiB"
+            if [ "$AVAILABLE_KB" -lt "$REQUIRED_KB" ]; then
+              echo "Insufficient disk for safe EV Admin deployment: need at least 512 MiB free." >&2
+              df -h "$ROOT" >&2 || true
+              docker system df >&2 || true
+              exit 1
+            fi
 
       - name: Upload admin deployment bundle
         uses: appleboy/scp-action@v1.0.0
@@ -167,5 +187,6 @@ jobs:
             echo "- Hero manifest: https://groupim.cn/ev-charge-book/release-meta/hero-assets-v1.json"
             echo "- Vehicle catalog: https://groupim.cn/ev-charge-book/release-meta/vehicle-catalog-v1.json"
             echo "- Server credentials file: /opt/ev-charge-book/hero-admin.env"
-            echo "- Server-side Docker/PyPI network access is not required for deployment."
+            echo "- Deployment preflight safely prunes dangling Docker images/build cache and requires 512 MiB free."
+            echo "- Persistent releases and release-meta data are never cleaned by the deploy preflight."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/deploy-hero-admin.sh
+++ b/scripts/deploy-hero-admin.sh
@@ -71,6 +71,10 @@ if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
   exit 1
 fi
 
+# The compressed image is only transport staging. Drop it immediately after a
+# successful docker load so each deployment does not keep another ~50-60 MiB.
+rm -f "${IMAGE_ARCHIVE}"
+
 log "Starting Hero Admin container on ${NETWORK}"
 docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 docker run -d \
@@ -224,6 +228,10 @@ catalog = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 assert catalog.get("schemaVersion") == 1
 assert isinstance(catalog.get("vehicles"), list) and catalog["vehicles"]
 PY
+
+# The previous image becomes dangling after the new tag/container is active.
+# Remove only dangling images; never prune images still referenced by containers.
+docker image prune -f >/dev/null 2>&1 || true
 
 log "EV Charge Book admin deployment complete"
 log "Credentials are stored only in ${ENV_FILE}"


### PR DESCRIPTION
## Summary

Fixes the production deployment failure that blocked #256 from reaching groupim.cn.

The failed main deployment reached SCP extraction and then hit `No space left on device`. The application/browser checks were green; this is a deployment-host disk lifecycle issue.

### Safe preflight cleanup
- removes only the disposable EV Admin staging directory
- prunes Docker dangling images
- prunes Docker builder cache
- explicitly does **not** touch `/opt/ev-charge-book/releases`, `/opt/ev-charge-book/release-meta`, or the admin credentials file
- requires at least 512 MiB free before SCP and prints `df` / `docker system df` diagnostics if the threshold is not met

### Prevent recurrence
- deletes the ~50–60 MiB transported image archive immediately after successful `docker load`
- prunes the previous dangling image only after the new container/runtime checks succeed

This PR is required to finish deploying the batch Brand Logo / Hero image upload work from #256.