### PR TITLE
docs: establish current project status authority

### DIFF
--- a/docs/CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/docs/CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,140 @@
+# EV Charge Book Charging v0.7 Design and Implementation Plan
+
+Status: Authority for #251
+Updated: 2026-08-31
+
+## 1. Purpose
+
+Charging v0.7 evolves the current completed-record ledger into a broader Local First charging workflow **without removing manual charging record maintenance**.
+
+The approved product model has two parallel creation paths:
+
+1. `开始充电` — optional lifecycle recording / preset flow.
+2. `充电记录维护` — manual add, backfill and edit of completed charging facts.
+
+A user must never be forced to start a live/local charging session just to maintain a historical record.
+
+This document extends the v0.6 Records baseline. It does not rewrite the existing v0.6 visual closeout owned by #159/#164.
+
+## 2. Locked UX principles
+
+### 2.1 Records overview
+
+Keep Dark First visual language, compact density and restrained spacing. Preserve useful range tabs. Add a truthful `充电中` state only when an active local charging session exists. Keep the ledger summary and dense historical charging list.
+
+Expose two sibling primary entries:
+
+- `开始充电`
+- `充电记录维护`
+
+`开始充电` is not a replacement for manual maintenance.
+
+### 2.2 Completed charging detail
+
+A completed charging record gets a dedicated detail surface.
+
+Primary facts may include location / charger type, total cost, billed or meter energy, effective unit price, start time, end time when present, start/end SOC when explicitly entered, odometer/mileage facts and notes.
+
+Derived facts may include duration, average charging power and charging-loss estimate. Derived facts are shown only when inputs are sufficient and semantically compatible.
+
+### 2.3 Manual maintenance
+
+Manual record maintenance remains fully supported: add historical record, edit existing record, backfill missing completion facts, edit start SOC/time, edit end time/address, and edit billed energy/cost/unit price through the coupled-field rules.
+
+The production UI must not expose internal/debug labels such as `手动输入`, `自动计算`, `自动带入` beside every field. Show `估算` only when it is a user-relevant semantic distinction.
+
+## 3. Data-truth boundary
+
+The app currently does not have an authoritative live SOC feed. Do not display a fake current SOC as if read from the car. Start/end SOC are manual/external facts unless a future authoritative source exists. Target SOC is user intent, not measurement.
+
+Use the currently selected vehicle automatically when entering charging flows, while still allowing explicit switching where appropriate.
+
+Start time defaults to now and remains editable. End time on completion defaults to now and remains editable. Duration is derived from start/end time.
+
+Location defaults to the current real coordinate fix when permission/provider is available. Persist latitude, longitude, accuracy and a readable address when reverse geocoding succeeds. Address text remains editable. If reverse geocoding fails, retain coordinates and allow manual address maintenance. Interactive map-point selection remains under #254.
+
+## 4. Optional start-charge lifecycle
+
+`开始充电` is bookkeeping only. It does not remotely control a charger or vehicle.
+
+Default inputs may include the current selected vehicle, start time = now, current real location and remembered charger/price defaults. Editable inputs may include manual start SOC, optional target SOC, charger type, price rule/unit price, address and notes.
+
+`保存为预设` stores reusable environment inputs only. It must not pre-commit future actual meter energy, end time, final cost or end SOC as facts.
+
+If an active local charging session exists, Records may show one compact `充电中` card containing only known or derivable local facts. Do not show fake live SOC, fake live power or fake BMS energy.
+
+Completion opens the same mature record editor with known start facts prefilled and completion facts pending.
+
+## 5. Coupled-field calculation rules
+
+Authority issue: #252.
+
+Product priority:
+
+```text
+total cost > unit price > billed/meter energy
+```
+
+When the user edits total cost, keep a valid unit price stable and recompute billed energy. When the user edits unit price, keep total cost stable and recompute billed energy. When the user edits billed energy, do not silently overwrite higher-priority user facts; update lower-priority derived outputs and surface an explicit inconsistency when the trio no longer agrees.
+
+The editor must avoid bidirectional recomposition loops and rounding drift. Formulas belong in one pure domain/state component, not duplicated across Composables.
+
+Derived duration:
+
+```text
+duration = endTime - startTime
+```
+
+If endTime <= startTime, duration is unavailable/invalid.
+
+Derived average power:
+
+```text
+averagePowerKw = billedEnergyKwh / durationHours
+```
+
+This is an energy/time average, not charger telemetry or peak power.
+
+Charging-loss estimate, only when compatible meter and vehicle-side energy exist:
+
+```text
+lossRate = (meterEnergy - vehicleEnergy) / meterEnergy * 100%
+```
+
+Guardrails: meter energy <= 0 -> unavailable; vehicle energy < 0 -> unavailable; vehicle energy > meter energy -> inconsistent; SOC-derived vehicle energy remains estimated and must not be relabeled as BMS measurement.
+
+## 6. Current implementation baseline
+
+The current completed-record model stores vehicle identity, one charge timestamp, energy, cost, start/end SOC, charger type, location, remark, odometer and optional coordinates/accuracy. It does not yet represent active-session lifecycle, explicit end time, explicit vehicle-side energy or presets.
+
+The existing Add Record flow already provides useful foundations: now-time default, current-location request/reverse geocoding, manual location fallback, recent defaults, partial energy/price/cost coupling and dirty-form protection. Reuse these foundations.
+
+As of 2026-08-31, Draft PR #258 establishes the first pure calculation-engine code slice for #252. It is not yet runtime authority until merged, and it does not by itself complete #252 because Add/Edit UI/state adoption remains required.
+
+## 7. Implementation ownership
+
+- #251 — parent product/implementation owner
+- #252 — centralized coupled calculation engine + derived metrics
+- #253 — optional active charging / preset lifecycle and persistence
+- #254 — current-location behavior + future map-point picker
+- #14 — existing Location / Geocoder physical acceptance foundation
+- #42 — accessibility / dirty forms / state safety
+- #159 / #164 — v0.6 Records visual closeout only
+
+Implementation order should preserve small slices: authority/model design -> calculation engine -> persistence/session migration -> Records overview/detail/manual maintenance -> optional start-charge/preset UI -> location/map follow-up -> migration/backup + physical acceptance.
+
+## 8. Migration and backup requirements
+
+Before persistence changes land, define the schema migration path, historical-field semantics and backup compatibility. Do not synthesize fake historical end times. Restore must not duplicate active/completed charging sessions.
+
+## 9. Acceptance
+
+Data truth: no fake live SOC/BMS/power values; missing facts remain missing; derived metrics follow sufficient inputs only.
+
+Editing maturity: cost/price/energy precedence is deterministic; time changes refresh duration/power; dependent loss/power refresh without value flicker; repeated edits do not accumulate rounding drift.
+
+Workflow: manual completed-record maintenance remains independent; optional start-charge remains independent; active session survives process recreation; completion produces one completed record; current vehicle/time/location defaults behave as specified.
+
+UI: compact Dark First hierarchy; no internal calculation/debug badges; 320–360dp and large-font usability; Light mode readable where supported.
+
+Engineering: Android CI Green, migration tests Green, backup/restore tests Green, and no unrelated Trip/Hero/catalog rewrite.

