### PR TITLE
docs: harden repository governance and project entrypoint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: Bug / Regression
+description: Report a concrete regression against the current main baseline
+title: "fix: "
+labels: []
+assignees: []
+---
+
+## Problem
+
+Describe the observed behavior. Prefer concrete evidence over a proposed implementation.
+
+## Current baseline checked
+
+- Current `main` / APK / commit used:
+- Relevant merged PR / authority document checked:
+- Existing owning Issue checked:
+
+> Open Issue does not imply missing code. Confirm the problem exists on current `main` before proposing a broad reimplementation.
+
+## Reproduction / evidence
+
+1.
+2.
+3.
+
+Evidence:
+- screenshot / recording / exported diagnostic facts / logs:
+- device / Android version when relevant:
+
+## Expected behavior
+
+
+## Data-truth / safety boundary
+
+What must not be fabricated, silently rewritten or weakened while fixing this problem?
+
+-
+
+## Scope
+
+### Required
+- [ ]
+
+### Non-goals
+- 
+
+## Acceptance
+
+- [ ] Reproduction fails before the fix and passes after it
+- [ ] Focused regression evidence/test exists where practical
+- [ ] Required current-head CI Green
+- [ ] Physical-device acceptance owner is explicit when CI cannot prove the result
+
+## Related
+
+- Issue:
+- PR:
+- Authority document:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/documentation_governance.md
+++ b/.github/ISSUE_TEMPLATE/documentation_governance.md
@@ -1,0 +1,46 @@
+---
+name: Documentation / Governance
+description: Reconcile stale authority, Issue/PR state, release evidence or repository hygiene
+title: "docs: "
+labels: ["documentation"]
+assignees: []
+---
+
+## Governance problem
+
+What source currently conflicts with project/repository facts?
+
+## Current evidence
+
+- Current `main` fact / repository metadata:
+- Merged PR / CI evidence:
+- Conflicting Issue / PR / document:
+
+## Authority decision
+
+Use the project precedence:
+
+1. current `main` implementation/schema/runtime facts
+2. merged PR + CI evidence
+3. `docs/CURRENT_STATUS_AUTHORITY.md`
+4. owning Open Issue for remaining work/acceptance
+5. roadmap / historical design material
+
+State the intended authority after reconciliation:
+
+
+## Required maintenance
+
+- [ ] stale implementation wording removed or version-bounded
+- [ ] completed implementation Issue closed or rewritten as acceptance-only
+- [ ] superseded Draft PR/document explicitly closed/marked
+- [ ] current owner for remaining work is explicit
+- [ ] CI is not presented as physical-device acceptance
+
+## Scope boundary
+
+This governance Issue does not authorize unrelated business-code implementation.
+
+## Close condition
+
+The same current stage is described by `main`, merged evidence, current authority docs and the owning Issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,63 @@
+---
+name: Feature / Enhancement
+description: Propose a focused capability without duplicating current implementation
+title: "feat: "
+labels: []
+assignees: []
+---
+
+## Goal
+
+What user/product outcome is needed?
+
+## Current baseline checked
+
+- Current `main` behavior:
+- Existing Issue / merged PR checked:
+- Relevant authority document:
+
+> Do not start from an old unchecked checklist. Record what is already implemented before listing remaining work.
+
+## Product / data truth
+
+What facts are authoritative? What values are derived/estimated? What must never be fabricated?
+
+-
+
+## Scope
+
+### Required
+- [ ]
+
+### Already implemented / reused
+- [ ]
+
+### Non-goals
+- 
+
+## Implementation slices
+
+Keep slices small and give each remaining responsibility one owner.
+
+1.
+2.
+
+## Acceptance
+
+### Automated
+- [ ] Required current-head CI Green
+
+### Physical / visual / production
+- [ ] Owner Issue or `Not applicable`:
+
+## Documentation / authority impact
+
+- [ ] Owning Issue remains the remaining-work authority
+- [ ] Current-status / architecture docs updated only where responsibility changes
+- [ ] Any superseded Draft PR/document is explicitly marked or closed
+
+## Related
+
+- Parent Issue:
+- Related PR:
+- Authority document:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## Owning Issue
+
+Refs #
+
+## Current baseline
+
+- Base branch:
+- Relevant current-main / authority context:
+
+## What changes
+
+-
+
+## What does not change
+
+-
+
+## Evidence
+
+- [ ] Required automated checks are Green on the current PR head, or not applicable for docs-only changes
+- [ ] Changed files/diff reviewed against the intended base
+- [ ] No stale Draft/Issue/document is being treated as runtime authority
+
+Evidence / run:
+
+## Physical acceptance
+
+- Owner Issue: # / Not applicable
+- This PR does **not** claim physical acceptance unless explicit device evidence is attached.
+
+## Documentation / authority impact
+
+- [ ] No authority document change required
+- [ ] Authority/status document updated
+- [ ] Owning Issue updated for implementation vs remaining acceptance
+
+Details:
+
+## Stacked PR dependency
+
+- Parent PR / base: None
+- If stacked, merge order and required retarget after parent merge:
+
+## Supersedes
+
+- PR / Issue / document superseded by this change: None
+
+## Closeout
+
+- [ ] PR description matches the final scope
+- [ ] Remaining work has an explicit owner
+- [ ] After merge, delete the head branch once no stacked PR depends on it

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Assembles-J
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,105 @@
 # EV Charge Book 🚗⚡
 
