### PR TITLE
docs: separate status, roadmap, architecture and workflow authority

### DIFF
--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,6 +1,6 @@
 # EV Charge Book CI/CD 与发布设计
 
-版本: v2.0.0
+版本: v2.0.1
 更新时间: 2026-08-31
 状态: CI / Production Release authority
 
@@ -266,16 +266,19 @@ Production workflow success 证明“发布流程执行成功”，但 App 升�
 
 Hero / catalog / admin workflows 不属于 Android Production Release。
 
-完整职责见 `WORKFLOW_OWNERSHIP.md`：
+完整职责见 `WORKFLOW_OWNERSHIP.md`。当前基线包括：
 
 - `hero-admin.yml` — integrated resource-admin validation；
-- `hero-admin-deploy.yml` — production admin deployment；
+- `hero-admin-deploy.yml` — production resource-admin deployment；
 - `hero-assets-publish.yml` — Hero package validation；
-- `admin-batch-image-upload.yml` — batch image browser-contract validation；
-- `admin-prompt-library.yml` — prompt/copy-center validation；
-- `vehicle-catalog-admin-tools.yml` — catalog admin tools validation。
+- `admin-resource-workbench.yml` — unified one-vehicle resource-bundle workbench validation；
+- `admin-batch-image-upload.yml` — retained focused/legacy batch-helper regression validation；
+- `admin-prompt-library.yml` — single-item + full-bundle prompt contract validation；
+- `vehicle-catalog-admin-tools.yml` — catalog admin tools/import-export validation。
 
-不要因为多个 workflow 命中相同目录就自动判断它们重复；先看它们的 responsibility / deployment authority。
+其中 PR #264 已将“新车型完整资源 onboarding”的产品入口收敛到 Resource Workbench；旧 split batch 面板退出主 UI，但其 focused helper workflow 仍存在，当前应理解为兼容/回归验证，而不是新的产品 authority。
+
+不要因为多个 workflow 命中相同目录就自动判断它们重复；先看 responsibility / deployment authority / 当前产品入口。
 
 ---
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,69 +1,141 @@
 # EV Charge Book CI/CD 与发布设计
 
-版本: v1.4.0
-更新时间: 2026-08-27
-状态: Authority Subdocument
+版本: v2.0.0
+更新时间: 2026-08-31
+状态: CI / Production Release authority
 
-## 1. 目标
+## 1. 文档职责
 
-遵循 Assembles-J 组织发布思路：CI 与 Production Release 分离、signed APK、Actions Artifact、production Environment、服务器不可变 release 与原子激活。
+本文件只负责 Android CI / Production Release 的稳定规则。
 
-新增原则：**正式 APK 版本只在真正执行 Production Release 时生成。普通业务提交、PR、Debug CI 和文档提交不升级正式版本。**
+各 GitHub Actions workflow 的具体职责、trigger 与 deployment boundary 见 `WORKFLOW_OWNERSHIP.md`。
 
-APK 自动升级详细设计见 `APK_AUTO_UPDATE.md`。
+当前 PR/head/run 状态不写死在本文件，统一以 current GitHub state / `CURRENT_STATUS_AUTHORITY.md` 为准。
+
+核心原则：
+
+- Android CI 与 Production Release 分离；
+- 正式 APK 版本只在明确触发 Production Release 时生成；
+- 普通 commit / PR / Debug CI / docs change 不生成新的正式版本；
+- CI Green 不等于真机验收；
+- Production workflow 成功也不自动等于 old-production -> new-production 真机覆盖升级已验收。
 
 ---
 
 ## 2. Android Build Baseline
 
-当前统一构建参数：
+当前稳定构建参数：
 
-- JDK 17
-- compile/target SDK 36
-- CI Android platform 36
-- Build Tools 36.0.0
-- Gradle Wrapper 9.5.0
+- JDK 17；
+- compileSdk 36；
+- targetSdk 36；
+- CI Android platform 36；
+- Build Tools 36.0.0；
+- Gradle Wrapper 9.5.0；
+- wrapper 实际路径：`android/gradlew`；
+- wrapper distribution：`android/gradle/wrapper/gradle-wrapper.properties`。
 
-CI 与 Release 必须使用仓库 `./gradlew`。
-
-开发/普通 CI 使用 `build.gradle.kts` 默认 dev 版本：
+普通开发/CI 默认版本来自 `android/app/build.gradle.kts`：
 
 ```text
 versionCode = 1
 versionName = 0.1.0-dev
 ```
 
-这些值不是正式发布版本，不应随业务 commit 修改。
-
----
-
-## 3. CI 流程
+Debug build 额外使用：
 
 ```text
-push / pull request Android change
- -> Checkout
- -> Validate build + wrapper
- -> JDK 17
- -> Android SDK 36 / Build Tools 36
- -> Gradle cache
- -> ./gradlew testDebugUnitTest :app:assembleDebug
- -> Debug APK Artifact
+applicationIdSuffix = .debug
+versionNameSuffix = -debug
 ```
 
-Android Build 只验证代码，不产生正式版本号，不更新线上 `latest.json`。
+因此 Debug 与 Production APK 可并存，不应再通过修改 production applicationId 来解决调试安装冲突。
 
 ---
 
-## 4. Production Release
+## 3. Android CI
 
-Production Release 继续保持 `workflow_dispatch` 手动门禁。
+Workflow：`.github/workflows/android-build.yml`
+
+Workflow name：`Android Build`
+
+Job/check name：`Android CI`
+
+### Trigger
+
+PR / `main` push 仅在以下路径变化时运行：
+
+- `android/**`
+- `.github/workflows/android-build.yml`
+
+同时支持 manual `workflow_dispatch`。
+
+### Current build contract
+
+```text
+checkout
+ -> validate Android repository baseline
+ -> enforce packaged Hero WebP size budget
+ -> JDK 17
+ -> Android SDK 36 / Build Tools 36.0.0
+ -> Gradle cache
+ -> cd android
+ -> ./gradlew --no-daemon testDebugUnitTest :app:assembleDebug
+ -> upload Debug APK artifact
+```
+
+Debug APK artifact retention 当前为 7 天。
+
+### CI authority
+
+Android CI 可以证明：
+
+- 当前 PR head 能完成配置的自动化测试；
+- Debug APK 能构建；
+- workflow 内显式 guardrail 通过。
+
+Android CI **不能证明**：
+
+- 真机后台/锁屏行为；
+- GPS/provider/OEM 差异；
+- 视觉/交互验收；
+- Production signing；
+- production server publish；
+- old-production -> new-production 覆盖升级。
+
+---
+
+## 4. Current-head merge evidence
+
+Repository governance 目标由 #75 跟踪。
+
+对于会触发 Android Build 的 runtime PR：
+
+1. 必须确认 PR 当前 base/stack 关系；
+2. 必须检查当前 changed files / effective diff；
+3. required evidence 应来自当前 PR head；
+4. 如果 sync/rebase/merge `main` 改变了 head/effective code，旧 Green run 不能继续当最终 merge evidence；
+5. 需要重新获得当前 head 的 `Android CI` 成功；
+6. stacked child 不能复用 parent 的 CI 作为自己的最终 merge evidence。
+
+Docs-only change 如果不命中 Android workflow path filter，可以没有 Android CI；不要为了“形式统一”强制无关 Android 构建。
+
+---
+
+## 5. Production Release
+
+Workflow：`.github/workflows/android-release.yml`
+
+Workflow name：`Android Release`
+
+Trigger：**manual `workflow_dispatch` only**。
 
 输入：
 
-- `ref`: 要发布的 commit / branch / tag
-- `release_series`: 产品阶段版本，例如 `0.4`
+- `ref` — 要发布的 git ref；
+- `release_series` — 产品阶段版本，例如 `0.4`。
 
-Release workflow 内部才生成：
+Workflow 内部生成：
 
 ```text
 VERSION_CODE = github.run_number
@@ -71,127 +143,148 @@ VERSION_NAME = <release_series>.<github.run_number>
 APK_FILE = ev-charge-book-<VERSION_NAME>.apk
 ```
 
-示例：Android Release Run #12 + release_series `0.4` => `0.4.12`。
+Release workflow 使用 `environment: production`。
 
-正式流程：
+### Production build contract
 
 ```text
-人工确认需要下发 APK
- -> Run Android Release
- -> Checkout ref
+manual release decision
+ -> checkout requested ref
  -> resolve real commit SHA
- -> inject production version
- -> restore production signing key
- -> assembleRelease
+ -> validate release baseline / secrets
+ -> verify current public update discovery route
+ -> ensure Android SDK 36 / Build Tools 36.0.0
+ -> restore production signing keystore
+ -> cd android
+ -> ./gradlew --no-daemon --build-cache :app:assembleRelease
  -> apksigner verify
  -> SHA-256
- -> Actions Artifact
- -> SCP *.part
- -> server SHA verification
- -> immutable releases/<version>.apk
- -> per-version env/json metadata
- -> update latest.env
- -> update latest APK symlink
- -> atomic replace release-meta/latest.json LAST
+ -> prepare immutable/atomic upload
+ -> publish release files / metadata
 ```
 
-只有 `latest.json` 最终替换成功后，App 才能发现新版本。
+具体 server upload / atomic activation 以 current `android-release.yml` 为实现事实。
 
 ---
 
-## 5. APK 自动升级发现
+## 6. Version Rules
 
-生产 App 默认读取：
+1. 普通 commit 不修改正式 `versionCode/versionName`。
+2. Android Build 不生成正式 release version。
+3. 只有明确触发 Android Release 时才生成正式版本。
+4. `versionCode` 必须单调增加；当前使用 release workflow run number。
+5. `versionName` 当前由 `release_series + run_number` 组成。
+6. Release 失败允许跳号；未成功激活的版本不能被客户端当作可用最新版本。
+7. `release_series` 只在产品阶段变化时调整，不随普通 feature PR 增长。
+
+---
+
+## 7. Production Signing
+
+Production Release 依赖：
+
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
+以及发布服务器相关 secret：
+
+- `COMMON_SERVER_HOST`
+- `COMMON_SERVER_USER`
+- `COMMON_SSH_PRIVATE_KEY`
+
+Production signing key 必须长期保持一致，否则旧正式 APK 无法被新版 APK 原地覆盖升级。
+
+签名 secret 不应被写入仓库文档、Issue、PR body 或日志。
+
+---
+
+## 8. App Update Discovery
+
+Production App 默认 update manifest：
 
 ```text
 https://groupim.cn/ev-charge-book/release-meta/latest.json
 ```
 
-该地址通过 `BuildConfig.UPDATE_MANIFEST_URL` 注入；Release 环境可用 `APP_UPDATE_MANIFEST_URL` 覆盖。
+BuildConfig 入口：`UPDATE_MANIFEST_URL`。
 
-App 仅在 `release` build 检查更新：
+Release 环境可以通过 `APP_UPDATE_MANIFEST_URL` 覆盖。
+
+客户端核心判断：
 
 ```text
 latest.versionCode > BuildConfig.VERSION_CODE
- -> 提示用户升级
- -> DownloadManager 下载 immutable APK
- -> SHA-256 校验
- -> Android 系统安装器确认覆盖安装
+ -> prompt
+ -> DownloadManager
+ -> SHA-256 verify
+ -> Android system installer
 ```
 
-更新检查失败必须静默降级，不影响 Local First 核心功能。
+更新服务不可用时必须 non-blocking，不能影响 Local First 核心功能。
+
+Updater 的 runtime/physical owner 见 `APK_AUTO_UPDATE.md` 与 #102。
 
 ---
 
-## 6. 版本规则
+## 9. Production Release Gate
 
-1. 普通 commit 不修改正式 `versionName/versionCode`。
-2. Android Build 不发布正式版本。
-3. 只有明确需要给用户下发新 APK 时才触发 Android Release。
-4. `versionCode` 是 Android 升级顺序依据，必须单调增加；Release workflow run number 满足该要求。
-5. `versionName` 用于用户展示，由 `release_series + release run number` 组成。
-6. Release 失败允许跳号；未成功原子激活的版本不对客户端可见。
-7. product series 只在产品阶段变化时修改，例如 `0.4 -> 0.5`。
+执行 Production Release 前至少确认：
 
----
+- 目标 ref/commit 是明确的；
+- applicable Android CI 已通过；
+- production signing secrets 可用；
+- public update discovery route 当前可验证；
+- assembleRelease 成功；
+- `apksigner verify` 成功；
+- SHA-256 生成；
+- server/staging 有足够权限和空间；
+- atomic metadata activation 逻辑未被绕过。
 
-## 7. Secrets
-
-Production Environment / organization secrets：
-
-- ANDROID_KEYSTORE_BASE64
-- ANDROID_KEYSTORE_PASSWORD
-- ANDROID_KEY_ALIAS
-- ANDROID_KEY_PASSWORD
-- COMMON_SERVER_HOST
-- COMMON_SERVER_USER
-- COMMON_SSH_PRIVATE_KEY
-
-生产 signing key 必须长期保持一致，否则 Android 不允许旧版 App 被新版 APK 覆盖安装。
+如果目标 ref 在最后一次 CI 后发生改变，应重新验证 current effective commit；不要用旧 CI run 给新的 release ref 背书。
 
 ---
 
-## 8. 发布门禁
+## 10. Production Acceptance
 
-Production Release 前至少满足：
+Production workflow success 证明“发布流程执行成功”，但 App 升级产品能力还需要真实设备验收：
 
-- 目标 commit 的 Android CI Green
-- Debug APK 可用
-- release signing secrets 可用
-- assembleRelease Green
-- apksigner verify Green
-- server directory 可写
+- old production APK 发现 newer production；
+- 下载 / restart recovery；
+- SHA-256；
+- unknown-source permission；
+- same-signing-key in-place install；
+- 用户数据保留；
+- service failure non-blocking。
 
-升级功能额外验收：
-
-- `release-meta/latest.json` 公网可访问
-- JSON 指向 immutable APK
-- SHA-256 与服务器 APK 一致
-- 旧正式 APK 能发现更高 versionCode
-- 下载后校验成功才进入安装器
-- 签名一致，可完成覆盖安装
+该验收由 #102 跟踪。
 
 ---
 
-## 9. 历史故障
+## 11. Other Repository Workflows
 
-2026-08-26 Android Build Run #41 曾因 workflow 请求不存在的 `platforms;android-37` 在 SDK 安装阶段失败。现已统一到 SDK 36；该故障与业务代码无关。
+Hero / catalog / admin workflows 不属于 Android Production Release。
+
+完整职责见 `WORKFLOW_OWNERSHIP.md`：
+
+- `hero-admin.yml` — integrated resource-admin validation；
+- `hero-admin-deploy.yml` — production admin deployment；
+- `hero-assets-publish.yml` — Hero package validation；
+- `admin-batch-image-upload.yml` — batch image browser-contract validation；
+- `admin-prompt-library.yml` — prompt/copy-center validation；
+- `vehicle-catalog-admin-tools.yml` — catalog admin tools validation。
+
+不要因为多个 workflow 命中相同目录就自动判断它们重复；先看它们的 responsibility / deployment authority。
 
 ---
 
-## 10. 变更记录
+## 12. Repository Governance Relationship
 
