### PR TITLE
feat(charging): add text-safe billing editor state

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/AddRecordScreen.kt
@@ -39,6 +39,8 @@ import androidx.core.content.ContextCompat
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
+import com.evchargebook.domain.charge.ChargeBillingField
+import com.evchargebook.domain.charge.ChargeCalculationIssue
 import com.evchargebook.domain.charge.ChargeDefaultResolver
 import com.evchargebook.domain.charge.ChargeEnergyCalculator
 import com.evchargebook.location.AndroidGeocoderAddressResolver
@@ -89,6 +91,14 @@ fun AddRecordScreen(
     val calendar = remember { Calendar.getInstance() }
     val initialChargeTime = remember { calendar.timeInMillis }
     val initialOdometer = remember(currentMileageKm) { currentMileageKm?.toEditableNumber().orEmpty() }
+    val initialBilling = remember(defaults) {
+        ChargeBillingEditor.create(
+            totalCostText = "",
+            unitPriceText = (defaults.pricePerKwh ?: defaultPriceForType(defaults.chargerType)).toEditableNumber(),
+            meterEnergyText = "",
+            authoritativeBillingFields = setOf(ChargeBillingField.UNIT_PRICE)
+        )
+    }
 
     var chargeTime by remember { mutableLongStateOf(initialChargeTime) }
     var location by remember(defaults) { mutableStateOf(defaults.location.orEmpty()) }
@@ -97,34 +107,22 @@ fun AddRecordScreen(
     var remark by remember { mutableStateOf("") }
     var startSoc by remember(defaults) { mutableStateOf(defaults.startSoc?.toString().orEmpty()) }
     var endSoc by remember(defaults) { mutableStateOf(defaults.endSoc.toString()) }
-    var energy by remember { mutableStateOf("") }
     var chargerType by remember(defaults) { mutableStateOf(defaults.chargerType) }
-    var pricePerKwh by remember(defaults) {
-        mutableStateOf((defaults.pricePerKwh ?: defaultPriceForType(defaults.chargerType)).toEditableNumber())
-    }
-    var cost by remember { mutableStateOf("") }
-    var costEditedManually by remember { mutableStateOf(false) }
+    var billing by remember(defaults) { mutableStateOf(initialBilling) }
     var odometer by remember(initialOdometer) { mutableStateOf(initialOdometer) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var addressMessage by remember { mutableStateOf<String?>(null) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    fun updateCalculatedCost(newEnergy: String = energy, newPrice: String = pricePerKwh) {
-        if (!costEditedManually) {
-            val amount = newEnergy.toDoubleOrNull()
-            val price = newPrice.toDoubleOrNull()
-            cost = if (amount != null && amount > 0.0 && price != null && price >= 0.0) {
-                (amount * price).toEditableNumber()
-            } else {
-                ""
-            }
-        }
-    }
+    val energy = billing.meterEnergyText
+    val pricePerKwh = billing.unitPriceText
+    val cost = billing.totalCostText
 
     val isDirty = chargeTime != initialChargeTime || remark.isNotBlank() || energy.isNotBlank() ||
         odometer != initialOdometer || startSoc != defaults.startSoc?.toString().orEmpty() ||
         endSoc != defaults.endSoc.toString() || chargerType != defaults.chargerType ||
-        location != defaults.location.orEmpty() || locationFix != null || costEditedManually
+        location != defaults.location.orEmpty() || locationFix != null ||
+        pricePerKwh != initialBilling.unitPriceText || cost.isNotBlank()
 
     fun requestBack() {
         if (isDirty) showDiscardConfirm = true else onBack()
@@ -170,7 +168,7 @@ fun AddRecordScreen(
     val previousOdometer = remember(records, vehicleId, chargeTime) { ChargingRecordRules.previousOdometerKm(records, vehicleId, chargeTime) }
     val odometerValue = odometer.toDoubleOrNull()
     val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometerValue)
-    val energyValue = energy.toDoubleOrNull()
+    val energyValue = billing.meterEnergyKwh
     val startSocValue = startSoc.toIntOrNull()
     val endSocValue = endSoc.toIntOrNull()
     val estimate = ChargeEnergyCalculator.estimate(batteryCapacityKwh, startSocValue, endSocValue, energyValue)
@@ -178,7 +176,7 @@ fun AddRecordScreen(
         startSoc = startSocValue,
         endSoc = endSocValue,
         energyKwh = energyValue,
-        cost = cost.toDoubleOrNull(),
+        cost = billing.totalCost,
         batteryCapacityKwh = batteryCapacityKwh
     )
     val recentPresets = remember(vehicleRecords) {
@@ -215,8 +213,11 @@ fun AddRecordScreen(
                 ChargerTypeSelector(chargerType) { selected ->
                     chargerType = selected
                     val remembered = ChargeDefaultResolver.priceForType(vehicleRecords, selected) ?: defaultPriceForType(selected)
-                    pricePerKwh = remembered.toEditableNumber()
-                    updateCalculatedCost(newPrice = pricePerKwh)
+                    billing = ChargeBillingEditor.edit(
+                        billing,
+                        ChargeBillingField.UNIT_PRICE,
+                        remembered.toEditableNumber()
+                    )
                 }
                 if (recentPresets.isNotEmpty()) {
                     Text("最近使用", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -226,9 +227,15 @@ fun AddRecordScreen(
                                 onClick = {
                                     chargerType = record.chargerType ?: ChargeDefaultResolver.FALLBACK_CHARGER_TYPE
                                     endSoc = record.endSoc.toString()
-                                    pricePerKwh = record.pricePerKwh.toEditableNumber()
-                                    record.location?.let { location = it }
-                                    updateCalculatedCost(newPrice = pricePerKwh)
+                                    billing = ChargeBillingEditor.edit(
+                                        billing,
+                                        ChargeBillingField.UNIT_PRICE,
+                                        record.pricePerKwh.toEditableNumber()
+                                    )
+                                    record.location?.let {
+                                        location = it
+                                        locationFix = null
+                                    }
                                 },
                                 label = { Text("${record.chargerType ?: "充电"} · ¥${formatTwo(record.pricePerKwh)}") }
                             )
@@ -244,10 +251,7 @@ fun AddRecordScreen(
                 }
                 AddNumberField(
                     energy,
-                    {
-                        energy = it
-                        updateCalculatedCost(newEnergy = it)
-                    },
+                    { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.METER_ENERGY, it) },
                     "桩端 / 电表电量",
                     "kWh",
                     Modifier.fillMaxWidth(),
@@ -266,14 +270,11 @@ fun AddRecordScreen(
                 }
             }
 
-            FormSection("电价与费用", "COST", "电价优先复用同类型最近记录；总费用默认自动计算，也允许修改。") {
+            FormSection("电价与费用", "COST", "按实际账单填写，费用、单价与用电量会保持联动。") {
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     AddNumberField(
                         pricePerKwh,
-                        {
-                            pricePerKwh = it
-                            updateCalculatedCost(newPrice = it)
-                        },
+                        { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.UNIT_PRICE, it) },
                         "电价",
                         "元/kWh",
                         Modifier.weight(1f),
@@ -281,20 +282,19 @@ fun AddRecordScreen(
                     )
                     AddNumberField(
                         cost,
-                        {
-                            cost = it
-                            costEditedManually = true
-                        },
+                        { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.TOTAL_COST, it) },
                         "总费用",
                         "元",
                         Modifier.weight(1f),
                         KeyboardType.Decimal
                     )
                 }
-                if (costEditedManually) {
-                    TextButton(onClick = { costEditedManually = false; updateCalculatedCost() }, contentPadding = PaddingValues(0.dp)) {
-                        Text("恢复按电价自动计算")
-                    }
+                if (ChargeCalculationIssue.BILLING_CONFLICT in billing.issues) {
+                    Text(
+                        "费用、单价与用电量暂不一致，请确认其中一项。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.warningColor
+                    )
                 }
             }
 
@@ -364,16 +364,18 @@ fun AddRecordScreen(
                     focusManager.clearFocus()
                     val start = startSoc.toIntOrNull()
                     val end = endSoc.toIntOrNull()
-                    val chargedEnergy = energy.toDoubleOrNull()
-                    val costValue = cost.toDoubleOrNull()
+                    val chargedEnergy = billing.meterEnergyKwh
+                    val price = billing.unitPrice
+                    val costValue = billing.totalCost
                     val odometerKm = odometer.toDoubleOrNull()
                     errorMessage = when {
                         start == null || start !in 0..100 -> "请输入 0~100 的起始 SOC"
                         end == null || end !in 0..100 -> "请输入 0~100 的结束 SOC"
                         end < start -> "结束 SOC 不能低于起始 SOC"
                         chargedEnergy == null || chargedEnergy <= 0 -> "桩端 / 电表电量必须大于 0"
-                        pricePerKwh.toDoubleOrNull() == null || pricePerKwh.toDouble() < 0 -> "请输入有效电价"
+                        price == null || price < 0 -> "请输入有效电价"
                         costValue == null || costValue < 0 -> "费用不能小于 0"
+                        ChargeCalculationIssue.BILLING_CONFLICT in billing.issues -> "费用、单价与用电量不一致，请先确认后再保存"
                         odometer.isNotBlank() && (odometerKm == null || odometerKm < 0) -> "里程需要是大于等于 0 的数字"
                         else -> null
                     }

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
@@ -1,0 +1,125 @@
+package com.evchargebook.ui.records
+
+import com.evchargebook.domain.charge.ChargeBillingField
+import com.evchargebook.domain.charge.ChargeCalculationEngine
+import com.evchargebook.domain.charge.ChargeCalculationInput
+import com.evchargebook.domain.charge.ChargeCalculationIssue
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+data class ChargeBillingEditorState(
+    val totalCostText: String,
+    val unitPriceText: String,
+    val meterEnergyText: String,
+    val calculationInput: ChargeCalculationInput,
+    val issues: Set<ChargeCalculationIssue> = emptySet()
+) {
+    val totalCost: Double? get() = calculationInput.totalCost
+    val unitPrice: Double? get() = calculationInput.unitPrice
+    val meterEnergyKwh: Double? get() = calculationInput.meterEnergyKwh
+}
+
+/**
+ * Text-safe adapter around [ChargeCalculationEngine].
+ *
+ * The edited field always keeps the user's raw text so intermediate states such as an empty field,
+ * `1.` or `0.` do not jump the cursor. Only dependant fields that were actually recalculated are
+ * replaced with formatted text. Full-precision numeric state stays in [calculationInput].
+ */
+object ChargeBillingEditor {
+    fun create(
+        totalCostText: String,
+        unitPriceText: String,
+        meterEnergyText: String,
+        authoritativeBillingFields: Set<ChargeBillingField>
+    ): ChargeBillingEditorState {
+        val input = ChargeCalculationInput(
+            totalCost = totalCostText.toFiniteDoubleOrNull(),
+            unitPrice = unitPriceText.toFiniteDoubleOrNull(),
+            meterEnergyKwh = meterEnergyText.toFiniteDoubleOrNull(),
+            authoritativeBillingFields = authoritativeBillingFields
+        )
+        val calculated = ChargeCalculationEngine.calculate(input)
+        return ChargeBillingEditorState(
+            totalCostText = totalCostText,
+            unitPriceText = unitPriceText,
+            meterEnergyText = meterEnergyText,
+            calculationInput = calculated.input,
+            issues = calculated.issues
+        )
+    }
+
+    fun edit(
+        state: ChargeBillingEditorState,
+        field: ChargeBillingField,
+        rawText: String
+    ): ChargeBillingEditorState {
+        val previous = state.calculationInput
+        val parsed = rawText.toFiniteDoubleOrNull()
+        val result = ChargeCalculationEngine.editBilling(previous, field, parsed)
+        val next = result.input
+
+        return ChargeBillingEditorState(
+            totalCostText = textFor(
+                field = ChargeBillingField.TOTAL_COST,
+                editedField = field,
+                rawText = rawText,
+                previousText = state.totalCostText,
+                previousValue = previous.totalCost,
+                nextValue = next.totalCost
+            ),
+            unitPriceText = textFor(
+                field = ChargeBillingField.UNIT_PRICE,
+                editedField = field,
+                rawText = rawText,
+                previousText = state.unitPriceText,
+                previousValue = previous.unitPrice,
+                nextValue = next.unitPrice
+            ),
+            meterEnergyText = textFor(
+                field = ChargeBillingField.METER_ENERGY,
+                editedField = field,
+                rawText = rawText,
+                previousText = state.meterEnergyText,
+                previousValue = previous.meterEnergyKwh,
+                nextValue = next.meterEnergyKwh
+            ),
+            calculationInput = next,
+            issues = result.issues
+        )
+    }
+
+    private fun textFor(
+        field: ChargeBillingField,
+        editedField: ChargeBillingField,
+        rawText: String,
+        previousText: String,
+        previousValue: Double?,
+        nextValue: Double?
+    ): String {
+        if (field == editedField) return rawText
+        if (sameNumber(previousValue, nextValue)) return previousText
+        return nextValue?.let { formatCalculated(field, it) }.orEmpty()
+    }
+
+    private fun sameNumber(left: Double?, right: Double?): Boolean = when {
+        left == null && right == null -> true
+        left == null || right == null -> false
+        else -> left.toBits() == right.toBits()
+    }
+
+    private fun formatCalculated(field: ChargeBillingField, value: Double): String {
+        val scale = when (field) {
+            ChargeBillingField.TOTAL_COST -> 2
+            ChargeBillingField.UNIT_PRICE -> 4
+            ChargeBillingField.METER_ENERGY -> 3
+        }
+        return BigDecimal.valueOf(value)
+            .setScale(scale, RoundingMode.HALF_UP)
+            .stripTrailingZeros()
+            .toPlainString()
+    }
+
+    private fun String.toFiniteDoubleOrNull(): Double? =
+        toDoubleOrNull()?.takeIf { it.isFinite() }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordEditScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.domain.ChargingAnomalyRules
 import com.evchargebook.domain.ChargingRecordRules
+import com.evchargebook.domain.charge.ChargeBillingField
+import com.evchargebook.domain.charge.ChargeCalculationIssue
 import com.evchargebook.domain.charge.ChargeEnergyCalculator
 import com.evchargebook.ui.theme.spacing
 import com.evchargebook.ui.theme.warningColor
@@ -61,13 +63,22 @@ fun RecordEditScreen(
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
     val calendar = remember { Calendar.getInstance().apply { timeInMillis = record.chargeTimeEpochMillis } }
+    val initialBilling = remember(record.id, record.updatedAtEpochMillis) {
+        ChargeBillingEditor.create(
+            totalCostText = record.cost.toEditableEditNumber(),
+            unitPriceText = record.pricePerKwh.toEditableEditNumber(),
+            meterEnergyText = record.energyKwh.toEditableEditNumber(),
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.TOTAL_COST,
+                ChargeBillingField.METER_ENERGY
+            )
+        )
+    }
+
     var chargeTime by remember { mutableLongStateOf(record.chargeTimeEpochMillis) }
     var location by remember { mutableStateOf(record.location.orEmpty()) }
     var remark by remember { mutableStateOf(record.remark.orEmpty()) }
-    var energy by remember { mutableStateOf(record.energyKwh.toEditableEditNumber()) }
-    var pricePerKwh by remember { mutableStateOf(record.pricePerKwh.toEditableEditNumber()) }
-    var cost by remember { mutableStateOf(record.cost.toEditableEditNumber()) }
-    var costEditedManually by remember { mutableStateOf(false) }
+    var billing by remember(record.id, record.updatedAtEpochMillis) { mutableStateOf(initialBilling) }
     var startSoc by remember { mutableStateOf(record.startSoc.toString()) }
     var endSoc by remember { mutableStateOf(record.endSoc.toString()) }
     var odometer by remember { mutableStateOf(record.odometerKm?.toEditableEditNumber().orEmpty()) }
@@ -75,20 +86,14 @@ fun RecordEditScreen(
     var error by remember { mutableStateOf<String?>(null) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    fun updateCalculatedCost(newEnergy: String = energy, newPrice: String = pricePerKwh) {
-        if (!costEditedManually) {
-            val amount = newEnergy.toDoubleOrNull()
-            val price = newPrice.toDoubleOrNull()
-            if (amount != null && amount > 0.0 && price != null && price >= 0.0) {
-                cost = (amount * price).toEditableEditNumber()
-            }
-        }
-    }
+    val energy = billing.meterEnergyText
+    val pricePerKwh = billing.unitPriceText
+    val cost = billing.totalCostText
 
     val isDirty = chargeTime != record.chargeTimeEpochMillis ||
         location != record.location.orEmpty() || remark != record.remark.orEmpty() ||
-        energy != record.energyKwh.toEditableEditNumber() || cost != record.cost.toEditableEditNumber() ||
-        pricePerKwh != record.pricePerKwh.toEditableEditNumber() ||
+        energy != initialBilling.meterEnergyText || cost != initialBilling.totalCostText ||
+        pricePerKwh != initialBilling.unitPriceText ||
         startSoc != record.startSoc.toString() || endSoc != record.endSoc.toString() ||
         odometer != record.odometerKm?.toEditableEditNumber().orEmpty() || chargerType != (record.chargerType ?: "公共慢充")
 
@@ -104,7 +109,7 @@ fun RecordEditScreen(
         ChargingRecordRules.previousOdometerKm(records, record.vehicleId, chargeTime, record.id)
     }
     val odometerWarning = ChargingRecordRules.odometerWarning(previousOdometer, odometer.toDoubleOrNull())
-    val energyValue = energy.toDoubleOrNull()
+    val energyValue = billing.meterEnergyKwh
     val estimate = ChargeEnergyCalculator.estimate(
         batteryCapacityKwh = batteryCapacityKwh,
         startSoc = startSoc.toIntOrNull(),
@@ -115,7 +120,7 @@ fun RecordEditScreen(
         startSoc = startSoc.toIntOrNull(),
         endSoc = endSoc.toIntOrNull(),
         energyKwh = energyValue,
-        cost = cost.toDoubleOrNull(),
+        cost = billing.totalCost,
         batteryCapacityKwh = batteryCapacityKwh
     )
 
@@ -156,10 +161,7 @@ fun RecordEditScreen(
                 }
                 NumberField(
                     energy,
-                    {
-                        energy = it
-                        updateCalculatedCost(newEnergy = it)
-                    },
+                    { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.METER_ENERGY, it) },
                     "桩端 / 电表电量",
                     "kWh",
                     Modifier.fillMaxWidth(),
@@ -178,10 +180,7 @@ fun RecordEditScreen(
                 Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
                     NumberField(
                         pricePerKwh,
-                        {
-                            pricePerKwh = it
-                            updateCalculatedCost(newPrice = it)
-                        },
+                        { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.UNIT_PRICE, it) },
                         "电价",
                         "元/kWh",
                         Modifier.weight(1f),
@@ -189,20 +188,19 @@ fun RecordEditScreen(
                     )
                     NumberField(
                         cost,
-                        {
-                            cost = it
-                            costEditedManually = true
-                        },
+                        { billing = ChargeBillingEditor.edit(billing, ChargeBillingField.TOTAL_COST, it) },
                         "总费用",
                         "元",
                         Modifier.weight(1f),
                         KeyboardType.Decimal
                     )
                 }
-                if (costEditedManually) {
-                    TextButton(onClick = { costEditedManually = false; updateCalculatedCost() }, contentPadding = PaddingValues(0.dp)) {
-                        Text("恢复按电价自动计算")
-                    }
+                if (ChargeCalculationIssue.BILLING_CONFLICT in billing.issues) {
+                    Text(
+                        "费用、单价与用电量暂不一致，请确认其中一项。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.warningColor
+                    )
                 }
             }
 
@@ -250,9 +248,9 @@ fun RecordEditScreen(
                     focusManager.clearFocus()
                     val start = startSoc.toIntOrNull()
                     val end = endSoc.toIntOrNull()
-                    val chargedEnergy = energy.toDoubleOrNull()
-                    val price = pricePerKwh.toDoubleOrNull()
-                    val costValue = cost.toDoubleOrNull()
+                    val chargedEnergy = billing.meterEnergyKwh
+                    val price = billing.unitPrice
+                    val costValue = billing.totalCost
                     val odometerKm = odometer.toDoubleOrNull()
                     error = when {
                         start == null || start !in 0..100 -> "起始 SOC 需要是 0 到 100"
@@ -261,6 +259,7 @@ fun RecordEditScreen(
                         chargedEnergy == null || chargedEnergy <= 0 -> "桩端 / 电表电量必须大于 0"
                         price == null || price < 0 -> "电价需要是大于等于 0 的数字"
                         costValue == null || costValue < 0 -> "费用不能小于 0"
+                        ChargeCalculationIssue.BILLING_CONFLICT in billing.issues -> "费用、单价与用电量不一致，请先确认后再保存"
                         odometer.isNotBlank() && (odometerKm == null || odometerKm < 0) -> "里程需要是大于等于 0 的数字"
                         else -> null
                     }

--- a/android/app/src/test/java/com/evchargebook/ui/records/ChargeBillingEditorStateTest.kt
+++ b/android/app/src/test/java/com/evchargebook/ui/records/ChargeBillingEditorStateTest.kt
@@ -1,0 +1,168 @@
+package com.evchargebook.ui.records
+
+import com.evchargebook.domain.charge.ChargeBillingField
+import com.evchargebook.domain.charge.ChargeCalculationIssue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChargeBillingEditorStateTest {
+    @Test
+    fun `preset price keeps calculated cost live across repeated energy typing`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "",
+            unitPriceText = "1.25",
+            meterEnergyText = "",
+            authoritativeBillingFields = setOf(ChargeBillingField.UNIT_PRICE)
+        )
+
+        val first = ChargeBillingEditor.edit(initial, ChargeBillingField.METER_ENERGY, "3")
+        val second = ChargeBillingEditor.edit(first, ChargeBillingField.METER_ENERGY, "30")
+
+        assertEquals("30", second.meterEnergyText)
+        assertEquals("1.25", second.unitPriceText)
+        assertEquals("37.5", second.totalCostText)
+        assertEquals(37.5, second.totalCost!!, 0.000001)
+        assertFalse(ChargeBillingField.TOTAL_COST in second.calculationInput.authoritativeBillingFields)
+        assertFalse(second.issues.contains(ChargeCalculationIssue.BILLING_CONFLICT))
+    }
+
+    @Test
+    fun `price edit keeps energy when displayed cost was calculated`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "",
+            unitPriceText = "1.25",
+            meterEnergyText = "",
+            authoritativeBillingFields = setOf(ChargeBillingField.UNIT_PRICE)
+        )
+        val withEnergy = ChargeBillingEditor.edit(initial, ChargeBillingField.METER_ENERGY, "32")
+        val result = ChargeBillingEditor.edit(withEnergy, ChargeBillingField.UNIT_PRICE, "1.10")
+
+        assertEquals("1.10", result.unitPriceText)
+        assertEquals("32", result.meterEnergyText)
+        assertEquals("35.2", result.totalCostText)
+        assertEquals(35.2, result.totalCost!!, 0.000001)
+        assertFalse(ChargeBillingField.TOTAL_COST in result.calculationInput.authoritativeBillingFields)
+        assertTrue(ChargeBillingField.UNIT_PRICE in result.calculationInput.authoritativeBillingFields)
+        assertTrue(ChargeBillingField.METER_ENERGY in result.calculationInput.authoritativeBillingFields)
+        assertFalse(result.issues.contains(ChargeCalculationIssue.BILLING_CONFLICT))
+    }
+
+    @Test
+    fun `edited raw text is preserved while dependant field is reformatted`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "45.76",
+            unitPriceText = "1.22",
+            meterEnergyText = "37.508",
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.TOTAL_COST,
+                ChargeBillingField.UNIT_PRICE
+            )
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.UNIT_PRICE, "1.10")
+
+        assertEquals("1.10", result.unitPriceText)
+        assertEquals("45.76", result.totalCostText)
+        assertEquals("41.6", result.meterEnergyText)
+        assertEquals(45.76 / 1.10, result.meterEnergyKwh!!, 0.000001)
+    }
+
+    @Test
+    fun `cost edit holds visible price and recalculates energy`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "40",
+            unitPriceText = "1.25",
+            meterEnergyText = "32",
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.UNIT_PRICE,
+                ChargeBillingField.METER_ENERGY
+            )
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.TOTAL_COST, "45")
+
+        assertEquals("45", result.totalCostText)
+        assertEquals("1.25", result.unitPriceText)
+        assertEquals("36", result.meterEnergyText)
+        assertTrue(ChargeBillingField.TOTAL_COST in result.calculationInput.authoritativeBillingFields)
+        assertFalse(ChargeBillingField.METER_ENERGY in result.calculationInput.authoritativeBillingFields)
+    }
+
+    @Test
+    fun `authoritative cost and price survive energy edit and expose one conflict`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "45.76",
+            unitPriceText = "1.22",
+            meterEnergyText = "37.508",
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.TOTAL_COST,
+                ChargeBillingField.UNIT_PRICE
+            )
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.METER_ENERGY, "40")
+
+        assertEquals("45.76", result.totalCostText)
+        assertEquals("1.22", result.unitPriceText)
+        assertEquals("40", result.meterEnergyText)
+        assertTrue(result.issues.contains(ChargeCalculationIssue.BILLING_CONFLICT))
+    }
+
+    @Test
+    fun `clearing an edited field keeps the raw blank without erasing unrelated text`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "45.76",
+            unitPriceText = "1.22",
+            meterEnergyText = "37.508",
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.TOTAL_COST,
+                ChargeBillingField.UNIT_PRICE
+            )
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.TOTAL_COST, "")
+
+        assertEquals("", result.totalCostText)
+        assertEquals("1.22", result.unitPriceText)
+        assertEquals("37.508", result.meterEnergyText)
+        assertNull(result.totalCost)
+    }
+
+    @Test
+    fun `intermediate decimal text remains untouched`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "",
+            unitPriceText = "1.25",
+            meterEnergyText = "",
+            authoritativeBillingFields = setOf(ChargeBillingField.UNIT_PRICE)
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.METER_ENERGY, "1.")
+
+        assertEquals("1.", result.meterEnergyText)
+        assertEquals("1.25", result.unitPriceText)
+        assertEquals("1.25", result.totalCostText)
+        assertEquals(1.0, result.meterEnergyKwh!!, 0.000001)
+    }
+
+    @Test
+    fun `display rounding does not replace full precision calculation state`() {
+        val initial = ChargeBillingEditor.create(
+            totalCostText = "45.76",
+            unitPriceText = "1.22",
+            meterEnergyText = "",
+            authoritativeBillingFields = setOf(
+                ChargeBillingField.TOTAL_COST,
+                ChargeBillingField.UNIT_PRICE
+            )
+        )
+
+        val result = ChargeBillingEditor.edit(initial, ChargeBillingField.TOTAL_COST, "45.76")
+
+        assertEquals("37.508", result.meterEnergyText)
+        assertEquals(45.76 / 1.22, result.meterEnergyKwh!!, 0.0000001)
+    }
+}