-新能源车充电成本记录与电池健康分析 App。
+EV Charge Book 是一个面向新能源车主的 **Local First 车辆数据与充电/行程记录 App**。
 
-## 项目定位
+项目优先记录可解释、可恢复的真实用车事实：车辆、充电记录、SOC/里程快照、GPS 行程、成本与本地分析。缺失数据保持缺失；估算值必须与实测/用户确认事实区分。
 
-EV Charge Book 是一个面向新能源车主的充电管理工具，目标是记录真实用车成本，并通过数据分析帮助车主管理车辆。
+> 本 README 只提供稳定入口，不维护高频实现 checklist。当前代码/Issue/PR 的实时状态以 [`docs/CURRENT_STATUS_AUTHORITY.md`](docs/CURRENT_STATUS_AUTHORITY.md) 为准。
 
-核心方向：
+## 当前稳定能力
 
-- 充电记账
-- 电耗分析
-- 每公里成本计算
-- 电池健康管理
-- AI 用车分析
+### Android / Local First
 
-## MVP 功能进度
+- Kotlin + Jetpack Compose
+- Room 本地数据库与显式 migration
+- 多车辆与当前车辆上下文
+- managed vehicle catalog + Offline First 缓存
+- 用户车辆 nickname；标准车型事实只读
+- Charging Record 新增 / 编辑 / 删除 / 统计
+- VehicleState 当前 SOC / 里程事实层
+- Trip 前台记录、真实 WGS84 TripPoint、距离/时间/速度/海拔分析
+- Trip LONG_GAP / provider / reliability 诊断与 truthful route presentation
+- Local JSON Backup / Restore
+- release-only APK 更新发现、下载、SHA-256 校验与 Android installer handoff
 
-### 车辆管理
-- [x] UI 设计：车辆信息卡片与电池健康度展示
-- [ ] 功能实现：添加车辆品牌/车型
-- [ ] 功能实现：电池容量记录
-- [ ] 功能实现：续航信息记录
+### Managed catalog / assets
 
-### 充电记录
-- [x] UI 设计：时间线列表与流式添加表单
-- [ ] 功能实现：记录充电时间
-- [ ] 功能实现：记录 SOC 变化
-- [ ] 功能实现：记录充电电量
-- [ ] 功能实现：记录充电费用
-- [ ] 功能实现：自动计算电价
+- 后台维护车型目录、品牌元数据与 Hero artwork key
+- Brand Logo Light/Dark 资产发布与 Android 缓存展示
+- Catalog JSON/CSV import/export 与批量资源维护工具
 
-### 数据分析
-- [x] UI 设计：月度费用卡片与电耗趋势图表
-- [ ] 功能实现：月度充电费用统计
-- [ ] 功能实现：百公里电费计算
-- [ ] 功能实现：平均电耗趋势分析
-- [ ] 功能实现：快充/慢充比例统计
+### 当前正在推进
 
-## 技术路线
+- Charging v0.7：成熟的费用/单价/桩端电量联动编辑、可选 `开始充电` 生命周期与 truthful derived metrics
+- Trip / Vehicle / Records / Stats 的真实设备 closeout
+- 后台定位、通知、Geocoder、production updater 的 physical acceptance
+- 车型目录 provenance / normalization / coverage quality
 
-### Android
-- Kotlin
-- Jetpack Compose (UI 框架)
-- Room Database (待实现)
-- Retrofit (待实现)
-- MVVM (架构)
+“代码已实现”“CI Green”“真机功能验收”“真机视觉验收”“Production Release 验收”是不同状态，不互相替代。
 