-### v1.4.0
+- #75 — `main` protection + required current-head applicable CI；
+- #265 — stale branch cleanup + merge-time branch deletion；
+- `BRANCH_AND_PR_GOVERNANCE.md` — PR/branch/stack rules；
+- `WORKFLOW_OWNERSHIP.md` — workflow responsibility；
+- `CURRENT_STATUS_AUTHORITY.md` — 当前 runtime/PR/CI snapshot。
 
-- 正式版本改为仅在 Production Release 生成
-- Release 增加 `release_series`
-- server publish `latest.json` update manifest
-- latest.json 作为客户端最后原子发现指针
-- 增加 App release-only 自动检查 / 下载 / SHA 校验 / 系统安装流程
-- 新增 `APK_AUTO_UPDATE.md`
-
-### v1.3.0
-
-- Gradle Wrapper 已实际提交
-- SDK 统一到项目 SDK 36
-- CI / Release 统一使用仓库 wrapper
+仓库保护未真正启用前，不得因为文档写了“必须 CI”就假装 GitHub 已经强制执行。

--- a/docs/CURRENT_STATUS_AUTHORITY.md
+++ b/docs/CURRENT_STATUS_AUTHORITY.md
@@ -63,39 +63,39 @@ Current product/data authority:
 
 #### PR #258 — pure calculation contract
 
-Snapshot at this baseline:
+Current parent state at this snapshot:
 
 - Draft;
-- head `2d9de0c666f56bc5b0e5f56e71afce0f1763eda0`;
-- own diff remains engine + focused test only;
-- Android Build #626 Green on that head;
-- comparison to baseline `main@e5149a6` shows it is **11 commits behind current `main`**.
+- current head `b506b749a6cea7041b4825b80b83ed9455b4196e`;
+- comparison to baseline `main@e5149a6` is **ahead 10 / behind 0**;
+- effective diff remains only `ChargeCalculationEngine.kt` + focused test;
+- prior head Android Build #626 was Green;
+- synchronized-head Android Build #637 is running at the time of this snapshot.
 
-The numerical behind-count is only a snapshot and will change as `main` moves. The durable rule is: #258 is not merge-ready until it is synchronized/revalidated against current `main`, its effective diff is re-read and current-head Android CI is Green.
+Durable merge gate: the current synchronized head needs successful current-head Android CI and unchanged intended diff before Ready/Merge. Historical #626 Green does not authorize the new head.
 
 #### PR #261 — stacked Add/Edit billing adoption
 
-Snapshot:
+Current child state:
 
 - Draft;
-- base = #258 branch;
-- head `c805ba3150576b57dc2cd74631edc09e0a8b8c44`;
-- 7 commits ahead / 0 behind its current #258 parent;
-- Android Build #630 Green on the stacked head;
-- actual diff includes `ChargeBillingEditorState`, focused tests, `AddRecordScreen.kt` adoption and `RecordEditScreen.kt` adoption.
-
-The earlier description that #261 did not yet modify Add/Edit forms was stale and has been corrected.
+- child head `c805ba3150576b57dc2cd74631edc09e0a8b8c44`;
+- base branch name is still the #258 calculation branch;
+- the child was built against the older #258 parent head;
+- Android Build #630 was Green for that older stack relationship;
+- after #258 synchronized to current `main`, comparison to the **new parent branch** is now diverged/behind;
+- intended child diff remains editor state/tests plus `AddRecordScreen.kt` and `RecordEditScreen.kt` adoption.
 
 Required order:
 
-1. synchronize/revalidate #258 against current `main`;
-2. review/merge #258 first;
-3. retarget #261 to `main`;
-4. re-read #261 changed files/diff against `main`;
-5. obtain current-head Android CI after effective base/head changes;
+1. finish current-head validation/review for #258;
+2. resolve/merge #258 first;
+3. normalize #261 onto the surviving `main` base using the normal code-maintenance workflow;
+4. re-read #261 effective diff;
+5. obtain current-head Android CI for the normalized child;
 6. only then decide Ready/Merge for #261.
 
-Do not delete the #258 branch while #261 depends on it.
+Do not delete the #258 branch while #261 still depends on it.
 
 ### Vehicle maturity / catalog / resource onboarding — #244 and #20
 
@@ -109,7 +109,7 @@ Already in `main` before #264:
 - range-standard metadata;
 - catalog JSON/CSV import/export and template;
 - managed Hero semantic key selection;
-- batch Brand Logo / Hero upload helpers;
+- batch Brand Logo / Hero helpers;
 - copyable Logo/Hero standards and prompt center.
 
 Merged PR #264 further advanced the resource workflow:
@@ -128,7 +128,7 @@ Merged PR #264 further advanced the resource workflow:
 
 Current product/admin authority: `RESOURCE_BUNDLE_WORKFLOW.md`, owner #244.
 
-#244 therefore owns remaining real workflow/device maturity, not implementation of another disconnected Logo/Hero/catalog onboarding system.
+#244 owns remaining real workflow/device maturity, not implementation of another disconnected Logo/Hero/catalog onboarding system.
 
 #20 remains the data-quality owner: provenance, normalization, conflicts/corrections, broader real-model coverage and coverage metrics. The unified one-vehicle workbench does not replace bulk catalog data-quality work.
 
@@ -225,7 +225,7 @@ Completed in the 2026-08-31 audit:
 - README/LICENSE/templates/branch-stack rules merged by #263;
 - #75 rewritten to exact current branch-protection/CI target;
 - #265 created for stale-branch cleanup/merge-time deletion;
-- #258/#261/#260/#251 descriptions synchronized to actual stacked state;
+- #258/#261/#260/#251 descriptions synchronized to actual stacked behavior;
 - PR #264 resource workbench / Hero theme-variant baseline incorporated into current authority.
 
 Remaining documentation debt after this authority-sync PR:

--- a/docs/CURRENT_STATUS_AUTHORITY.md
+++ b/docs/CURRENT_STATUS_AUTHORITY.md
@@ -2,16 +2,16 @@
 
 Updated: 2026-08-31
 Status: Operational status authority
-Baseline: `main@81b50a5b15408bac7bb998041d0681426c829c61`
+Baseline: `main@e5149a6474a17c7a5ce0a987f04fc3ab38a143b0`
 
 ## Purpose
 
-This file owns **fast-changing project execution status**. Stable product and architecture principles remain in `PROJECT_MASTER.md` and the domain-specific authority documents.
+This file owns **fast-changing project execution status**. Stable product and architecture principles remain in `PROJECT_MASTER.md` and domain-specific authority documents.
 
 When status sources disagree, use this order:
 
 1. current `main` implementation facts and persisted schemas;
-2. merged PR / CI evidence;
+2. merged PR / current-head CI evidence;
 3. this current-status authority;
 4. owning Open Issue for remaining acceptance or future work;
 5. older roadmap/history/versioned design text.
@@ -24,26 +24,29 @@ An Open Issue does not imply missing code. A Draft/unmerged PR is not runtime au
 
 Merged PR #263 established:
 
-- current root README as a stable project entrypoint instead of a stale MVP checklist;
-- root MIT `LICENSE` matching the repository's declared license intent;
+- root README as a stable project entrypoint instead of a stale pre-Room/MVP checklist;
+- root MIT `LICENSE`;
 - `.github/PULL_REQUEST_TEMPLATE.md`;
 - evidence-first Bug / Feature / Documentation-Governance Issue templates;
 - `docs/BRANCH_AND_PR_GOVERNANCE.md` for branch lifecycle, stacked PRs and merge evidence.
 
 ### Remaining repository-setting gaps
 
-- `main` is still not branch-protected;
-- required status checks are still empty;
-- repository rulesets are empty;
-- `delete_branch_on_merge` is still false;
-- the 2026-08-31 branch audit returned 192 remote branch refs across two pages.
+Current repository metadata still reports:
+
+- `main` not branch-protected;
+- required status checks empty;
+- repository rulesets empty;
+- `delete_branch_on_merge = false`.
+
+The 2026-08-31 branch audit returned 192 remote branch refs across two pages.
 
 Ownership:
 
 - #75 — `main` protection + current-head required Android CI policy;
 - #265 — stale remote branch cleanup + merge-time branch deletion.
 
-The current ChatGPT GitHub connection can read these repository states but does not expose ruleset/protection writes or remote-ref deletion. #75/#265 must not be closed until GitHub metadata itself confirms the settings/cleanup.
+The connected GitHub tool can read these states but currently exposes neither branch-protection/ruleset writes nor remote-ref deletion. #75/#265 must not be closed until GitHub metadata itself confirms the change.
 
 ## Active delivery streams
 
@@ -60,19 +63,19 @@ Current product/data authority:
 
 #### PR #258 — pure calculation contract
 
-Current status:
+Snapshot at this baseline:
 
 - Draft;
 - head `2d9de0c666f56bc5b0e5f56e71afce0f1763eda0`;
-- only engine + focused test files in its own diff;
+- own diff remains engine + focused test only;
 - Android Build #626 Green on that head;
-- current repository comparison shows the branch is **10 commits behind current `main`**.
+- comparison to baseline `main@e5149a6` shows it is **11 commits behind current `main`**.
 
-Therefore the old “behind by 0” claim is stale. #258 must synchronize with current `main`, re-check its effective diff and obtain current-head CI after synchronization before Ready/Merge.
+The numerical behind-count is only a snapshot and will change as `main` moves. The durable rule is: #258 is not merge-ready until it is synchronized/revalidated against current `main`, its effective diff is re-read and current-head Android CI is Green.
 
 #### PR #261 — stacked Add/Edit billing adoption
 
-Current status:
+Snapshot:
 
 - Draft;
 - base = #258 branch;
@@ -94,31 +97,46 @@ Required order:
 
 Do not delete the #258 branch while #261 depends on it.
 
-### Vehicle maturity / catalog — #244 and #20
+### Vehicle maturity / catalog / resource onboarding — #244 and #20
 
-Already in `main`:
+Already in `main` before #264:
 
 - user vehicle nickname and nickname-first display;
 - managed-catalog-only primary add flow;
 - standard vehicle facts read-only in Android;
-- removal of Android supported-model hard-code as product authority;
 - managed brand metadata / stable `brandId`;
 - managed Light/Dark Brand Logo publishing and Android cached rendering;
-- vehicle switchers show managed Logo + nickname/fallback;
 - range-standard metadata;
-- JSON/CSV catalog import/export and template;
-- managed Hero-key selection;
-- filename-prefix batch Brand Logo / Hero upload;
-- copyable Logo/Hero standards and prompt center;
-- #259 Brand Logo batch-upload simplification and light-card contrast correction.
+- catalog JSON/CSV import/export and template;
+- managed Hero semantic key selection;
+- batch Brand Logo / Hero upload helpers;
+- copyable Logo/Hero standards and prompt center.
 
-#244 is implementation-mostly-complete and now owns remaining maturity/physical acceptance. #20 owns provenance, normalization/conflict quality and broader real-model coverage, not a second catalog runtime/import architecture.
+Merged PR #264 further advanced the resource workflow:
+
+- unified `车型资源工作台` for one-vehicle resource-bundle onboarding;
+- one resource-bundle JSON carrying one managed brand + one vehicle plus coordinated assets;
+- mixed Logo/Hero multi-file queue with automatic matching as suggestion only and explicit manual correction;
+- duplicate/shared Hero-key review with explicit update confirmation;
+- all-in-one full asset-bundle prompt while retaining the single-item prompt library;
+- stable base `heroArtworkKey` with published `<base>-dark` / `<base>-light` variants;
+- Android Hero resolution with backward-compatible fallback:
+  - Dark: `<base>-dark -> legacy <base>`;
+  - Light: `<base>-light -> <base>-dark -> legacy <base>`;
+- old split batch Logo/Hero panels retired from the main admin UI; single-item maintenance remains;
+- new `Admin Resource Workbench` CI contract.
+
+Current product/admin authority: `RESOURCE_BUNDLE_WORKFLOW.md`, owner #244.
+
+#244 therefore owns remaining real workflow/device maturity, not implementation of another disconnected Logo/Hero/catalog onboarding system.
+
+#20 remains the data-quality owner: provenance, normalization, conflicts/corrections, broader real-model coverage and coverage metrics. The unified one-vehicle workbench does not replace bulk catalog data-quality work.
 
 ### Trip background/location reliability — #77
 
 Current `main` includes:
 
-- #80 removal of the old 8m callback displacement gate;
+- #80 removal of old 8m callback displacement gate;
 - #184 delayed-delivery grace while preserving original `Location.time` authority and 120s LONG_GAP;
 - #217 Google Play Fused production source;
 - #220 non-GMS platform GPS/network fallback;
@@ -168,18 +186,19 @@ Updater runtime includes release discovery, DownloadManager, SHA-256, installer 
 
 Detailed trigger/ownership boundaries are documented in `WORKFLOW_OWNERSHIP.md`.
 
-High-level split:
+At this baseline there are **nine** workflow files:
 
 - `android-build.yml` — Android PR/push validation + Debug APK artifact;
 - `android-release.yml` — manual production signed APK publish path;
-- `hero-admin.yml` — resource-admin application/container/lifecycle validation;
-- `hero-admin-deploy.yml` — production deployment of the resource admin on main push;
+- `hero-admin.yml` — integrated resource-admin application/container/lifecycle validation;
+- `hero-admin-deploy.yml` — production resource-admin deployment on qualifying `main` push;
 - `hero-assets-publish.yml` — Hero asset package validation;
-- `admin-batch-image-upload.yml` — batch-image browser-contract validation;
-- `admin-prompt-library.yml` — copy/prompt-library contract validation;
-- `vehicle-catalog-admin-tools.yml` — catalog admin browser/import-export contract validation.
+- `admin-resource-workbench.yml` — unified vehicle resource-bundle workbench contract validation;
+- `admin-batch-image-upload.yml` — retained focused/legacy batch-helper regression contract, not preferred new-model onboarding authority;
+- `admin-prompt-library.yml` — single-item + full-bundle prompt/index contract validation;
+- `vehicle-catalog-admin-tools.yml` — catalog admin/import-export browser-contract validation.
 
-These workflows overlap by changed paths intentionally but do not have the same responsibility.
+These workflows overlap by paths intentionally but do not have the same responsibility. Validation, resource publication through existing admin endpoints and production admin deployment are distinct states.
 
 ## Authority maintenance rules
 
@@ -193,6 +212,7 @@ These workflows overlap by changed paths intentionally but do not have the same 
 8. No broad reimplementation may start from an old Issue before checking current `main` and merged PR history.
 9. Stacked parent branches remain until every Open child is safely retargeted.
 10. Historical Green CI does not authorize merge after effective head/base changes.
+11. When an admin surface is superseded, its old workflow must be explicitly treated as retained regression coverage or retired; existence of a workflow file does not make that old UI the current product authority.
 
 ## Current governance queue
 
@@ -205,12 +225,11 @@ Completed in the 2026-08-31 audit:
 - README/LICENSE/templates/branch-stack rules merged by #263;
 - #75 rewritten to exact current branch-protection/CI target;
 - #265 created for stale-branch cleanup/merge-time deletion;
-- #258/#261/#260/#251 descriptions synchronized to actual stacked state.
+- #258/#261/#260/#251 descriptions synchronized to actual stacked state;
+- PR #264 resource workbench / Hero theme-variant baseline incorporated into current authority.
 
-Remaining documentation debt:
+Remaining documentation debt after this authority-sync PR:
 