### PR DESCRIPTION
## Summary

Add/Edit charging-record adoption for the merged v0.7 calculation contract. This remains the **single** Add/Edit billing-editor candidate owned by #260; do not create a duplicate PR solely to bypass the Draft badge.

## Current normalized scope — 2026-09-02

Current head: `349ce28c30da7461fb15eb65b19d2235fe874bb0`
Current base: `main@672d92b19eb51678a05d8493325c77ada55584dd`

`main` advanced through Trip background guidance #278. That commit touched only Trip files and had no overlap with this charging slice. The branch was rebuilt directly on the latest main tree while preserving the same four reviewed billing-editor blobs.

Effective diff remains exactly:
- `AddRecordScreen.kt`
- `ChargeBillingEditorState.kt`
- `RecordEditScreen.kt`
- `ChargeBillingEditorStateTest.kt`

Current gates:
- [x] ahead = 1
- [x] behind = 0
- [x] exactly four intended changed files
- [x] calculation engine merged via #268
- [x] persistence merged via #271
- [x] Start/Active UI merged via #276
- [x] Android Build **#697 Green** on exact current head/base
- [x] GitHub reports mergeable
- [x] no unresolved review threads
- [x] no PR conversation blockers

## Editor behavior

`ChargeBillingEditor` preserves raw edited text (`1.10`, `1.`, blank intermediate state), full-precision calculation values separately from display formatting, authoritative/preset provenance, and the merged billing precedence/one-conflict behavior.

AddRecord and RecordEdit both use the shared editor. The old one-way `costEditedManually` recovery path is removed. Historical location selection clears stale GPS coordinate evidence when the address changes.

## Draft metadata limitation / governance

A fresh Draft -> Ready attempt on 2026-09-02 still fails because the connected GitHub GraphQL wrapper queries nonexistent `Repository.fullDatabaseId`.

Per #260 authority:
- keep this existing PR as the single Add/Edit candidate;
- do **not** create another duplicate PR solely to clear Draft metadata;
- a maintainer may clear Draft state in GitHub UI;
- current code/CI/review gates are otherwise clean.

## Follow-up stack

Completion UI remains Draft #277 stacked directly on this branch and has its own exact-head Build #698 Green.

## Related
- parent #251
- calculation #252 / merged #268
- Add/Edit owner #260
- persistence merged #271
- Start/Active merged #276
- completion #277
- lifecycle #253
- location #254

CI Green is automated evidence only; production Add/Edit interaction/readability acceptance remains required by #260.