-### Backend
-- Spring Boot
-- PostgreSQL
-- Redis
-- Docker
+## 数据真值原则
+
+- Local First：服务端/网络不可成为核心记账与 Trip 记录的前置条件。
+- coordinates 是位置事实，address 是派生展示。
+- 不生成 synthetic GPS point，不跨真实 LONG_GAP 补造路线或距离。
+- 不把手工 SOC、SOC-derived energy、估算值描述为 BMS 实测。
+- Catalog reference data 不等于 VIN / BMS / live vehicle telemetry。
+- CI Green 不等于真机验收。
+
+## 权威文档入口
+
+### 当前执行状态
+
+- [`docs/CURRENT_STATUS_AUTHORITY.md`](docs/CURRENT_STATUS_AUTHORITY.md) — 高频变化的当前实现/验收状态
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — 路线与阶段顺序
+
+### 稳定产品与架构
+
+- [`docs/PROJECT_MASTER.md`](docs/PROJECT_MASTER.md) — 项目总纲
+- [`docs/PRODUCT.md`](docs/PRODUCT.md) — 产品边界
+- [`docs/FEATURE_MATRIX.md`](docs/FEATURE_MATRIX.md) — 功能矩阵
+- [`docs/DATABASE.md`](docs/DATABASE.md) — 数据模型
+- [`docs/LOCATION_TRIP.md`](docs/LOCATION_TRIP.md) — Location / Trip
+- [`docs/CI_CD.md`](docs/CI_CD.md) — CI / Production Release
+- [`docs/APK_AUTO_UPDATE.md`](docs/APK_AUTO_UPDATE.md) — App updater
+- [`docs/VEHICLE_CATALOG_MULTI_VEHICLE.md`](docs/VEHICLE_CATALOG_MULTI_VEHICLE.md) — Vehicle / Catalog
+- [`docs/BRANCH_AND_PR_GOVERNANCE.md`](docs/BRANCH_AND_PR_GOVERNANCE.md) — Branch / PR / stacked-PR 治理
+
+当文档冲突时，使用以下优先级：
+
+1. 当前 `main` 的实现事实 / schema / runtime contract
+2. merged PR + CI evidence
+3. `CURRENT_STATUS_AUTHORITY.md`
+4. owning Open Issue 的剩余验收 / future work
+5. 旧 Roadmap、版本化 UI baseline 与历史设计文档
 
 ## Repository Structure
 
 ```text
-EV-Charge-Book
-├── android
-│   └── app/src/main/java/com/evchargebook/ui  <-- 已完成核心 UI 实现
-├── server
-├── docs
-│   ├── PRODUCT.md
-│   ├── DATABASE.md
-│   └── ROADMAP.md
+EV-Charge-Book/
+├── android/          # Android / Compose / Room
+├── server/           # managed backend/admin related code
+├── docs/             # product, architecture, UX and status authority
+├── .github/          # CI/CD workflows and contribution templates
 └── README.md
 ```
 
-## Roadmap
+## 开发与发布
 
-### Phase 1 - MVP
-- [x] 核心 UI/UX 骨架搭建
-- [ ] 本地数据库 (Room) 集成
-- [ ] 基础充电记录功能联调
+开发、构建与验收规则见 [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) 与 [`docs/CI_CD.md`](docs/CI_CD.md)。
 
-### Phase 2 - 数据分析
-增加动态趋势图表和车辆画像。
+Production Release 与普通 Android CI 分离。正式 APK 版本只在明确触发 Production Release 时生成；普通业务提交、PR、Debug CI 和文档变更不生成新的正式版本。
 
-### Phase 3 - Intelligent EV Assistant
-增加 OCR、AI 分析、电池健康预测。
+## Issue / PR 规则
+
+- Open Issue 不代表代码一定未实现；先核对 current `main` 与 merged PR。
+- Draft / unmerged PR 不是 runtime authority。
+- 实现完成但仍需真机验证时，Issue 必须明确改写为 physical acceptance owner。
+- Stacked PR 必须明确 parent/base，并按依赖顺序合并和 retarget。
+- 已关闭/合并工作的远端 head branch 应按治理规则清理。
+
+持续文档治理由 Issue #6 跟踪；仓库保护与 required CI 由 Issue #75 跟踪。
 
 ## License
-MIT
+
+MIT License. See [`LICENSE`](LICENSE).