-- reconcile dated `ROADMAP.md` milestone narrative without turning it into an hourly status log;
-- reconcile `PROJECT_MASTER.md` present-tense runtime wording where it conflicts with this file;
 - reconcile older Trip/UI acceptance Issues that still call historical SHAs “latest main”;
 - narrow old #70 local-Hero/model-whitelist wording to physical visual closeout;
 - add explicit supersession/version notes to older docs that still look current.

--- a/docs/CURRENT_STATUS_AUTHORITY.md
+++ b/docs/CURRENT_STATUS_AUTHORITY.md
@@ -2,47 +2,97 @@
 
 Updated: 2026-08-31
 Status: Operational status authority
-Baseline: `main@2ca393490fcd027e016261cf09c383cd70387de8`
+Baseline: `main@81b50a5b15408bac7bb998041d0681426c829c61`
 
 ## Purpose
 
-This file owns fast-changing project execution status. Stable product and architecture principles remain in `PROJECT_MASTER.md` and the domain-specific authority documents.
+This file owns **fast-changing project execution status**. Stable product and architecture principles remain in `PROJECT_MASTER.md` and the domain-specific authority documents.
 
 When status sources disagree, use this order:
 
 1. current `main` implementation facts and persisted schemas;
 2. merged PR / CI evidence;
 3. this current-status authority;
-4. owning open Issue for remaining acceptance or future work;
-5. older roadmap/history text.
+4. owning Open Issue for remaining acceptance or future work;
+5. older roadmap/history/versioned design text.
 
-An open Issue does not imply missing code. A draft/unmerged PR is not runtime authority.
+An Open Issue does not imply missing code. A Draft/unmerged PR is not runtime authority. CI Green is not physical acceptance.
 
 ## Current repository governance
 
-- `main` is currently not branch-protected and has no required status checks. #75 remains a valid repository-governance issue.
-- Code, CI, physical functional acceptance, physical visual acceptance and Production Release acceptance are distinct states.
-- Physical acceptance must never be inferred from CI Green.
-- Implementation issues that are fully merged should not remain written as future implementation work. If physical acceptance is still needed, move that responsibility to an explicit acceptance owner or rewrite the Issue as physical-only.
+### Implemented governance baseline
+
+Merged PR #263 established:
+
+- current root README as a stable project entrypoint instead of a stale MVP checklist;
+- root MIT `LICENSE` matching the repository's declared license intent;
+- `.github/PULL_REQUEST_TEMPLATE.md`;
+- evidence-first Bug / Feature / Documentation-Governance Issue templates;
+- `docs/BRANCH_AND_PR_GOVERNANCE.md` for branch lifecycle, stacked PRs and merge evidence.
+
+### Remaining repository-setting gaps
+
+- `main` is still not branch-protected;
+- required status checks are still empty;
+- repository rulesets are empty;
+- `delete_branch_on_merge` is still false;
+- the 2026-08-31 branch audit returned 192 remote branch refs across two pages.
+
+Ownership:
+
+- #75 — `main` protection + current-head required Android CI policy;
+- #265 — stale remote branch cleanup + merge-time branch deletion.
+
+The current ChatGPT GitHub connection can read these repository states but does not expose ruleset/protection writes or remote-ref deletion. #75/#265 must not be closed until GitHub metadata itself confirms the settings/cleanup.
 
 ## Active delivery streams
 
 ### Charging v0.7 — parent #251
 
-Current product authority:
+Current product/data authority:
 
-- #251 parent workflow and data-truth rules
-- `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`
-- #252 coupled-field calculation / derived metrics
-- #253 optional active charging session / preset lifecycle
-- #254 current-location default / future map-point picker
+- #251 parent workflow and truth rules;
+- `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`;
+- #252 coupled calculation / derived metrics;
+- #260 Add/Edit linked billing adoption;
+- #253 optional active charging session / preset lifecycle;
+- #254 current-location behavior / future map-point picker.
 
-Current implementation stage:
+#### PR #258 — pure calculation contract
 
-- PR #258 is a Draft first code slice for #252.
-- #258 establishes the pure calculation-engine contract only; it does not yet wire Add/Edit UI state or active-session persistence.
-- #252 therefore remains open after that domain slice until the editing state adopts the centralized rules and its acceptance examples are satisfied.
-- #253 and #254 remain valid future implementation owners.
+Current status:
+
+- Draft;
+- head `2d9de0c666f56bc5b0e5f56e71afce0f1763eda0`;
+- only engine + focused test files in its own diff;
+- Android Build #626 Green on that head;
+- current repository comparison shows the branch is **10 commits behind current `main`**.
+
+Therefore the old “behind by 0” claim is stale. #258 must synchronize with current `main`, re-check its effective diff and obtain current-head CI after synchronization before Ready/Merge.
+
+#### PR #261 — stacked Add/Edit billing adoption
+
+Current status:
+
+- Draft;
+- base = #258 branch;
+- head `c805ba3150576b57dc2cd74631edc09e0a8b8c44`;
+- 7 commits ahead / 0 behind its current #258 parent;
+- Android Build #630 Green on the stacked head;
+- actual diff includes `ChargeBillingEditorState`, focused tests, `AddRecordScreen.kt` adoption and `RecordEditScreen.kt` adoption.
+
+The earlier description that #261 did not yet modify Add/Edit forms was stale and has been corrected.
+
+Required order:
+
+1. synchronize/revalidate #258 against current `main`;
+2. review/merge #258 first;
+3. retarget #261 to `main`;
+4. re-read #261 changed files/diff against `main`;
+5. obtain current-head Android CI after effective base/head changes;
+6. only then decide Ready/Merge for #261.
+
+Do not delete the #258 branch while #261 depends on it.
 
 ### Vehicle maturity / catalog — #244 and #20
 
@@ -51,88 +101,116 @@ Already in `main`:
 - user vehicle nickname and nickname-first display;
 - managed-catalog-only primary add flow;
 - standard vehicle facts read-only in Android;
-- removal of Android supported-model hard-code as the product authority;
+- removal of Android supported-model hard-code as product authority;
 - managed brand metadata / stable `brandId`;
-- managed light/dark Brand Logo publishing and Android cached rendering;
+- managed Light/Dark Brand Logo publishing and Android cached rendering;
 - vehicle switchers show managed Logo + nickname/fallback;
 - range-standard metadata;
 - JSON/CSV catalog import/export and template;
 - managed Hero-key selection;
 - filename-prefix batch Brand Logo / Hero upload;
 - copyable Logo/Hero standards and prompt center;
-- PR #259 simplified Brand Logo batch upload and restored light-card contrast.
+- #259 Brand Logo batch-upload simplification and light-card contrast correction.
 
-#244 must be treated as implementation-mostly-complete and should track only remaining acceptance/data gaps, not repeat unchecked implementation tasks.
-
-#20 remains valid for catalog provenance, broader real-model coverage, normalization/conflict quality and coverage metrics. Its old “build CSV/JSON bulk import” item is now implemented and must not remain an active task.
+#244 is implementation-mostly-complete and now owns remaining maturity/physical acceptance. #20 owns provenance, normalization/conflict quality and broader real-model coverage, not a second catalog runtime/import architecture.
 
 ### Trip background/location reliability — #77
 
-Current `main` is materially newer than the old post-#184 baseline. Implemented after that baseline includes:
+Current `main` includes:
 