--- a/docs/CURRENT_STATUS_AUTHORITY.md
+++ b/docs/CURRENT_STATUS_AUTHORITY.md
@@ -1,0 +1,138 @@
+# EV Charge Book Current Status Authority
+
+Updated: 2026-08-31
+Status: Operational status authority
+Baseline: `main@2ca393490fcd027e016261cf09c383cd70387de8`
+
+## Purpose
+
+This file owns fast-changing project execution status. Stable product and architecture principles remain in `PROJECT_MASTER.md` and the domain-specific authority documents.
+
+When status sources disagree, use this order:
+
+1. current `main` implementation facts and persisted schemas;
+2. merged PR / CI evidence;
+3. this current-status authority;
+4. owning open Issue for remaining acceptance or future work;
+5. older roadmap/history text.
+
+An open Issue does not imply missing code. A draft/unmerged PR is not runtime authority.
+
+## Current repository governance
+
+- `main` is currently not branch-protected and has no required status checks. #75 remains a valid repository-governance issue.
+- Code, CI, physical functional acceptance, physical visual acceptance and Production Release acceptance are distinct states.
+- Physical acceptance must never be inferred from CI Green.
+- Implementation issues that are fully merged should not remain written as future implementation work. If physical acceptance is still needed, move that responsibility to an explicit acceptance owner or rewrite the Issue as physical-only.
+
+## Active delivery streams
+
+### Charging v0.7 — parent #251
+
+Current product authority:
+
+- #251 parent workflow and data-truth rules
+- `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`
+- #252 coupled-field calculation / derived metrics
+- #253 optional active charging session / preset lifecycle
+- #254 current-location default / future map-point picker
+
+Current implementation stage:
+
+- PR #258 is a Draft first code slice for #252.
+- #258 establishes the pure calculation-engine contract only; it does not yet wire Add/Edit UI state or active-session persistence.
+- #252 therefore remains open after that domain slice until the editing state adopts the centralized rules and its acceptance examples are satisfied.
+- #253 and #254 remain valid future implementation owners.
+
+### Vehicle maturity / catalog — #244 and #20
+
+Already in `main`:
+
+- user vehicle nickname and nickname-first display;
+- managed-catalog-only primary add flow;
+- standard vehicle facts read-only in Android;
+- removal of Android supported-model hard-code as the product authority;
+- managed brand metadata / stable `brandId`;
+- managed light/dark Brand Logo publishing and Android cached rendering;
+- vehicle switchers show managed Logo + nickname/fallback;
+- range-standard metadata;
+- JSON/CSV catalog import/export and template;
+- managed Hero-key selection;
+- filename-prefix batch Brand Logo / Hero upload;
+- copyable Logo/Hero standards and prompt center;
+- PR #259 simplified Brand Logo batch upload and restored light-card contrast.
+
+#244 must be treated as implementation-mostly-complete and should track only remaining acceptance/data gaps, not repeat unchecked implementation tasks.
+
+#20 remains valid for catalog provenance, broader real-model coverage, normalization/conflict quality and coverage metrics. Its old “build CSV/JSON bulk import” item is now implemented and must not remain an active task.
+
+### Trip background/location reliability — #77
+
+Current `main` is materially newer than the old post-#184 baseline. Implemented after that baseline includes:
+
+- Google Play Fused production source (#217);
+- non-GMS/platform GPS + network fallback (#220);
+- ~1 Hz active Trip location target and ~2 s stationary heartbeat (#226);
+- trusted-speed-first stationary distance handling (#231);
+- silent-provider recovery: platform no longer trusts framework `fused`, and Google Fused falls back after a 12 s no-callback watchdog (#234).
+
+Truth boundaries remain:
+
+- original `Location.time` is authoritative;
+- no synthetic route points;
+- `LONG_GAP_SECONDS = 120` remains a hard continuity boundary;
+- stationary GNSS drift must not become distance.
+
+#77 remains open for current-main physical lock-screen/background/provider-loss acceptance. #203 no longer owns a missing Fused migration; that implementation is complete and its remaining physical responsibility belongs in #77.
+
+### Bluetooth-triggered Trip — #235
+
+Current `main` has advanced beyond the original exploration-only baseline:
+
+- #239: auto-trip mode/state/reason model + pure eligibility policy;
+- #241: persisted per-vehicle Bluetooth detection sessions, dedupe, ignore handling and notification entry flow;
+- #242: explicit per-vehicle `蓝牙连接后自动开始行程` option routed through `TripStartCoordinator`, with location/notification/active-Trip guards.
+
+Therefore any document or Issue that still says auto-start is wholly unimplemented is stale.
+
+#235 remains open for real-device/OEM/background acceptance, trigger-quality policy and later verified-movement / parking-assistant work. Bluetooth connection alone must not be documented as proven driving evidence.
+
+### Trip interaction / analysis follow-ups
+
+Already implemented in `main`:
+
+- interactive route pan/pinch/reset and trusted-speed route encoding (#219/#221/#230);
+- interactive trend pan/zoom/tap and stock-style long-press drag inspection (#218/#227);
+- smoother SOC wheel gesture behavior (#230);
+- uncertainty-aware altitude filtering for completed and active trends (#228/#232);
+- recent-consumption-based Trip end-SOC estimator seed (#213).
+
+Remaining map work under #192/#199 is specifically basemap/provider/context validation, road labels, licensing/attribution, China-region behavior and truthful fallback — not basic pan/zoom.
+
+### Updater
+
+Updater runtime has continued beyond the early #102 description, including non-blocking DownloadManager behavior, prompt dedupe and persisted recovery of an install-ready download after process restart (#247).
+
+#102 remains valid only as the physical production old-APK -> new-APK in-place upgrade acceptance owner. It must not be read as evidence that updater root wiring is still missing.
+
+## Authority maintenance rules
+
+1. Update the owning Issue whenever implementation stage changes.
+2. Close superseded implementation-only Issues when their code is merged and physical acceptance is owned elsewhere.
+3. Keep physical-only Issues explicitly labeled in their body as physical acceptance; do not leave unchecked implementation lists.
+4. Draft PRs may propose design, but they are not project authority until merged or explicitly adopted by an owning Issue.
+5. `PROJECT_MASTER.md` owns stable architecture/product principles; this file owns fast-moving execution status.
+6. `ROADMAP.md` should describe ordering and milestones, but when its dated status lags this file, this file wins for current execution state.
+7. Historical design/reference documents remain useful only when their supersession boundary is explicit.
+8. No broad reimplementation may be started from an old Issue without first checking current `main` and merged PR history.
+
+## Immediate governance queue
+
+- reconcile #6 to this status authority and the 2026-08-31 baseline;
+- reconcile #77 and close/supersede #203 as a missing-implementation owner;
+- reconcile #235 and remove stale pre-implementation wording;
+- reconcile #244 and #20 with the merged catalog/Logo/batch-maintenance baseline;
+- reconcile #205 to mark recent historical-consumption estimator input implemented by #213;
+- reconcile #192 so basic route pan/zoom is marked implemented while provider/basemap remains open;
+- close or rewrite #222/#223/#224/#225 so merged implementation is not represented as future work;
+- keep #75 open while `main` remains unprotected.


### PR DESCRIPTION
## Purpose

Documentation/governance only. No Android/backend/admin/runtime code changes.

This PR fixes an authority problem found while auditing current `main`, open Issues and open PRs on 2026-08-31: stable project documents still describe the 2026-08-29 post-#184/#195 state while `main` has advanced through newer Trip reliability, Bluetooth auto-start, vehicle/catalog/Brand Logo administration, updater recovery and Charging v0.7 work.

## Changes

- add `docs/CURRENT_STATUS_AUTHORITY.md` as the fast-changing operational status authority;
- define precedence: current `main` facts -> merged PR/CI -> current-status authority -> owning Issue -> older roadmap/history;
- record the current implementation baseline through merged PR #259;
- explicitly separate implemented code from remaining physical acceptance;
- identify stale Issue ownership such as #203 and #222-#225;
- carry the approved Charging v0.7 design into a clean current-main document instead of leaving Draft PR #255 as de facto authority;
- document that Draft PR #258 is only the first calculation-engine slice and does not complete #252.

## Governance rules

- Open Issue != missing code.
- Draft/unmerged PR != runtime authority.
- CI Green != physical acceptance.
- Fully merged implementation must not remain described as future implementation work.
- No broad reimplementation should start from an old Issue before checking current `main`.

## Scope

Docs only. This PR intentionally does not modify business code, CI workflows, schemas, release behavior or runtime behavior.

Follow-up is Issue/PR status reconciliation under #6.