--- a/docs/BRANCH_AND_PR_GOVERNANCE.md
+++ b/docs/BRANCH_AND_PR_GOVERNANCE.md
@@ -1,0 +1,188 @@
+# EV Charge Book Branch and Pull Request Governance
+
+Updated: 2026-08-31
+Status: Repository governance authority
+Owner: #6 documentation/status governance; #75 repository protection
+
+## 1. Purpose
+
+Keep a high-frequency repository understandable and safe without adding heavy process.
+
+This document governs:
+
+- branch lifecycle;
+- pull request authority and status;
+- stacked PR behavior;
+- stale-branch cleanup;
+- relationship between CI and physical acceptance;
+- target `main` protection policy.
+
+It does not define product behavior.
+
+## 2. Authority rules
+
+1. current `main` implementation/schema/runtime facts win over stale prose;
+2. merged PR evidence is implementation history, not physical acceptance;
+3. Draft/unmerged PR is never runtime authority;
+4. Open Issue does not imply missing implementation;
+5. implementation-complete Issues must close or explicitly become physical-acceptance owners;
+6. historical branches and closed PRs must not be used as the source for new implementation work without checking current `main`.
+
+## 3. Branch lifecycle
+
+### Active branches
+
+A remote branch is active only when at least one is true:
+
+- it is `main`;
+- it is the head/base of an Open PR;
+- it contains explicitly preserved unpublished work with a current owning Issue;
+- it is a temporary release/operations branch with a documented current purpose.
+
+### Cleanup candidates
+
+A branch is a cleanup candidate when all are true:
+
+- its PR is merged or closed, or it was a temporary/no-op branch;
+- no Open PR currently depends on it as head or base;
+- it is not `main` or another explicitly protected branch;
+- it has no unique unpublished work that an owning Issue still requires.
+
+Examples include old `docs/*`, historical `feat/*`, `fix/*`, `ui/*`, `noop*` and `tmp-*` heads whose work already landed or was superseded.
+
+### Cleanup timing
+
+- merged PR head: delete after merge once no stacked PR depends on it;
+- closed/superseded PR head: delete after the closure is documented and no recovery need exists;
+- temporary/no-op branch: delete immediately after purpose is complete;
+- stacked parent branch: retain until all dependent stacked PRs are retargeted or closed.
+
+Git history remains available through merged commits/PRs; long-lived abandoned remote branches are not documentation.
+
+## 4. Automatic branch deletion target
+
+Repository target setting:
+
+- enable `delete_branch_on_merge`.
+
+Exception: if a merged branch is still the base of an active stacked PR, GitHub/maintainer must first retarget the child PR to the appropriate surviving base.
+
+A repository setting must never be documented as enabled until the repository metadata confirms it.
+
+## 5. Pull request minimum contract
+
+Every non-trivial PR should identify:
+
+- owning Issue;
+- current baseline / base branch;
+- what this PR changes;
+- what it intentionally does not change;
+- test/CI evidence required for this slice;
+- physical acceptance owner when applicable;
+- documentation/authority impact;
+- superseded PR/Issue/document when applicable.
+
+For docs-only PRs, runtime testing may be `Not applicable`, but authority impact must still be explicit.
+
+## 6. Draft vs Ready
+
+Use Draft when:
+
+- scope or contract is still changing;
+- required implementation slice is incomplete;
+- the PR is a stacked child waiting for an unstable parent;
+- the author explicitly does not want merge review yet.
+
+Mark Ready only when:
+
+- the PR's own stated scope is complete;
+- its current head has the required automated evidence;
+- the base relationship is intentional and current;
+- no known unresolved blocker remains for that slice.
+
+`Ready` still does not mean physical acceptance is complete.
+
+## 7. Stacked PR rules
+
+Stacked PRs are allowed, but dependency must be explicit.
+
+Example:
+
+```text
+main
+  <- PR A / branch-a
+       <- PR B / branch-b
+```
+
+Rules:
+
+1. PR B must state that it is stacked on PR A and name the parent/base.
+2. Review PR A before PR B unless the review explicitly understands the combined diff.
+3. Merge PR A first.
+4. After PR A lands, retarget PR B to `main` (or the next intentional surviving parent).
+5. Re-read PR B's changed files/diff after retarget; do not assume the old stacked diff equals the new main diff.
+6. Re-run/confirm required CI for PR B's current head/base state.
+7. Delete the parent branch only after dependent children are retargeted.
+8. Never merge a child merely because the parent CI was Green.
+
+## 8. CI evidence
+
+Automated evidence and device acceptance are separate.
+
+For Android/runtime code:
+
+- required build/test checks must pass on the PR's current head;
+- a stale Green run from an older head is supporting history, not current merge evidence;
+- branch synchronization that changes effective code requires current-head evidence;
+- docs-only changes may intentionally skip Android CI when workflow path filters do so.
+
+Physical acceptance remains in its owning Issue and cannot be inferred from CI.
+
+## 9. Target `main` protection
+
+Repository target policy, owned by #75:
+
+- protect `main`;
+- require pull requests for normal changes;
+- require the applicable Android Build check before runtime-code merge;
+- require or otherwise verify that the checked PR head includes current `main` before merge;
+- keep emergency admin bypass deliberate and exceptional;
+- do not force unrelated Android checks on docs-only PRs when path filters intentionally skip them.
+
+Until repository metadata confirms these controls, #75 remains Open.
+
+## 10. Repository hygiene snapshot
+
+The 2026-08-31 governance audit enumerated 192 remote branch refs across two result pages, including many branches for already merged/closed work. Repository metadata also reported `delete_branch_on_merge = false`.
+
+This is a cleanup signal, not permission to bulk-delete blindly. The safe cleanup process is:
+
+1. enumerate current Open PR head/base branches;
+2. preserve `main` and all active dependency branches;
+3. map remaining branches to merged/closed PRs where possible;
+4. delete obvious merged/superseded/temp branches first;
+5. review branches with no PR mapping for unique unpublished commits before deletion;
+6. enable merge-time branch deletion after repository settings allow it.
+
+## 11. Naming guidance
+
+Prefer short purpose-oriented names:
+
+- `feat/<area>-<purpose>`
+- `fix/<area>-<purpose>`
+- `docs/<purpose>`
+- `chore/<purpose>`
+- `ui/<area>-<purpose>`
+
+Avoid permanent `tmp-*`, `noop*`, repeated `-final`, `-final2`, `-v2` chains. If experimentation requires them, remove them after the owning PR/work is resolved.
+
+## 12. Closeout rule
+
+Repository governance is healthy when:
+
+- `main` protection is verifiably enabled;
+- required current-head CI cannot be bypassed accidentally for runtime code;
+- merged branches are normally removed;
+- active stacked PR dependencies are visible and current;
+- README points to current authority instead of duplicating an implementation checklist;
+- old branches, Issues and Draft PRs cannot plausibly be mistaken for current implementation authority.