-- Google Play Fused production source (#217);
-- non-GMS/platform GPS + network fallback (#220);
-- ~1 Hz active Trip location target and ~2 s stationary heartbeat (#226);
-- trusted-speed-first stationary distance handling (#231);
-- silent-provider recovery: platform no longer trusts framework `fused`, and Google Fused falls back after a 12 s no-callback watchdog (#234).
+- #80 removal of the old 8m callback displacement gate;
+- #184 delayed-delivery grace while preserving original `Location.time` authority and 120s LONG_GAP;
+- #217 Google Play Fused production source;
+- #220 non-GMS platform GPS/network fallback;
+- #226 ~1 Hz active Trip location target and faster stationary transition handling;
+- #231 trusted-speed-first stationary distance handling;
+- #234 silent-provider recovery with platform-provider restrictions and Google Fused watchdog fallback.
 
 Truth boundaries remain:
 
-- original `Location.time` is authoritative;
+- original `Location.time` is capture-time authority;
 - no synthetic route points;
-- `LONG_GAP_SECONDS = 120` remains a hard continuity boundary;
+- `LONG_GAP_SECONDS = 120` is a hard continuity boundary;
 - stationary GNSS drift must not become distance.
 
-#77 remains open for current-main physical lock-screen/background/provider-loss acceptance. #203 no longer owns a missing Fused migration; that implementation is complete and its remaining physical responsibility belongs in #77.
+#77 remains Open for current-main physical lock-screen/background/provider-loss acceptance. Closed #203 no longer owns a missing Fused migration.
 
 ### Bluetooth-triggered Trip — #235
 
-Current `main` has advanced beyond the original exploration-only baseline:
+Already in `main`:
 
-- #239: auto-trip mode/state/reason model + pure eligibility policy;
-- #241: persisted per-vehicle Bluetooth detection sessions, dedupe, ignore handling and notification entry flow;
-- #242: explicit per-vehicle `蓝牙连接后自动开始行程` option routed through `TripStartCoordinator`, with location/notification/active-Trip guards.
+- #239 auto-trip mode/state/reason model + eligibility policy;
+- #241 persisted per-vehicle Bluetooth detection sessions, dedupe, ignore handling and notification entry flow;
+- #242 explicit per-vehicle Bluetooth auto-start option routed through `TripStartCoordinator` with location/notification/active-Trip guards.
 
-Therefore any document or Issue that still says auto-start is wholly unimplemented is stale.
+#235 remains Open for OEM/background physical acceptance, trigger-quality policy, verified-movement evaluation and possible later parking-assistant work. Bluetooth connection alone is not proven driving evidence.
 
-#235 remains open for real-device/OEM/background acceptance, trigger-quality policy and later verified-movement / parking-assistant work. Bluetooth connection alone must not be documented as proven driving evidence.
+### Trip interaction / analysis
 
-### Trip interaction / analysis follow-ups
+Already in `main`:
 
-Already implemented in `main`:
+- route pan/pinch/reset and trusted-speed route encoding (#219/#221/#230);
+- trend pan/zoom/tap and stock-style long-press drag inspection (#218/#227);
+- smoother SOC wheel behavior (#230);
+- uncertainty-aware altitude filtering (#228/#232);
+- recent-completed-Trip consumption input for end-SOC estimator (#213);
+- truthful trajectory playback engine/UI (#198/#201).
 
-- interactive route pan/pinch/reset and trusted-speed route encoding (#219/#221/#230);
-- interactive trend pan/zoom/tap and stock-style long-press drag inspection (#218/#227);
-- smoother SOC wheel gesture behavior (#230);
-- uncertainty-aware altitude filtering for completed and active trends (#228/#232);
-- recent-consumption-based Trip end-SOC estimator seed (#213).
-
-Remaining map work under #192/#199 is specifically basemap/provider/context validation, road labels, licensing/attribution, China-region behavior and truthful fallback — not basic pan/zoom.
+Remaining map work under #192/#199 is basemap/provider/context validation, road labels, licensing/attribution, mainland-China usefulness and truthful fallback — not basic pan/zoom.
 
 ### Updater
 
-Updater runtime has continued beyond the early #102 description, including non-blocking DownloadManager behavior, prompt dedupe and persisted recovery of an install-ready download after process restart (#247).
+Updater runtime includes release discovery, DownloadManager, SHA-256, installer handoff, prompt dedupe and #247 persisted recovery of download/install-ready state across process restart.
 
-#102 remains valid only as the physical production old-APK -> new-APK in-place upgrade acceptance owner. It must not be read as evidence that updater root wiring is still missing.
+#102 remains valid only as the production old-APK -> new-APK physical in-place-upgrade acceptance owner.
+
+## GitHub Actions workflow ownership
+
+Detailed trigger/ownership boundaries are documented in `WORKFLOW_OWNERSHIP.md`.
+
+High-level split:
+
+- `android-build.yml` — Android PR/push validation + Debug APK artifact;
+- `android-release.yml` — manual production signed APK publish path;
+- `hero-admin.yml` — resource-admin application/container/lifecycle validation;
+- `hero-admin-deploy.yml` — production deployment of the resource admin on main push;
+- `hero-assets-publish.yml` — Hero asset package validation;
+- `admin-batch-image-upload.yml` — batch-image browser-contract validation;
+- `admin-prompt-library.yml` — copy/prompt-library contract validation;
+- `vehicle-catalog-admin-tools.yml` — catalog admin browser/import-export contract validation.
+
+These workflows overlap by changed paths intentionally but do not have the same responsibility.
 
 ## Authority maintenance rules
 
 1. Update the owning Issue whenever implementation stage changes.
 2. Close superseded implementation-only Issues when their code is merged and physical acceptance is owned elsewhere.
-3. Keep physical-only Issues explicitly labeled in their body as physical acceptance; do not leave unchecked implementation lists.
-4. Draft PRs may propose design, but they are not project authority until merged or explicitly adopted by an owning Issue.
+3. Keep physical-only Issues explicitly written as physical acceptance; do not leave stale implementation checklists.
+4. Draft PRs may propose implementation/design but are not runtime authority.
 5. `PROJECT_MASTER.md` owns stable architecture/product principles; this file owns fast-moving execution status.
-6. `ROADMAP.md` should describe ordering and milestones, but when its dated status lags this file, this file wins for current execution state.
-7. Historical design/reference documents remain useful only when their supersession boundary is explicit.
-8. No broad reimplementation may be started from an old Issue without first checking current `main` and merged PR history.
+6. `ROADMAP.md` owns milestone ordering. When its dated prose lags this file, this file wins for current execution state.
+7. Historical design/reference documents remain useful only when their version/supersession boundary is explicit.
+8. No broad reimplementation may start from an old Issue before checking current `main` and merged PR history.
+9. Stacked parent branches remain until every Open child is safely retargeted.
+10. Historical Green CI does not authorize merge after effective head/base changes.
 
-## Immediate governance queue
+## Current governance queue
 
-- reconcile #6 to this status authority and the 2026-08-31 baseline;
-- reconcile #77 and close/supersede #203 as a missing-implementation owner;
-- reconcile #235 and remove stale pre-implementation wording;
-- reconcile #244 and #20 with the merged catalog/Logo/batch-maintenance baseline;
-- reconcile #205 to mark recent historical-consumption estimator input implemented by #213;
-- reconcile #192 so basic route pan/zoom is marked implemented while provider/basemap remains open;
-- close or rewrite #222/#223/#224/#225 so merged implementation is not represented as future work;
-- keep #75 open while `main` remains unprotected.
+Completed in the 2026-08-31 audit:
+
+- #6 authority graph reconciled;
+- #203/#214/#222/#223/#224/#225 stale implementation Issues closed;
+- #77/#235/#244/#20/#192/#205/#102/#94/#215 rewritten to current responsibilities;
+- stale Draft PR #236/#255 closed without merge;
+- README/LICENSE/templates/branch-stack rules merged by #263;
+- #75 rewritten to exact current branch-protection/CI target;
+- #265 created for stale-branch cleanup/merge-time deletion;
+- #258/#261/#260/#251 descriptions synchronized to actual stacked state.
+
+Remaining documentation debt:
+
+- reconcile dated `ROADMAP.md` milestone narrative without turning it into an hourly status log;
+- reconcile `PROJECT_MASTER.md` present-tense runtime wording where it conflicts with this file;
+- reconcile older Trip/UI acceptance Issues that still call historical SHAs “latest main”;
+- narrow old #70 local-Hero/model-whitelist wording to physical visual closeout;
+- add explicit supersession/version notes to older docs that still look current.

--- a/docs/PROJECT_MASTER.md
+++ b/docs/PROJECT_MASTER.md
@@ -1,28 +1,52 @@
 # EV Charge Book 项目总纲（PROJECT MASTER）
 
-版本: v2.4.0
-更新时间: 2026-08-29
-状态: Authority Document / Single Source of Truth
+版本: v3.0.0
+更新时间: 2026-08-31
+状态: Stable product / architecture authority
 
-## 1. 项目定位
+## 1. 文档职责
 
-EV Charge Book 是新能源车主的 Local First 车辆数据中心。
+`PROJECT_MASTER.md` 只维护 **稳定产品定位、数据真值、架构边界和长期工程原则**。
 
-演进顺序:
+它不再承担“今天代码做到哪”“哪个 PR Green”“当前 head SHA 是什么”的高频状态职责。
 
-1. 充电记账与成本
-2. 多车辆与车型目录
-3. 位置 / 驾驶行程数据
-4. 充电与行程的数据闭环
-5. 本地分析与可靠性
-6. 跨设备同步 / 云恢复
-7. Web / AI 增值能力
+状态职责分工：
 
-首个验证车型为零跑 C16，但产品、数据库和 UI 不绑定单一品牌。
+- `CURRENT_STATUS_AUTHORITY.md` — 当前实现 / PR / Issue / CI / acceptance 快照；
+- `ROADMAP.md` — 产品里程碑与执行顺序；
+- domain authority — 具体模块设计；
+- merged PR / current `main` — 实现事实。
+
+当本文与 current `main` / `CURRENT_STATUS_AUTHORITY.md` 在“当前实现状态”上冲突时，以后者为准；本文继续约束产品/架构原则。
 
 ---
 
-## 2. 权威文档
+## 2. 项目定位
+
+EV Charge Book 是新能源车主的 **Local First 车辆数据与用车事实中心**。
+
+核心演进方向：
+
+1. 充电记账与真实成本；
+2. 多车辆与可维护车型目录；
+3. 位置 / 驾驶行程事实；
+4. Charge / Trip / VehicleState 数据闭环；
+5. 本地分析与数据可靠性；
+6. 可恢复、可解释的跨设备同步；
+7. 在真实数据基础上的可选 Web / AI 增值。
+
+首个重点验证车型可以是具体车型，但产品、数据库和 UI 不能绑定单一品牌或单一车型。
+
+---
+
+## 3. 权威文档体系
+
+### 当前状态
+
+- `CURRENT_STATUS_AUTHORITY.md`
+- `ROADMAP.md`
+
+### 产品 / 架构
 
 - `PRODUCT.md`
 - `FEATURE_MATRIX.md`
@@ -30,518 +54,299 @@ EV Charge Book 是新能源车主的 Local First 车辆数据中心。
 - `FRONTEND.md`
 - `BACKEND.md`
 - `DATABASE.md`
-- `CI_CD.md`
-- `APK_AUTO_UPDATE.md`
-- `ROADMAP.md`
 - `DEVELOPMENT.md`
 - `LOCATION_TRIP.md`
-- `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`
-- `TRIP_V0.6_APPROVED_UI_BASELINE.md`
-- `EVChargeBook_UI_Redesign_Task_Breakdown.md`
-- `VEHICLE_CATALOG_MULTI_VEHICLE.md`
 - `DATA_QUALITY_BACKUP.md`
 - `SYNC_PROTOCOL.md`
-- `LOCAL_AGENT_HANDOFF.md`
-- `NEXT_PHASE_DESIGN.md`
+- `VEHICLE_CATALOG_MULTI_VEHICLE.md`
 
-实现与文档冲突时，先以当前代码、CI 与真机事实为准，再修正文档。
+### CI / 发布 / 仓库治理
 
-阶段状态必须严格区分:
+- `CI_CD.md`
+- `APK_AUTO_UPDATE.md`
+- `BRANCH_AND_PR_GOVERNANCE.md`
+- `WORKFLOW_OWNERSHIP.md`
 
-- 代码已实现
-- Android CI Green
-- 真机功能验收
-- 真机视觉验收
-- Production Release 验收
+### 当前 domain authority
 
-不得用其中一个替代另一个；Open Issue 也不代表代码一定未实现。
+- `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`
+- `TRIP_V0.7_SOC_WHEEL_EDIT_DESIGN.md`
+- 版本化 UI baseline 文档仅对其明确版本/视觉范围负责。
 
----
-
-## 3. 产品原则
-
-- 简单可维护
-- Local First / Offline First
-- 真实数据来源
-- 用户录入成本低
-- 统计口径可解释
-- 原始事实 / 派生值 / 估算值明确区分
-- 不伪造实时 SOC / SOH / 续航
-- 定位记录与地图 SDK 解耦
-- GPS 缺失不通过假路线 / 假距离补齐
-- coordinates 是位置事实，address 是派生展示
-- 速度保留来源语义，不把 GNSS / derived / future OBD 混成无来源真值
-- notification 是后台状态可见性，不是 Trip 是否能记录的业务前置条件
-- 云同步不能成为 App 运行前提或唯一恢复路径
-- 正式 APK 版本只在真正执行 Production Release 时生成
+实现与文档冲突时：先检查 current `main` / merged PR / CI / 真机证据，再修正文档；不要为了维护旧文档而倒退实现。
 
 ---
 
-## 4. v0.1 - Local Charging Book
+## 4. 核心产品原则
 
-状态: **Released / Accepted**
-
-已完成:
-
-- Vehicle CRUD
-- ChargingRecord add/edit/delete
-- Dashboard / Records / Stats
-- ChargingRecordRules / ChargingStatistics
-- Android CI / Debug APK
-- 真机核心 CRUD
-- signed production APK / atomic release
+- **Local First / Offline First**：核心记账、车辆和 Trip 不能依赖网络才能工作。
+- **真实数据来源**：不伪造 live SOC / SOH / BMS / charger telemetry / GPS route。
+- **事实分层**：原始事实、用户确认值、派生值、估算值必须可区分。
+- **可解释**：成本、能耗、距离、速度、海拔、SOC 推导必须能解释输入与限制。
+- **可恢复**：本地备份长期保留；云端不能成为唯一恢复路径。
+- **低录入成本**：在不牺牲真值的情况下复用当前车辆、最近设置、真实位置等已有事实。
+- **渐进复杂度**：没有产品/数据证据时不引入重型框架、第二套状态系统或新服务。
+- **真机独立验收**：CI Green 不替代 physical functional / visual / Production acceptance。
 
 ---
 
-## 5. v0.2 - Vehicle, Location & Trip Foundation
+## 5. 事实模型
 
-状态: **Core Implemented / Physical Reliability Revalidation**
+### 5.1 Vehicle / Catalog
 
-### 5.1 已实现基础
+区分两类事实：
 
-- Multi Vehicle / selected vehicle context
-- managed/offline-first Vehicle Catalog baseline
-- Bluetooth selected-device -> Trip confirmation
-- Android LocationManager + WGS84
-- AddressResolver + Android Geocoder
-- TripSession / TripPoint
-- foreground tracking + ongoing notification
-- Trip start / completion / interrupted resume
-- distance / elapsed / moving / stopped / average / max speed
-- speed / bearing / altitude / accuracy
-- bad-point / jump filtering
-- route geometry / no-basemap truthful preview
-- Local Backup / Restore Trip coverage
+**标准车型参考事实**
 
-### 5.2 post-RC Trip reliability
+- brand / series / model year / trim；
+- battery/range 等公开规格；
+- Brand Logo / Hero artwork metadata；
+- 由 managed catalog 维护，用户侧只读。
 
-当前代码已经实现:
+**用户车辆事实**
 
-- runtime `TripGpsHealth`
-- WAITING / GOOD / DEGRADED / LOST / LONG_GAP
-- callback heartbeat 与 accepted-point heartbeat 分离
-- `lastLocationCallbackAt` 与 accepted-point evidence 分离诊断
-- provider / permission / service lifecycle / re-delivery evidence
-- LONG_GAP route segmentation
-- LONG_GAP 两端不计可信连续距离
-- foreground Location callback 使用 time-based liveness
-- `SAMPLE_DISTANCE_METERS = 0f`，不再依赖旧 8m displacement gate
-- stationary write throttling 保留在 `TripSamplingRules`（约 15s heartbeat）
-- coarse/network max-speed peak rejection
-- trusted speed-colored route
-- start/end 非纯颜色语义
+- nickname；
+- 当前 VehicleState；
+- 用户历史 Charge / Trip；
+- 已保存 snapshot。
 
-PR #80 已完成 8m callback gate 的代码修复并通过 Android CI；Issue #77 现在只负责真实设备上的“另一 App 前台 / 2-3 分钟 stationary hold / genuine callback-provider loss / stationary write volume”验收。
+Catalog 后续更新不能静默改写用户历史事实。Retire 车型可阻止未来选择，但不能删除已有用户车辆或历史。
 
-### 5.3 Trip altitude / validity
+Catalog reference data 不等于 VIN/BMS/live telemetry。
 
-已实现:
+### 5.2 VehicleState
 
-- start/end/min/max altitude
-- trusted elevation gain/loss
-- vertical accuracy filtering + jitter deadband
-- elevation 不跨 LONG_GAP 拼接
-- conservative Trip validity classification
-- invalid/empty completed Trip 不进入 Dashboard/aggregate
-- short real Trip 使用 REVIEW，不自动删除
-- 删除由用户明确确认
+VehicleState 代表当前车辆的本地事实状态，例如：
 
----
+- 当前已知 SOC；
+- 当前已知里程；
+- 事实来源与时间顺序。
 
-## 6. Trip 距离与速度事实模型
+Trip / Charge / manual update 应遵守明确的事件时间 authority。旧事件不得覆盖更新的真实事实。
 
-### 6.1 距离
+### 5.3 ChargingRecord
 
-Trip distance 是连续可信 accepted location point 的地理距离累计，不是道路里程或车辆轮速里程。
+ChargingRecord 表示已完成或历史补录的充电事实。
 
-LONG_GAP 两端不进入可信连续距离。原始 TripPoint 保留，派生统计只决定哪些证据可进入汇总。
+核心原则：
 
-### 6.2 速度
+- 用户可以独立维护历史记录；
+- `开始充电` 不能成为维护历史记录的强制入口；
+- cost / unit price / meter energy 的联动必须集中在 domain/editor state；
+- duration / average power / loss 只有输入充分且语义兼容时才派生；
+- SOC-derived vehicle energy 必须保持 estimate 语义。
 
-区分:
+未来 active charging session 可以是独立生命周期，但不能伪造 charger/BMS 实时遥测。
 
-- `Location.speed`: Android/GNSS 报告速度
-- derived segment evidence: 连续点距离/时间校验证据
-- whole-trip / moving average: 基于可信累计距离的派生统计
-- future OBD: 可选独立来源
+### 5.4 Location
 
-最高速度只允许可信 GPS evidence 更新。UI 应理解为“最高已记录可信速度”，不得宣称车辆真实绝对峰值。
+- WGS84 coordinates 是位置事实；
+- address 是 reverse-geocode 派生展示；
+- Geocoder 失败不能阻止坐标保存；
+- 用户手工地址不应在无显式动作时偷偷改写底层 coordinates；
+- map renderer 只是展示层，不能改写持久化位置事实。
 
-### 6.3 route speed visualization
+### 5.5 Trip
 
-当前 route 支持可信 GPS speed 颜色表达，同时保留:
+Trip 记录真实 accepted location evidence。
 
-- unknown/untrusted speed 中性语义
-- LONG_GAP 断开
-- legend / 区间说明
-- “本车速度，不代表道路拥堵”说明
+必须保持：
 
-不为了 route 外观提前引入道路吸附、限速/拥堵语义或 MapLibre 依赖。
+- 原始 capture timestamp authority；
+- accuracy / provider / speed trust；
+- `LONG_GAP` 硬连续性边界；
+- 不跨真实 gap 补造距离、速度或路线；
+- stationary GNSS drift 不得制造明显行驶距离；
+- raw TripPoint 可保留，派生统计决定哪些证据进入汇总；
+- route / trend / playback 不得创建新的持久化 Trip 事实。
+
+速度来源必须有语义：GNSS reported speed、derived evidence、future OBD 不混成无来源“真值”。
 
 ---
 
-## 7. v0.3 - Local Analytics & Data Reliability
+## 6. Android 架构边界
 
-状态: **Feature Complete / Incremental Follow-up Only**
-
-已实现:
-
-- charging interval odometer distance
-- cost / 100km estimate
-- charged kWh / 100km estimate
-- Trip + odometer coverage evidence
-- SOC confidence hints
-- monthly trends / month-over-month
-- charger type mix
-- ChargingPlace aggregation / common-place reuse
-- charging CSV analysis export
-- non-blocking anomaly hints
-- Local JSON Backup / Restore
-- Trip validity-aware analytics
-- Charge facts 与 Trip SOC-derived energy estimate 分层展示
-
-Issue #19 已完成关闭。
-
----
-
-## 8. v0.4 - Local First Sync & Catalog
-
-### 8.1 Sync Phase A
-
-已完成:
-
-- Vehicle `syncId` + `updatedAtEpochMillis`
-- ChargingRecord `syncId` + `updatedAtEpochMillis`
-- ChargingRecord tombstone
-- explicit Room migration / old identity generation
-- Backup / Restore sync metadata
-- active UI/analytics 排除 tombstone
-- pure JVM identity tests
-
-后续由 #27 继续:
-
-- protocol/schema runtime
-- Vehicle / ChargingRecord envelope
-- push/pull cursor
-- idempotent upsert
-- tombstone propagation
-- simple conflict rule
-- smallest HTTPS + Spring Boot monolith + PostgreSQL slice
-
-第一批不做 TripSession / TripPoint cloud sync、CRDT、微服务、MQ。
-
-### 8.2 Catalog
-
-managed catalog runtime + Android offline-first refresh 已实现。#20 剩余是 source provenance、bulk import/validation、normalization、coverage quality。
-
----
-
-## 9. v0.5 / v0.6 - Local Experience & Trip UI
-
-状态: **Code Baseline Implemented / Physical Closeout**
-
-### 9.1 Global UI
-
-已实现:
-
-- Dark First + persisted Light mode
-- Dashboard / Records / Stats / Trip / Vehicle 五一级页面
-- low-elevation / restrained-outline surface language
-- responsive metric grids
-- Dashboard dynamic Vehicle Hero
-- Dashboard recent Trip card
-- Records v0.6 dense ledger
-- Stats v0.6 compact analytics hierarchy
-
-#70/#94/#95/#159/#164/#165/#42/#22 保留真实设备视觉/可访问性 closeout。
-
-### 9.2 Trip v0.6 information architecture
-
-Trip v0.6 代码侧已完成，不再需要 broad redesign。
-
-当前页面/状态:
-
-1. Trip home/history
-2. READY preparation
-3. active/interrupted cockpit
-4. completion form
-5. completed detail `概览`
-6. completed detail `轨迹`
-7. completed detail `数据`
-
-已落地:
-
-- Trip home/history 与 READY 分离（PR #176）
-- dense truthful history rows
-- READY vehicle/SOC/mileage/GPS truth
-- restrained slide-to-start
-- active distance + trusted current speed hierarchy
-- active real route + speed/altitude trends
-- active primary metrics 去除重复 diagnostic facts
-- slide-to-end 直接进入唯一 compact completion form（PR #174）
-- completed overview + one endpoint card
-- completed detail `概览 / 轨迹 / 数据` split（#178 / PR #179）
-- completed start = green start/play
-- completed end = small red flag
-- active latest point = green current point
-- LONG_GAP route/trends 不插值
-- raw GPS diagnostics collapsed by default
-- unavailable route/altitude 使用 truthful empty state
-- 不加入 unsupported `充电` / `备注` / destination / fake basemap tabs
-
-Trip UI implementation authority:
-
-- `TRIP_V0.6_APPROVED_UI_BASELINE.md`
-- #145 parent
-- #168 device-fidelity corrections
-- #178 detail-section split
-
-当前 main 的 Trip UI behavior baseline 包含 PR #179；Android CI run `33198331727` Green。代码完成不能替代 #145/#168/#178 的真机 design-device comparison。
-
-### 9.3 Trip SOC / mileage / energy -> VehicleState
-
-当前代码已经实现:
-
-- start snapshot current SOC / mileage
-- explicit end SOC
-- optional validated end mileage
-- TripSession start/end SOC + mileage
-- positive trustworthy SOC drop 才估算 consumed energy
-- required inputs 足够才估算 kWh/100km
-- completion 更新 VehicleState
-- 删除 completed Trip 后 rebuild VehicleState
-- 后发生 Charge/manual VehicleState 继续保持 authority
-
-#124 负责真机数据闭环。
-
-### 9.4 Location / address
-
-已实现:
-
-- coordinates-first
-- Geocoder optional
-- AddressResolver 分离
-- successful geocode bounded cache
-- failed/blank geocode 不缓存
-
-#14 保留真机 permission / Geocoder / restore acceptance。
-
-### 9.5 Lock-screen / background Trip UX
-
-当前代码:
-
-- ongoing notification = elapsed + trusted persisted distance
-- notification tap / action -> active Trip
-- permission/provider loss -> `INTERRUPTED`
-- one-shot repair notification
-- repair 后用户显式 resume
-- Android 13+ notification permission 在 tracking 已开始后请求
-- notification denial 不回滚 Trip
-- lock screen 不显示精确坐标 / HOME / WORK
-- notification 不直接 complete Trip
-
-#26 保留真机 round-trip；#77 独立负责 callback/stationary reliability。
-
-### 9.6 Production updater
-
-已实现 discovery / DownloadManager / SHA-256 / unknown-source permission / Android installer / root wiring / Dashboard-style non-modal UI。
-
-#102 保留 old-production -> newer-production 真实覆盖升级验收。
-
----
-
-## 10. Map / destination / OBD 边界
-
-### Map
-
-当前真实 WGS84 route preview 已满足 Trip v0.6 数据可信展示。MapLibre 是 future optional renderer，不是当前完成门槛。
-
-### Destination
-
-#152 是 future capability。当前 Trip v0.6 不显示 destination selector / ETA / navigation preview / fake endpoint。
-
-### OBD-II
-
-OBD 仅作为 future optional adapter。首个 PoC 只验证标准 Vehicle Speed；不进入私有 CAN/BMS 逆向，不成为 Trip 必需依赖。
-
----
-
-## 11. 恢复与隐私
-
-- Local JSON Backup 长期保留
-- Cloud Sync 不是唯一恢复路径
-- restore 失败不得破坏当前数据
-- 持续定位必须可见
-- notification permission denial 不阻止 Trip tracking
-- ongoing notification 不显示精确坐标 / HOME / WORK
-- route share/export 前需要 Privacy Zone
-- future cloud Trip sync 需要明确产品与隐私设计
-
----
-
-## 12. CI / Release
-
-基线:
-
-- JDK 17
-- Android SDK 36
-- Build Tools 36.0.0
-- repository Gradle Wrapper
-- Android CI 与 Production Release 分离
-- 普通业务提交不生成新的正式版本号
-- Production Release 才生成正式 `versionCode/versionName`
-- release 最后原子发布 `release-meta/latest.json`
-
-近期关键 Trip/UI evidence:
-
-- PR #80 Android CI run `33083631555` Green: stationary callback implementation slice
-- PR #170 Build #482 Green: slider/trends/history/insets/endpoint corrections
-- PR #172 Build #485 Green: READY/active density
-- PR #174 Build #489 Green: compact completion flow
-- PR #176 Build #490 Green: home vs READY split
-- PR #179 Android CI run `33198331727` Green: completed detail sections
-
-这些证据只证明 automated build/test；physical acceptance 独立存在。
-
----
-
-## 13. 架构约束
-
-Android 保持简单单体:
+首选保持简单单体和清晰事实流：
 
 ```text
-Compose -> MainViewModel -> Repository/domain -> Room DAO -> Room
-TripTrackingService -> LocationManager -> sampling/trust -> Room
+Compose UI
+  -> ViewModel / UI state
+  -> Repository / domain rules
+  -> Room DAO / Room
+
+Trip foreground service
+  -> location source abstraction
+  -> trust / sampling / continuity rules
+  -> Room
 ```
 
-future sync 第一版:
+允许 provider adapter，例如 Google Fused / platform GPS-network fallback，但 provider abstraction 不能改变 persisted fact semantics。
+
+默认不引入：
+
+- 为了“架构完整”拆多 module Clean Architecture；
+- 无真实收益的 Hilt/Koin 重构；
+- 第二套 Trip tracking service；
+- 为 foreground Trip 再叠一套 WorkManager 状态机；
+- 为 UI 动画增加高频数据库写入。
+
+---
+
+## 7. Backend / Cloud 边界
+
+第一版云能力应保持：
 
 ```text
 Android Room
-   <-> HTTPS Sync API
-Spring Boot Monolith
-   -> PostgreSQL
+  <-> HTTPS Sync API
+Spring Boot monolith
+  -> PostgreSQL
 ```
 
-不要引入 Hilt/Koin、多 module Clean Architecture、微服务、MQ、第二套 Trip service 或为了 notification 增加 WorkManager。
+原则：
+
+- 云端是第二份恢复/多设备数据，不是 App 运行前提；
+- 第一批同步优先 Vehicle + ChargingRecord；
+- stable sync identity + idempotent upsert；
+- explicit tombstone；
+- 简单可解释冲突规则；
+- 服务端失败不破坏当前 Room 事实。
+
+默认不做：
+
+- 微服务；
+- MQ/Kafka；
+- CRDT；
+- realtime websocket sync；
+- 第一批 TripPoint cloud sync；
+- AI 自动改写账本事实。
 
 ---
 
-## 14. 当前执行顺序
+## 8. UI / UX 原则
 
-```text
-v0.5 physical acceptance bundle
-  -> #145 / #168 / #178 Trip v0.6 design-device comparison
-  -> #77 background / stationary Trip reliability
-  -> #124 Trip SOC -> VehicleState
-  -> #26 lock-screen + repair notification
-  -> #14 Location / Geocoder
-  -> #70 / #94 / #95 / #159 / #164 / #165 / #42 / #22 UI-device checks
-  -> #102 old-production -> new-production updater
-  -> only fix concrete device regressions
-  -> resume #27 minimal Local First sync
-  -> advance #20 catalog pipeline when justified
-  -> optional MapLibre / destination / OBD only when product evidence exists
-```
+- Dark First；Light mode 需要保持可读。
+- 信息密度靠 hierarchy / spacing，不靠极小字体。
+- 关键状态不能只靠颜色。
+- 320–360dp / large font / IME / TalkBack 是真实 closeout 场景。
+- finished Hero artwork 作为完整视觉资产使用；不要在 Compose 重建复杂极光/倒影/glow。
+- route / trends / playback 可以增强解释性，但不能为了“好看”伪造数据。
+- 驾驶状态 UI 优先显示少量可信事实，不做导航 App 式高噪音信息堆叠。
 
 ---
 
-## 15. 开发验收规则
+## 9. Notification / Background 原则
 
-每轮业务代码必须:
+Notification 是后台状态可见性，不是 Trip 数据事实本身。
 
-- Android Gradle test/build
-- current-head GitHub CI Green
-- owning Issue / PR 同步
-- execution-stage 变化同步 ROADMAP / PROJECT_MASTER
-- schema change 必须 explicit Migration
-- 不把“代码已写”标成“CI Accepted”
-- 不把 CI Green 标成“真机已验收”
-- GPS `COMPLETED` 不等于 continuity accepted
-- notification available 不等于 tracking data accepted
-- Open Issue 不等于“代码还没写”
+要求：
 
-正式 APK:
-
-- 不发布 -> 不升级正式版本
-- 需要下发 -> current-head CI Green -> manual Production Release
+- ongoing Trip 使用 foreground notification；
+- permission/provider loss 可进入显式 repair flow；
+- 修复后由用户明确恢复，不偷偷修改历史事实；
+- Android 13+ notification denial 不能回滚已合法开始的 Trip；
+- 锁屏通知默认不泄露精确坐标 / HOME / WORK；
+- 蓝牙连接只是候选触发信号，不自动等同“正在驾驶”；
+- 蓝牙断开不能直接静默完成 Trip。
 
 ---
 
-## 16. 当前 Issues
+## 10. Backup / Privacy
 
-### 代码主体已完成、等待真机/视觉验收
-
-- #14 Location / Geocoder
-- #22 top spacing / density
-- #26 background / lock-screen / repair notification
-- #42 accessibility / large font / small screen / state safety
-- #67 trajectory presentation device check
-- #70 core UI physical closeout
-- #77 background callback / stationary hold
-- #94 Dashboard dynamic Hero
-- #95 recent Trip card
-- #102 Production APK auto-update
-- #124 Trip SOC -> VehicleState
-- #145 Trip v0.6 parent design-device matrix
-- #146 Trip history density
-- #147 READY slide interaction
-- #148 active Trip cockpit live update
-- #149 completed overview
-- #150 route surface
-- #151 diagnostics/trends
-- #168 Trip device-fidelity corrections
-- #171 READY/active density
-- #173 completion form
-- #175 home vs READY
-- #178 completed detail tabs
-- #159/#164/#165 Records/Stats v0.6 physical closeout
-
-### Future / expansion
-
-- #27 Local First Sync Phase B / smallest cloud slice
-- #20 scalable Vehicle Catalog pipeline
-- #152 destination selection / pre-trip planning
-
-### Repository / maintenance
-
-- #6 authoritative docs ongoing maintenance
-- #75 main branch protection / required CI; requires repository administration, not a code PR
+- Local JSON Backup 长期保留；
+- schema 变化必须考虑 migration / backward compatibility；
+- restore 失败不得破坏当前有效数据；
+- active Trip / active charging session 的 restore 语义必须显式；
+- 坐标、家庭/公司地点等敏感位置不应被无必要上传或暴露；
+- future route share/export 需要 Privacy Zone / 明确隐私设计。
 
 ---
 
-## 17. 决策记录
+## 11. CI / Release 原则
 
-### v2.4.0
+阶段必须严格区分：
 
-- added Trip v0.6 approved UI baseline and implementation breakdown to authority set
-- reconciled master with current Trip home/READY/active/completion/detail architecture
-- recorded #178 / PR #179 `概览 / 轨迹 / 数据` detail split
-- recorded PR #80 stationary callback implementation as code-complete with #77 physical-only acceptance
-- aligned execution order with ROADMAP v2.8.0: Trip design-device closeout before feature expansion
-- clarified MapLibre / destination / OBD remain optional/future and are not Trip v0.6 blockers
+- Implemented；
+- CI Green；
+- Physical Functional Accepted；
+- Physical Visual Accepted；
+- Production Accepted。
 
-### v2.3.0
+Android 普通 CI：
 
-- reconciled reliability/data-quality work through #123/#127/#128/#129
-- recorded Trip SOC/mileage/energy -> VehicleState authority and #124
-- recorded Dashboard Hero / recent Trip (#96/#100)
-- recorded updater wiring/UI (#103/#126)
-- recorded lock-screen Trip progress, repair flow and notification permission semantics (#130/#131/#132)
-- moved execution to physical acceptance bundle before sync expansion
+- build/test Debug；
+- 不生成正式版本号；
+- 不发布 production metadata。
 
-### v2.2.0
+Production Release：
 
-- added `APK_AUTO_UPDATE.md` to authority
-- formalized Production Release-only version generation and atomic `latest.json`
+- 显式人工触发；
+- 使用 production signing；
+- versionCode 单调增加；
+- verify signed APK；
+- atomic publish update metadata；
+- old-production -> new-production 覆盖升级仍需独立真机验收。
 
-### v2.1.0
+详细流程见 `CI_CD.md` / `APK_AUTO_UPDATE.md` / `WORKFLOW_OWNERSHIP.md`。
 
-- promoted GPS continuity to P0 based on real Trip evidence
-- separated Location.speed / derived speed / average speed semantics
-- established OBD-II as optional future source
+---
 
-### v2.0.1
+## 12. Repository Governance 原则
 
-- added `SYNC_PROTOCOL.md` to authority
-- fixed first sync payload / idempotency / tombstone / conflict / cursor boundaries
+高频开发不能让旧分支、Draft PR、历史 Issue 变成伪权威。
+
+要求：
+
+- runtime code 通过 PR + current-head applicable CI；
+- `main` 目标状态为 protected；
+- merged/closed stale branch 定期清理；
+- stacked PR 显式 parent/base/merge order；
+- parent merge 后 child retarget + re-diff + current-head CI；
+- merged branch 在无 child dependency 后删除；
+- PR/Issue 模板明确 owning Issue、authority、evidence、physical acceptance、supersession。
+
+详细规则见 `BRANCH_AND_PR_GOVERNANCE.md`。当前仓库设置事实见 #75 / #265 / `CURRENT_STATUS_AUTHORITY.md`。
+
+---
+
+## 13. 可选未来能力边界
+
+### Map context
+
+只有 provider/style 在目标地区真实设备上证明价值后才引入 production basemap。现有 truthful no-basemap renderer 始终可作为 fallback。
+
+不做 road snapping 来“修饰”GPS 事实。
+
+### Destination
+
+没有真实 product capability 前，不显示 fake destination / ETA / navigation state。
+
+### OBD / higher-fidelity telemetry
+
+优先用户授权、稳定、可解释的数据源。
+
+不做：
+
+- 其他 App 私有数据绕过；
+- root/sandbox bypass；
+- 未验证的通用 CAN 逆向平台；
+- 让 OBD 成为 Trip 核心前置条件。
+
+### AI
+
+AI 可以解释、总结、提示，但不能无证据改写账本/Trip 原始事实。
+
+---
+
+## 14. 当前执行入口
+
+不要在本文件寻找今天的 PR/CI 状态。
+
+使用：
+
+- `CURRENT_STATUS_AUTHORITY.md` — 当前项目执行快照；
+- `ROADMAP.md` — 阶段与顺序；
+- owning Issue — 剩余验收或 future work；
+- current `main` / merged PR — 实现事实。
+
+本文件只有在稳定产品原则、事实语义或架构边界变化时才更新。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,349 +1,320 @@
 # EV Charge Book Roadmap
 
-版本: v2.8.2
-更新时间: 2026-08-29
+版本: v3.0.0
+更新时间: 2026-08-31
+状态: Milestone / sequencing authority
 
-## 0. 路线原则
+## 0. 文档职责
 
-以 `PROJECT_MASTER.md` / `PRODUCT.md` / `FEATURE_MATRIX.md` 为准。
+本文件只负责 **里程碑、阶段顺序和产品优先级**。
 
-继续坚持：简单可维护、Local First、真实数据、先验收后扩功能；原始事实、派生值与估算值必须区分。
+它不再维护高频 PR/commit/CI/head-SHA 状态。当前实现、Open PR stack、真机验收 owner 和仓库治理快照统一以 `CURRENT_STATUS_AUTHORITY.md` 为准。
 
-阶段状态必须区分：
+当本文件的日期晚于旧设计文档但早于 current-status snapshot 时：
 
-- 代码已实现
-- Android CI 已通过
-- 真机功能验收
-- 真机视觉验收
-- Production Release 验收
+- 产品阶段顺序仍以本文件为准；
+- “现在代码做到哪”以 `CURRENT_STATUS_AUTHORITY.md` / current `main` 为准；
+- Open Issue 不代表代码一定未实现；
+- CI Green 不等于真机或 Production Release 验收。
 
-不得用 CI Green 代替真机结论，也不得因为 Issue 仍然 Open 就重复实现已经进入 `main` 的代码。
+路线原则：简单可维护、Local First、真实数据、先验收后扩功能；原始事实、派生值与估算值必须明确区分。
 
 ---
 
-## v0.1 - Local Charging Book
+## v0.1 — Local Charging Book
 
 状态: **Released / Accepted**
 
-- [x] Room / DAO / Repository / ViewModel
-- [x] 车辆创建 / 编辑持久化
-- [x] 充电记录新增 / 编辑 / 删除
-- [x] Dashboard / Records / Stats
-- [x] Android CI / Debug APK
-- [x] 真机核心 CRUD 验收
-- [x] signed production APK / atomic server release
+目标：建立离线可用的车辆与充电记账基础。
+
+稳定能力：
+
+- Vehicle / ChargingRecord 本地持久化；
+- 充电记录新增、编辑、删除；
+- Dashboard / Records / Stats 基础；
+- 本地数据恢复基础；
+- Android Debug / Production Release 基础链路。
+
+本阶段不再作为活跃开发 owner。
 
 ---
 
-## v0.2 - Vehicle, Location & Trip Foundation
+## v0.2 — Vehicle, Location & Trip Foundation
 
-状态: **Core Implemented / Post-#184 Physical Reliability Revalidation**
+状态: **Core Implemented / Physical Reliability Closeout**
 
-### Trip / Location 基础
+目标：建立真实、可解释的驾驶行程事实层。
 
-- [x] TripSession / TripPoint + Room migration
-- [x] manual start / completion / interrupted resume
-- [x] foreground location service + persistent notification
-- [x] WGS84 / accuracy / speed / bearing / altitude
-- [x] distance / elapsed / moving / stopped / average / max speed
-- [x] runtime GPS health / callback heartbeat / accepted-point heartbeat
-- [x] `lastLocationCallbackAt` 与 `lastAcceptedPointAt` 分离诊断
-- [x] GPS / Network provider fallback
-- [x] provider / permission / service lifecycle diagnostics
-- [x] `START_REDELIVER_INTENT` evidence
+稳定方向：
 
-### GPS continuity / data trust
+- TripSession / TripPoint；
+- foreground tracking；
+- WGS84 坐标、速度、方向、海拔、accuracy；
+- distance / elapsed / moving / stopped / average / max；
+- provider / callback / accepted-point diagnostics；
+- `LONG_GAP` 断点与不补造距离原则；
+- Fused + non-GMS/provider fallback；
+- truthful route / speed / altitude presentation；
+- interruption / resume / repair notification。
 
-- [x] callback registration 改为 time-based liveness，不再依赖 8m system displacement gate（PR #80）
-- [x] stationary TripPoint 继续由 app-level 15s throttling 控制
-- [x] 2026-08-29 新锁屏证据后，delayed callback freshness 从 15s 放宽到 10min（PR #184）
-- [x] delayed fix 仍使用原始 `location.time`，倒序 historical point 继续拒绝
-- [x] `LONG_GAP_SECONDS = 120` 未因 callback grace 放宽；真实 capture-time long gap 两端仍不累计可信距离/时长/速度
-- [x] PR #184 Android CI run `33229162800` Green，merged as `bae3a21`
-- [x] long gap 在 route preview 中保持断开，不画假实线
-- [x] GPS health 区分 WAITING / GOOD / DEGRADED / LOST / LONG_GAP
-- [x] coarse/network provider 不直接制造 Trip max-speed peak
-- [x] extreme GPS peak 缺失 `speedAccuracy` 时不进入可信 max speed
-- [x] raw TripPoint 保留，不通过派生统计“清洗掉”原始证据
-- [x] 轨迹按可信本车速度着色，并保留 gap / unknown speed 语义
-- [x] 起点 / 终点不只依赖颜色区分
+当前关闭条件不是再做一套 tracking architecture，而是完成 current-main 真机可靠性：锁屏、另一 App 前台、静止、provider loss/recovery、delayed callback、距离可信度。
 
-### Trip analytics / data quality
-
-- [x] 起终点 / 最低 / 最高海拔
-- [x] 累计爬升 / 下降，过滤明显弱 vertical accuracy 和小幅 GPS 垂直抖动
-- [x] 累计海拔变化不跨 LONG_GAP 拼接
-- [x] Trip validity：明确空/异常完成行程从 Dashboard 与汇总统计排除
-- [x] 极短真实行程只标 `REVIEW`，不自动删除、不自动排除
-- [x] 用户仍通过显式确认删除无效/测试 Trip
-
-### Physical reliability remaining
-
-2026-08-29 新锁屏真机证据在 PR #80 后仍出现 2 个长缺口，因此完成了聚焦修复 PR #184。#77 现在保留为 **post-#184 真机复验 owner**，不是新的 broad tracking architecture 项目：
-
-- [ ] 锁屏/另一 App 前台 5–10 分钟时，连续 capture 的 delayed fixes 不再因 >15s delivery age 被整体丢弃
-- [ ] 原始 capture timestamps 连续时可信距离继续增加
-- [ ] 真实 >=120s capture-time gap 仍产生断点且不补造距离
-- [ ] 2–3 分钟停车/红灯能累计 stopped time，不产生 false LONG_GAP
-- [ ] 真正 callback/provider loss 仍产生 LOST / LONG_GAP
-- [ ] stationary heartbeat 不产生过量 TripPoint
-- [ ] out-of-order delayed historical point 仍被 non-monotonic guard 拒绝
-
-相关：#77、#67、#42、#26。
+主要 owner：#77 / #26 / #14 / #215。
 
 ---
 
-## v0.3 - Local Analytics & Data Reliability
+## v0.3 — Local Analytics & Data Reliability
 
 状态: **Feature Complete / Incremental Follow-up Only**
 
-已实现：
+目标：在不伪造 BMS/车辆遥测的前提下，把本地 Charge / Trip 事实转成可解释分析。
 
-- charging interval odometer distance
-- cost / 100km estimate
-- charged kWh / 100km estimate
-- Trip + odometer coverage evidence
-- SOC confidence hints
-- six-month cost / energy trend
-- month-over-month comparison
-- charger type mix
-- ChargingPlace aggregation + common-place reuse
-- selected-vehicle charging CSV analysis export
-- non-blocking charging anomaly hints
-- Local JSON Backup / Restore
-- Trip validity-aware analytics
-- Trip SOC energy estimate 与桩端充电事实分层展示
+稳定方向：
 
-Issue #19 已完成关闭。HOME / WORK 结构化地点、Privacy Zone、DataSource metadata 等只在真实需求出现时增量实现，不为了“数据治理完整度”新增重表或框架。
+- 月度充电费用 / 电量趋势；
+- month-over-month；
+- charger type mix；
+- common place / interval evidence；
+- cost / 100km 与 energy / 100km 估算；
+- Trip validity-aware analytics；
+- anomaly / confidence hints；
+- CSV / JSON 本地导出与恢复。
+
+只在真实需求或数据质量证据出现时增量扩展，不为“看起来完整”增加重型分析框架。
 
 ---
 
-## v0.4 - Cloud & Catalog Sync
+## v0.4 — Local First Sync & Catalog Platform
 
-状态: **Phase A Complete / Expansion Deferred Until v0.5 Physical Closeout**
+状态: **Identity / Catalog Runtime Baseline Implemented; Sync Expansion Deferred**
 
-### 已完成 Phase A
+### Sync
 
-- [x] Vehicle stable `syncId`
-- [x] Vehicle `updatedAtEpochMillis`
-- [x] ChargingRecord stable `syncId`
-- [x] ChargingRecord `updatedAtEpochMillis`
-- [x] ChargingRecord tombstone
-- [x] Room migration + old-row identity generation
-- [x] Backup / Restore 保留 sync metadata
-- [x] active UI / analytics 排除 tombstone
-- [x] pure JVM sync identity tests
+已建立 Vehicle / ChargingRecord 稳定 sync identity、updatedAt / tombstone / backup compatibility 等基础。
 
-Issue #28 已完成关闭；后续由父 Issue #27 跟踪。
+后续 #27 的第一批目标保持最小：
 
-### 下一阶段 #27
+- protocol/schema version；
+- Vehicle / ChargingRecord envelope；
+- push/pull cursor；
+- idempotent upsert；
+- explicit tombstone propagation；
+- 简单冲突策略；
+- smallest HTTPS + Spring Boot monolith + PostgreSQL slice。
 
-- [ ] protocol/schema version runtime implementation
-- [ ] Vehicle / ChargingRecord sync envelope DTO
-- [ ] push changed entities
-- [ ] pull changes since cursor/revision
-- [ ] idempotent upsert by `syncId`
-- [ ] explicit delete/tombstone propagation
-- [ ] last successful sync cursor/status
-- [ ] conflict policy pure Kotlin tests
-- [ ] smallest HTTPS + Spring Boot monolith + PostgreSQL slice
+明确不做：CRDT、微服务、MQ、让云端成为 App 运行前提、第一批同步 TripPoint。
 
-约束不变：云端不能成为 App 运行前提或唯一恢复路径；第一批不做 TripSession / TripPoint cloud sync，不做 CRDT / 微服务 / MQ。
+### Catalog
 
-### Catalog #20
+Managed catalog runtime、Offline First refresh、后台维护、JSON/CSV import/export、Brand Logo/Hero metadata 已建立。
 
-现有本地 versioned JSON seed、离线搜索、自定义车辆 fallback 继续使用。完整车型管道仍是独立长期任务：
+剩余 #20 聚焦：
 
-- [ ] 可追溯公开数据来源
-- [ ] 品牌 / 车系 / 年款 / 配置归一化
-- [ ] 可重复导入 / 校验工具
-- [ ] 增量更新、弃用和纠错
-- [ ] catalog 更新不自动改写用户 Vehicle snapshot
+- 可审计 source provenance；
+- brand/series/year/trim normalization；
+- duplicate/conflict/correction policy；
+- broader real-model coverage；
+- coverage quality metrics。
 
 ---
 
-## v0.5 - Local Experience & VehicleState Closure
+## v0.5 / v0.6 — Local Experience & Physical Closeout
 
 状态: **Code Baseline Implemented / Physical Closeout**
 
-### UI baseline
+目标：把 Dashboard / Records / Stats / Trip / Vehicle 收敛到成熟的 Dark First、信息密集、truthful UI，并完成真实设备验收。
 
-- [x] Dark First design language / persisted Light mode
-- [x] Dashboard / Records / Stats / Trip / Vehicle 核心页面重构（#71）
-- [x] Dashboard dynamic Vehicle Hero（#96）
-- [x] Dashboard recent Trip card（#100）
-- [x] release updater UI 对齐 Dashboard dark/green language（#126）
-- [x] Trip v0.6 information-dense baseline and device-fidelity corrections（#145 / #168）
-- [x] Trip home/history 与 READY preparation 分离（PR #176）
-- [x] READY / active / completion density and interaction corrections（PR #170 / #172 / #174）
-- [x] completed Trip detail 分为 `概览` / `轨迹` / `数据`（#178 / PR #179，Android CI run `33198331727` Green）
-- [x] completed route endpoint red-flag visual language further unified by PR #184
-- [x] completion narrow-width/fontScale/IME hardening merged by #187 / PR #189（Android CI run `33236915039` Green）
-- [x] Trip-home latest-summary narrow-width/fontScale hardening + completion helper copy alignment merged by #194 / PR #195 as `8a895bc`（Android Build run `33240198841` Green）
-- [x] Trip v0.6 authority docs synchronized through PR #191; post-#195 authority synchronization is part of the current documentation closeout
+代码方向已经从“重设计”转为“真机 closeout”：
 
-### VehicleState / SOC / mileage
+- Dashboard dynamic Vehicle Hero + recent Trip；
+- Records dense charging ledger；
+- Stats compact analytics hierarchy；
+- Trip home / READY / active / completion / completed detail 分层；
+- route / trends / diagnostics progressive disclosure；
+- narrow width / large font / IME / accessibility hardening；
+- Trip playback / route interaction / trend inspection 等增量能力。
 
-- [x] VehicleState 当前 SOC / 当前里程作为当前车辆事实层
-- [x] Trip start 保存当前 SOC / mileage 快照
-- [x] Trip completion 要求 explicit end SOC
-- [x] end mileage 可按 start mileage + GPS distance 预填并允许修正
-- [x] Trip end SOC / mileage 回写 VehicleState
-- [x] 正 SOC drop 才估算 consumed kWh / kWh per 100km
-- [x] 删除完成 Trip 后重新构建 VehicleState
-- [x] 后发生的 Charge / manual VehicleState 保持 authority
+主要剩余 owner：#70 / #42 / #94 / #95 / #145 / #168 / #77 / #14 / #26 / #102 / #124。
 
-代码基线由 #87/#89 等已合并 PR 提供；真机闭环由 #124 验收。
-
-### Location / address
-
-- [x] coordinates 是事实，address 是派生展示
-- [x] Add Charge 自动请求当前位置
-- [x] Geocoder failure 不阻塞坐标保存
-- [x] LocationProvider / AddressResolver 分离
-- [x] successful geocode process-local bounded cache
-- [x] failed / blank geocode 不缓存，允许真实 retry（#129）
-
-#14 已收窄为 Location / Geocoder / backup restore 真机验收；交互地图增强由 #192 独立跟踪，不再作为 #14 或 #145 blocker。
-
-### Lock-screen / background notification
-
-- [x] ongoing notification 显示 Trip elapsed time + trusted persisted distance（#130）
-- [x] notification tap / `打开行程` 直接进入 active Trip（#130）
-- [x] provider / Location permission runtime loss -> Trip `INTERRUPTED` + one-shot repair notification（#131）
-- [x] repair action deep-link 到 App 权限设置或系统 Location 设置（#131）
-- [x] 修复后由用户明确 resume，不自动后台恢复（#131）
-- [x] Android 13+ Trip 通知权限在 tracking 已开始/恢复后再请求（#132）
-- [x] 通知权限拒绝不阻塞、不回滚 Trip（#132）
-
-#26 保持 Open，只做上述行为的真机验收；trusted speed / battery optimization guidance 为 evidence-driven optional，不是代码 blocker。
-
-### Production updater
-
-- [x] updater infrastructure / latest.json / SHA-256 / installer handoff
-- [x] root composition wiring（#103）
-- [x] Dashboard-style update card（#126）
-- [ ] old production APK -> newer production APK 真机覆盖升级（#102）
-
-### v0.5 physical closeout
-
-仍需真实设备验收，不由 CI 代替：
-
-- #145 Trip v0.6 parent physical matrix
-- #168 Trip device-fidelity correction acceptance
-- #146 Trip home/history + latest-summary narrow-width acceptance
-- #173/#187 completion normal width / 320–360dp / fontScale / IME acceptance
-- #178 completed-detail tabs / 320–360dp / fontScale 1.3 / Dark-Light comparison
-- #70 五个一级页面 + Light mode
-- #94 Dashboard Hero
-- #95 recent Trip card
-- #42 accessibility / large font / small screen / active-Trip state safety
-- #22 top spacing / density
-- #14 Location / Geocoder / backup restore
-- #77 post-#184 lock-screen / delayed callback / stationary hold
-- #124 Trip SOC -> VehicleState
-- #26 lock-screen / repair notifications
-- #102 release APK updater
-
-#192 interactive map context and #193 truthful trajectory playback are post-v0.6 enhancements. They do not block this physical closeout.
+原则：没有具体真机 regression，就不重新开启 broad redesign。
 
 ---
 
-## P3 - Optional Vehicle Data Source / OBD-II
+## v0.7 — Charging Maturity + Current Product Closure
 
-状态: **Future Exploration / Not Product Blocker**
+状态: **Active Delivery**
 
-首个最小 PoC：
+当前主线产品工作是 Charging v0.7，而不是重做既有 Vehicle/Trip 基础。
 
-- [ ] 定义轻量 `VehicleSpeedSource` 边界
-- [ ] 外接 OBD-II Bluetooth / BLE / Wi-Fi adapter
-- [ ] 查询标准 Vehicle Speed 支持能力
-- [ ] 读取 OBD Vehicle Speed
-- [ ] 与 GNSS `Location.speed` 对照
+### Charging workflow
 
-明确不进入当前主线：
+Parent: #251
 
-- 厂商私有 CAN ID 逆向
-- 私有 BMS PID 逆向
-- 单车型复杂协议维护
-- OBD 成为 Trip 必需依赖
+产品模型：
 
-只有 Vehicle Speed PoC 证明稳定价值后，才评估 SOC / 电压 / 电流 / 电池温度等更多车辆事实。
+- `开始充电` — 可选 lifecycle / preset bookkeeping；
+- `充电记录维护` — 独立、完整的历史记录新增/补录/编辑入口。
+
+手工维护不能被“开始充电”取代。
+
+### Billing / derived metrics
+
+Owners: #252 / #260
+
+核心规则：
+
+`总费用 > 单价 > 桩端/电表电量`
+
+要求：
+
+- centralized calculation/editor state；
+- raw typing 稳定；
+- 不出现 bidirectional recomposition loop；
+- duration / average power / loss 只在输入充分时派生；
+- 估算值不冒充 BMS/桩端遥测。
+
+当前 PR stack 与实时 merge gate 不写死在本文件，见 `CURRENT_STATUS_AUTHORITY.md`。
+
+### Optional active charging lifecycle
+
+Owner: #253
+
+目标：
+
+- Local First active session；
+- process-death recovery；
+- truthful `充电中` 状态；
+- completion 只生成/更新一条 completed record；
+- preset 只保存可复用环境输入，不保存未来结果。
+
+### Charging location
+
+Owner: #254
+
+先复用真实 coordinate + reverse geocode + manual address 基础；map-point picker 只在产品价值明确时增加。
+
+---
+
+## Vehicle maturity / managed assets — Parallel Closeout
+
+Owners: #244 / #20
+
+并行完成：
+
+- managed read-only standard vehicle facts；
+- user nickname；
+- Brand Logo / Hero asset runtime；
+- Offline First / last-known-good；
+- catalog retire compatibility；
+- provenance / normalization / coverage quality。
+
+这不是新的产品主线架构项目，而是成熟度与数据质量收口。
+
+---
+
+## Repository governance — Parallel P0
+
+Owners: #6 / #75 / #265
+
+项目高频迭代要求仓库治理同步成熟：
+
+- README / authority hierarchy / Issue/PR templates；
+- stacked PR 明确依赖与 retarget 规则；
+- `main` protection + current-head required CI；
+- merged/closed stale remote branch cleanup；
+- merge-time branch deletion；
+- workflow ownership documentation。
+
+仓库治理不应阻塞业务探索，但必须防止旧 Issue/branch/PR/CI 证据重新成为伪权威。
+
+---
+
+## Post-v0.7 / Optional Enhancements
+
+### Map context
+
+Owners: #192 / #199
+
+只有 provider/style 在中国大陆真实 Trip 上证明道路/中文标签/可用性/许可价值后，才引入 basemap。现有 truthful no-basemap route 继续作为 fallback。
+
+### Destination planning
+
+Owner: #152
+
+未来 capability；当前 Trip 不伪造 destination / ETA / navigation state。
+
+### Higher-fidelity vehicle telemetry
+
+Owner: #138 / future OBD research
+
+优先级：公开/用户授权 API > 用户自有 OBD/telemetry > 用户提供事实 > 当前透明估算。
+
+不逆向其他 App 私有数据，不让 OBD/云端成为核心 Trip 必需依赖。
+
+### Cross-device sync
+
+Owner: #27
+
+在当前 Local Experience / Charging closure 之后恢复最小 Vehicle + ChargingRecord cloud sync。
 
 ---
 
 ## 当前执行顺序
 
+产品主线：
+
 ```text
-v0.5 physical acceptance bundle
-  -> #145 / #168 / #146 / #173 / #187 / #178 Trip v0.6 design-device comparison
-  -> #77 post-#184 lock-screen / delayed callback / stationary reliability revalidation
-  -> #124 Trip SOC -> VehicleState
-  -> #26 lock-screen + repair notification
-  -> #14 Location / Geocoder / backup restore
-  -> #70 / #94 / #95 / #42 / #22 remaining UI-device checks
-  -> #102 old-production -> new-production updater flow
-  -> only fix concrete device regressions
-  -> resume #27 minimal Local First sync protocol/runtime
-  -> advance #20 catalog pipeline when source/coverage work is justified
-  -> evaluate #192 / #193 only after current Trip closeout and only when map/playback product value is justified
-  -> P3 OBD-II optional PoC only when product value justifies it
+Charging v0.7 calculation/editor stack
+  -> manual Add/Edit maturity
+  -> optional active charging lifecycle
+  -> charging location/detail workflow
+  -> migration/backup/physical acceptance
 ```
 
-当前已有真实 WGS84 no-basemap route preview。#192 可探索交互地图/道路上下文，#193 可探索真实轨迹回放，但两者都保持 post-v0.6、非 blocker；不为了“看起来完整”提前绑定地图 SDK 或回放架构。
+并行 closeout：
+
+```text
+Trip / Vehicle / Dashboard / Records / Stats physical acceptance
+  + background/location/notification reliability
+  + production updater acceptance
+  + catalog provenance/coverage quality
+```
+
+并行仓库治理：
+
+```text
+main protection / required current-head CI
+  + stale branch cleanup
+  + documentation / Issue / PR authority maintenance
+```
+
+之后再恢复：
+
+```text
+minimal Local First cloud sync
+  -> optional map context / destination / telemetry research
+```
 
 ---
 
-## 变更记录
+## 阶段状态定义
 
-### v2.8.2
+文档必须使用下列不同状态，不可混用：
 
-- recorded #187 / PR #189 completion narrow-width/fontScale/IME hardening and Android CI `33236915039` Green
-- recorded #194 / PR #195 Trip-home latest-summary responsive layout and completion helper-copy alignment; Android Build `33240198841` Green; merged as `8a895bc`
-- moved #14 to Location / Geocoder / backup-restore physical acceptance only; map rendering ownership moved to #192
-- classified #192 interactive map context and #193 trajectory playback as post-v0.6, non-blocking enhancements
-- updated Trip physical closeout owners to include #146 and #173/#187 explicitly
-- synchronized direct Trip UI authority to the post-#195 code baseline
+- **Implemented** — 代码已进入 `main`；
+- **CI Green** — 自动化检查通过；
+- **Physical Functional Accepted** — 真机功能链路通过；
+- **Physical Visual Accepted** — 真机视觉/交互通过；
+- **Production Accepted** — 正式发布/升级链路通过。
 
-### v2.8.1
+任何一个状态都不能自动推导另一个状态。
 
-- recorded 2026-08-29 post-PR #80 physical evidence: a lock-screen Trip still showed 2 long gaps
-- recorded focused PR #184: delayed callback freshness 15s -> 10min while preserving original capture timestamps, non-monotonic rejection and the unchanged 120s LONG_GAP trust boundary
-- recorded PR #184 Android CI run `33229162800` Green and merge `bae3a21`
-- changed #77 from generic background physical acceptance to explicit post-#184 lock-screen/delayed-callback revalidation
-- recorded the small completed endpoint red-flag visual convergence from PR #184
+---
 
-### v2.8.0
+## 路线维护规则
 
-- synchronized Roadmap with the approved Trip v0.6 design authority and current `main`
-- recorded Trip device-fidelity correction series #168 / PR #170/#172/#174/#176
-- recorded completed Trip detail information architecture #178 / PR #179 (`概览` / `轨迹` / `数据`) and Android CI run `33198331727` Green
-- recorded documentation synchronization through PR #180
-- added #145/#168/#178 to the explicit physical acceptance bundle; CI remains insufficient to close them
-
-### v2.7.0
-
-- reconciled ROADMAP with current `main` after Trip reliability/data-quality work through #123/#127/#128/#129
-- recorded Trip SOC/mileage/energy -> VehicleState baseline from #87/#89 and physical acceptance owner #124
-- recorded v0.5 Dashboard Hero/recent-Trip implementation (#96/#100)
-- recorded updater wiring/UI implementation (#103/#126) while preserving #102 physical release acceptance
-- recorded lock-screen Trip progress and direct active-Trip navigation (#130)
-- recorded provider/permission repair notifications and explicit INTERRUPTED -> user resume semantics (#131)
-- recorded Android 13+ non-blocking Trip notification permission flow (#132)
-- moved the active stage from “implement Trip P0 slices” to “physical acceptance bundle, then resume minimal sync”
-
-### v2.6.0
-
-- PR #36 GPS health / notification / route-gap / speed semantics passed Android Build Run #184
-- clarified current peak speed comes primarily from `Location.speed`, not point-to-point straight-line division
-- recorded that average speed still inherits GPS distance-quality limitations
-- promoted long-gap distance correction and GPS/Network dedupe ahead of colored route work
-- added OBD-II as P3 optional VehicleSpeedSource PoC, explicitly excluding private CAN/BMS reverse engineering from current product scope
-
-### v2.5.0
-
-- based on real Trip #7, promoted 12-15 minute GPS gaps to P0 reliability work
-- added segmented speed / continuous color visualization as P1
-- clarified speed colors describe this vehicle's speed, not real traffic congestion
-- clarified long GPS gaps must not be rendered as trustworthy solid routes
-- deferred v0.4 execution until Trip P0 reliability becomes observable
+1. 里程碑/执行顺序变化才更新本文件。
+2. PR head、最新 CI run、branch behind/ahead、当天 Issue 状态写入 `CURRENT_STATUS_AUTHORITY.md` / owning Issue，而不是本文件。
+3. 稳定产品/架构原则写入 `PROJECT_MASTER.md` / domain authority。
+4. 历史实现证据保留在 merged PR / Git 历史，不在 Roadmap 长期堆叠 SHA 清单。
+5. Open Issue 不等于未实现；开始新开发前必须检查 current `main`。

--- a/docs/WORKFLOW_OWNERSHIP.md
+++ b/docs/WORKFLOW_OWNERSHIP.md
@@ -14,17 +14,20 @@ Use this file to answer:
 - which checks are relevant to a PR;
 - which workflow must not be mistaken for another acceptance layer.
 
-## Workflow matrix
+## Current workflow matrix
+
+At baseline `main@e5149a6474a17c7a5ce0a987f04fc3ab38a143b0`, the repository contains **nine** workflow files.
 
 | Workflow | Trigger / scope | Primary responsibility | Deployment / publish authority |
 | --- | --- | --- | --- |
 | `.github/workflows/android-build.yml` | PR/push when `android/**` or the workflow changes; manual dispatch | Build/test Android, enforce packaged Hero budget, produce Debug APK | **No** production publish |
 | `.github/workflows/android-release.yml` | Manual `workflow_dispatch` only | Build/sign/verify Production APK, version it inside the release run, publish release/update metadata | **Yes — Android Production Release** |
-| `.github/workflows/hero-admin.yml` | PR/push for `hero-admin/**`, `vehicle-catalog/**`; manual dispatch | Validate resource-admin browser assets, Python/container runtime and catalog/brand lifecycle contracts | **No** production deploy |
-| `.github/workflows/hero-admin-deploy.yml` | PR/push for admin/assets/catalog/deploy script; manual dispatch | Validate deployment bundle; on `main` push deploy resource admin to production | **Yes — resource admin deployment** |
+| `.github/workflows/hero-admin.yml` | PR/push for `hero-admin/**`, `vehicle-catalog/**`; manual dispatch | Validate integrated resource-admin browser assets, Python/container runtime and catalog/brand lifecycle contracts | **No** production deploy |
+| `.github/workflows/hero-admin-deploy.yml` | PR/push for admin/assets/catalog/deploy script; manual dispatch | Validate deployment bundle; on qualifying `main` push deploy resource admin to production | **Yes — resource admin deployment** |
 | `.github/workflows/hero-assets-publish.yml` | PR/push for `hero-assets/**`; manual dispatch | Validate Hero manifest/package, remote WebP existence/size/URL contract | **No direct deploy**; validates repository-hosted Hero package |
-| `.github/workflows/admin-batch-image-upload.yml` | PR/push for batch-upload browser files/docs | Verify filename matching, duplicate handling and Brand Logo contrast/batch-planning contract | **No** deployment |
-| `.github/workflows/admin-prompt-library.yml` | PR/push for prompt-library/index; manual dispatch | Verify Logo/Hero prompt/copy-center browser contract | **No** deployment |
+| `.github/workflows/admin-resource-workbench.yml` | PR/push for unified workbench/full-bundle prompt/docs | Validate coordinated one-vehicle resource bundle workbench, matching, variants, review/confirmation and bundle contract | **No** deployment |
+| `.github/workflows/admin-batch-image-upload.yml` | PR/push for legacy/focused batch-upload browser files/docs | Retained focused regression checks for filename matching, duplicate handling and Brand Logo contrast/batch-planning helpers | **No** deployment; not preferred new-vehicle onboarding authority |
+| `.github/workflows/admin-prompt-library.yml` | PR/push for single-item + full-bundle prompt surfaces; manual dispatch | Verify single-item prompt library plus full asset-bundle prompt/index contract | **No** deployment |
 | `.github/workflows/vehicle-catalog-admin-tools.yml` | PR/push for catalog-tools browser files/docs | Verify catalog import/export, Hero-key and Brand Logo admin browser contract | **No** deployment |
 
 ## Android Build
@@ -70,13 +73,13 @@ Normal PR/Debug CI must never be documented as having produced a Production Rele
 
 Production Release success still does not replace #102's real old-APK -> new-APK in-place upgrade acceptance.
 
-## Resource Admin Validation
+## Integrated Resource Admin Validation
 
 Workflow: `hero-admin.yml`
 
 This is the broad **resource-admin application validation** workflow.
 
-It checks:
+It checks integrated behavior such as:
 
 - browser/admin assets;
 - Python syntax/runtime;
@@ -85,7 +88,7 @@ It checks:
 - served browser assets;
 - managed brand / Brand Logo / vehicle catalog lifecycle contracts.
 
-It may overlap path triggers with narrower browser-contract workflows because it validates the integrated admin application, while the narrow workflows give faster focused evidence.
+It may overlap path triggers with narrower browser-contract workflows because it validates the integrated admin application, while focused workflows give faster domain-specific evidence.
 
 It is **not** the production deploy authority.
 
@@ -121,11 +124,35 @@ It checks:
 
 Do not document this workflow as publishing a server release unless the workflow is later changed to perform such a publish action.
 
+## Unified Vehicle Resource Workbench
+
+Workflow: `admin-resource-workbench.yml`
+
+Merged PR #264 introduced this as the current focused contract check for coordinated vehicle onboarding.
+
+It validates:
+
+- `车型资源工作台` browser surface;
+- one-vehicle resource-bundle JSON contract;
+- coordinated Brand Logo + Hero image queue;
+- automatic matching as a suggestion rather than hidden authority;
+- manual target/variant correction paths;
+- base Hero semantic key + `-dark` / `-light` variant rules;
+- catalog/brand diff review and explicit confirmation semantics;
+- server-standard next-version filename preview logic;
+- full asset-bundle prompt contract.
+
+Product/admin authority: `RESOURCE_BUNDLE_WORKFLOW.md`, owner #244.
+
+The Resource Workbench is the **preferred path for new vehicle resource onboarding**. Single-item tools remain valid for replacing one Logo, correcting one catalog field or publishing one Hero revision.
+
+This workflow validates the browser/workbench contract only. It does not prove production admin deployment or physical Android rendering.
+
 ## Focused Admin Browser Contracts
 
-### Batch Image Upload
+### Batch Image Upload — legacy/focused compatibility check
 
-`admin-batch-image-upload.yml` validates:
+`admin-batch-image-upload.yml` remains present and validates helper behavior around:
 
 - filename normalization;
 - longest-prefix Hero matching;
@@ -133,14 +160,20 @@ Do not document this workflow as publishing a server release unless the workflow
 - Brand Logo visual/contrast classification;
 - Light/Dark Brand Logo batch planning.
 
+PR #264 retired the old split batch Logo/Hero panels from the main admin UI in favor of the unified Resource Workbench. Therefore this workflow must **not** be documented as the preferred new-model onboarding flow merely because the file still exists.
+
+If its underlying batch helper files are later removed, this workflow should be retired or narrowed in the same PR rather than becoming an orphan check.
+
 ### Prompt Library
 
-`admin-prompt-library.yml` validates:
+`admin-prompt-library.yml` now validates both prompt surfaces:
 
-- prompt/copy-center presence in the admin;
-- Logo and Hero standard markers;
-- copy/generation affordances;
-- current key image-standard constants exposed to users.
+- single-item Logo/Hero prompt library;
+- full asset-bundle prompt;
+- index links that distinguish `全量资产包 Prompt` from `单项规范 / Prompt`;
+- current Logo/Hero standard markers and machine-readable bundle expectations.
+
+The full bundle prompt dynamically reuses single-item prompt authority rather than copying independent design rules.
 
 ### Vehicle Catalog Admin Tools
 
@@ -150,6 +183,8 @@ Do not document this workflow as publishing a server release unless the workflow
 - template/import controls;
 - Brand Logo center controls;
 - Hero-key selection/management hooks.
+
+Bulk spreadsheet/catalog maintenance remains separate from the one-vehicle Resource Workbench bundle contract.
 
 These focused workflows complement `hero-admin.yml`; they do not deploy production services.
 
@@ -162,11 +197,12 @@ These focused workflows complement `hero-admin.yml`; they do not deploy producti
 5. A Green admin validation workflow does not prove production deployment.
 6. A Green Android Build does not prove Production Release or physical-device acceptance.
 7. A workflow whose responsibility changes must update this file and `CI_CD.md`/domain docs when relevant.
-8. Avoid adding a new workflow when an existing workflow already owns the same contract; prefer adding a focused job only when responsibility remains clear.
+8. Avoid adding a new workflow when an existing workflow already owns the same contract; add a focused workflow/job only when the responsibility is genuinely distinct.
 9. When overlap is intentional, document why the overlap exists rather than deleting checks solely to reduce workflow count.
+10. When a product surface is superseded, decide explicitly whether its focused workflow remains a regression/compatibility check or should be retired; do not leave ambiguous orphan CI.
 
 ## Current conclusion
 
-The eight current workflows are not simple duplicates. Their main governance problem was **missing ownership documentation**, not necessarily excessive workflow count.
+The nine current workflow files are not simple duplicates. Their main governance risk is **authority drift as admin surfaces evolve**, especially when a newer unified workbench supersedes older UI entry points while old helper checks remain useful.
 
-Future simplification should be evidence-driven: consolidate only when two workflows truly test/deploy the same contract and the merge does not weaken path-specific feedback or authority clarity.
+Future simplification should be evidence-driven: consolidate or retire only when two workflows truly validate/deploy the same contract or when a superseded surface/helper is actually removed.

--- a/docs/WORKFLOW_OWNERSHIP.md
+++ b/docs/WORKFLOW_OWNERSHIP.md
@@ -1,0 +1,172 @@
+# EV Charge Book GitHub Actions Workflow Ownership
+
+Updated: 2026-08-31
+Status: Repository workflow authority
+
+## Purpose
+
+The repository currently has multiple focused workflows across Android, Hero assets, resource admin and vehicle-catalog tooling. Several intentionally watch overlapping paths, but they do **not** own the same responsibility.
+
+Use this file to answer:
+
+- which workflow validates which surface;
+- which workflow is allowed to deploy/publish;
+- which checks are relevant to a PR;
+- which workflow must not be mistaken for another acceptance layer.
+
+## Workflow matrix
+
+| Workflow | Trigger / scope | Primary responsibility | Deployment / publish authority |
+| --- | --- | --- | --- |
+| `.github/workflows/android-build.yml` | PR/push when `android/**` or the workflow changes; manual dispatch | Build/test Android, enforce packaged Hero budget, produce Debug APK | **No** production publish |
+| `.github/workflows/android-release.yml` | Manual `workflow_dispatch` only | Build/sign/verify Production APK, version it inside the release run, publish release/update metadata | **Yes — Android Production Release** |
+| `.github/workflows/hero-admin.yml` | PR/push for `hero-admin/**`, `vehicle-catalog/**`; manual dispatch | Validate resource-admin browser assets, Python/container runtime and catalog/brand lifecycle contracts | **No** production deploy |
+| `.github/workflows/hero-admin-deploy.yml` | PR/push for admin/assets/catalog/deploy script; manual dispatch | Validate deployment bundle; on `main` push deploy resource admin to production | **Yes — resource admin deployment** |
+| `.github/workflows/hero-assets-publish.yml` | PR/push for `hero-assets/**`; manual dispatch | Validate Hero manifest/package, remote WebP existence/size/URL contract | **No direct deploy**; validates repository-hosted Hero package |
+| `.github/workflows/admin-batch-image-upload.yml` | PR/push for batch-upload browser files/docs | Verify filename matching, duplicate handling and Brand Logo contrast/batch-planning contract | **No** deployment |
+| `.github/workflows/admin-prompt-library.yml` | PR/push for prompt-library/index; manual dispatch | Verify Logo/Hero prompt/copy-center browser contract | **No** deployment |
+| `.github/workflows/vehicle-catalog-admin-tools.yml` | PR/push for catalog-tools browser files/docs | Verify catalog import/export, Hero-key and Brand Logo admin browser contract | **No** deployment |
+
+## Android Build
+
+Workflow: `android-build.yml`
+
+Authority:
+
+- workflow name: `Android Build`;
+- job/check name: `Android CI`;
+- validates Android repository baseline;
+- runs JVM/unit tests and `assembleDebug`;
+- uploads a short-retention Debug APK artifact;
+- enforces that oversized finished Hero WebP assets are not packaged into the APK drawable directory.
+
+This workflow proves an automated Android build/test baseline only.
+
+It does **not** prove:
+
+- physical-device behavior;
+- production signing;
+- old-production -> new-production APK upgrade;
+- production server/update-manifest publication.
+
+Repository protection target is tracked by #75: applicable runtime PRs should require current-head `Android CI` before merge.
+
+## Android Release
+
+Workflow: `android-release.yml`
+
+Authority:
+
+- manual production gate only;
+- resolves the requested release ref;
+- creates release-only `versionCode/versionName` from the release run;
+- restores production signing credentials;
+- builds and verifies a signed release APK;
+- verifies the public update-discovery endpoint before release;
+- prepares SHA-256 and atomic publication artifacts;
+- runs in the `production` Environment.
+
+Normal PR/Debug CI must never be documented as having produced a Production Release.
+
+Production Release success still does not replace #102's real old-APK -> new-APK in-place upgrade acceptance.
+
+## Resource Admin Validation
+
+Workflow: `hero-admin.yml`
+
+This is the broad **resource-admin application validation** workflow.
+
+It checks:
+
+- browser/admin assets;
+- Python syntax/runtime;
+- container build;
+- isolated admin startup;
+- served browser assets;
+- managed brand / Brand Logo / vehicle catalog lifecycle contracts.
+
+It may overlap path triggers with narrower browser-contract workflows because it validates the integrated admin application, while the narrow workflows give faster focused evidence.
+
+It is **not** the production deploy authority.
+
+## Resource Admin Production Deployment
+
+Workflow: `hero-admin-deploy.yml`
+
+This workflow owns the resource-admin deployment bundle and production deployment path.
+
+Behavior:
+
+- validates deploy script and seed manifests;
+- builds the admin image;
+- on qualifying `main` push, deploy job runs with `environment: production`;
+- prepares remote staging and safe disk-space reclamation;
+- uploads the image/seeds/deploy script to the production host.
+
+Do not treat `hero-admin.yml` Green as proof that production deployment occurred; deployment authority belongs here.
+
+## Hero Asset Package Validation
+
+Workflow: `hero-assets-publish.yml`
+
+Despite the filename, the workflow name is `Hero Assets Validate` and its present responsibility is **validation**, not a separate production deployment service.
+
+It checks:
+
+- Hero manifest schema;
+- non-empty artwork set;
+- repository-hosted remote WebP existence;
+- 2.5 MB hard safety ceiling;
+- expected first-party raw GitHub URL contract.
+
+Do not document this workflow as publishing a server release unless the workflow is later changed to perform such a publish action.
+
+## Focused Admin Browser Contracts
+
+### Batch Image Upload
+
+`admin-batch-image-upload.yml` validates:
+
+- filename normalization;
+- longest-prefix Hero matching;
+- duplicate/unmatched planning;
+- Brand Logo visual/contrast classification;
+- Light/Dark Brand Logo batch planning.
+
+### Prompt Library
+
+`admin-prompt-library.yml` validates:
+
+- prompt/copy-center presence in the admin;
+- Logo and Hero standard markers;
+- copy/generation affordances;
+- current key image-standard constants exposed to users.
+
+### Vehicle Catalog Admin Tools
+
+`vehicle-catalog-admin-tools.yml` validates:
+
+- catalog JSON/CSV import/export UI contract;
+- template/import controls;
+- Brand Logo center controls;
+- Hero-key selection/management hooks.
+
+These focused workflows complement `hero-admin.yml`; they do not deploy production services.
+
+## Governance rules
+
+1. A workflow's filename is not enough to infer authority; use its actual trigger/jobs/actions.
+2. Validation and deployment are separate states.
+3. PR checks must correspond to the paths and responsibilities changed by that PR.
+4. A Green narrow browser-contract workflow does not replace broad integrated admin validation when both apply.
+5. A Green admin validation workflow does not prove production deployment.
+6. A Green Android Build does not prove Production Release or physical-device acceptance.
+7. A workflow whose responsibility changes must update this file and `CI_CD.md`/domain docs when relevant.
+8. Avoid adding a new workflow when an existing workflow already owns the same contract; prefer adding a focused job only when responsibility remains clear.
+9. When overlap is intentional, document why the overlap exists rather than deleting checks solely to reduce workflow count.
+
+## Current conclusion
+
+The eight current workflows are not simple duplicates. Their main governance problem was **missing ownership documentation**, not necessarily excessive workflow count.
+
+Future simplification should be evidence-driven: consolidate only when two workflows truly test/deploy the same contract and the merge does not weaken path-specific feedback or authority clarity.


### PR DESCRIPTION
## Purpose

Documentation/authority only. No Android/backend/admin/workflow runtime files are changed.

This PR finishes the 2026-08-31 governance reset by giving each high-level document one responsibility instead of letting dated PR/SHA/status text compete across multiple authority files.

It also incorporates merged PR #264, which landed while this documentation pass was in progress and introduced the unified Vehicle Resource Workbench, Hero Light/Dark variants and a ninth GitHub Actions workflow.

## Changes

- refresh `docs/CURRENT_STATUS_AUTHORITY.md` to `main@e5149a6474a17c7a5ce0a987f04fc3ab38a143b0`, including #264 and current Charging stack behavior;
- replace `ROADMAP.md` with milestone/sequencing-only authority;
- replace `PROJECT_MASTER.md` with stable product/data/architecture principles only;
- update `CI_CD.md` against current Android Build/Release workflow facts, including the real `android/gradlew` location and current-head CI semantics;
- add `WORKFLOW_OWNERSHIP.md` covering all **nine** current workflow files and separating validation from deployment/publish authority;
- explicitly document `admin-resource-workbench.yml` as the current coordinated onboarding contract and `admin-batch-image-upload.yml` as retained focused/legacy helper regression coverage after #264 retired the split batch panels from the main UI.

## Authority model

- current `main` / merged evidence = implementation fact;
- `CURRENT_STATUS_AUTHORITY.md` = fast-changing execution snapshot;
- `ROADMAP.md` = milestone and priority ordering;
- `PROJECT_MASTER.md` = stable product/architecture boundary;
- `CI_CD.md` = Android CI/Release rules;
- `WORKFLOW_OWNERSHIP.md` = GitHub Actions responsibility map;
- owning Issue = remaining acceptance/future work.

## Why

The previous Roadmap/Project Master contained dated present-tense implementation claims and historical PR/SHA evidence, so they became stale within days. Git history preserves those older versions; current authority should not depend on stale prose remaining in active files.

The concurrent #264 merge also demonstrated why workflow ownership must be explicit: the repository moved from eight to nine workflow files and changed the preferred new-vehicle resource onboarding surface during this audit.

## Scope

Docs only. No workflow YAML, Android source, backend source, schema, release behavior or repository setting is modified.

Refs #6 #75 #244 #265 #251 #252 #260