### PR DESCRIPTION
## Purpose

Repository governance/documentation only. No Android/backend/admin/runtime behavior changes.

This PR closes several governance gaps found during the 2026-08-31 authority audit:

- the root README was still an obsolete pre-Room/MVP checklist and contradicted current `main`;
- README declared MIT but the repository had no root `LICENSE` file and GitHub metadata did not identify a license;
- `.github` had workflows only, with no PR/Issue templates to force current-main/authority/acceptance ownership;
- the repository has accumulated ~192 remote branch refs and currently reports `delete_branch_on_merge = false`;
- stacked PR rules were implicit even though current Charging work uses #258 -> #261 stacking.

## Changes

- replace stale MVP README with a stable project entrypoint that points fast-moving status to `docs/CURRENT_STATUS_AUTHORITY.md`;
- add canonical MIT `LICENSE`, matching the license already declared by README;
- add `docs/BRANCH_AND_PR_GOVERNANCE.md`;
- add `.github/PULL_REQUEST_TEMPLATE.md`;
- add evidence-first Bug, Feature and Documentation/Governance Issue templates;
- keep blank issues enabled;
- define safe branch cleanup criteria and merge-time deletion target without pretending repository settings are already enabled;
- define stacked-PR merge/retarget/current-head-CI rules;
- restate that CI Green != physical acceptance and Draft/unmerged PR != runtime authority.

## Scope

Docs/repository templates only. This PR intentionally does not:

- change business code;
- change GitHub branch protection/rulesets (tracked by #75; current connector exposes read but not ruleset write);
- bulk-delete remote branches without first protecting current Open PR dependencies;
- merge or modify Charging runtime code in #258/#261.

## Acceptance

- changed files are limited to README/LICENSE/docs/.github templates;
- no runtime source/workflow file changes;
- after merge, #6/#75 and current stacked PR metadata will be reconciled against this policy.

Refs #6 #75 #251 #252 #260