### PR TITLE
feat(admin): surface automatic PNG to WebP conversion

### DIFF
--- a/.github/workflows/admin-png-auto-webp.yml
+++ b/.github/workflows/admin-png-auto-webp.yml
@@ -1,0 +1,65 @@
+name: Admin PNG Auto WebP
+
+on:
+  pull_request:
+    paths:
+      - 'hero-admin/app.py'
+      - 'hero-admin/static/resource-workbench.html'
+      - 'hero-admin/static/png-auto-webp.js'
+      - '.github/workflows/admin-png-auto-webp.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'hero-admin/app.py'
+      - 'hero-admin/static/resource-workbench.html'
+      - 'hero-admin/static/png-auto-webp.js'
+      - '.github/workflows/admin-png-auto-webp.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify PNG detection helper
+        shell: bash
+        run: |
+          set -eu
+          node --check hero-admin/static/png-auto-webp.js
+          node - <<'NODE'
+          require('./hero-admin/static/png-auto-webp.js');
+          const assert=require('assert');
+          const h=globalThis.__evPngAutoWebpTest;
+          assert.equal(h.isPngName('hero_demo_dark.png'),true);
+          assert.equal(h.isPngName('BRAND_demo_LIGHT.PNG'),true);
+          assert.equal(h.isPngName('hero_demo_dark.webp'),false);
+          NODE
+      - name: Verify server WebP output contract
+        shell: bash
+        run: |
+          set -eu
+          python3 - <<'PY'
+          from pathlib import Path
+          app = Path('hero-admin/app.py').read_text(encoding='utf-8')
+          page = Path('hero-admin/static/resource-workbench.html').read_text(encoding='utf-8')
+          js = Path('hero-admin/static/png-auto-webp.js').read_text(encoding='utf-8')
+          for marker in [
+              'ALLOWED_INPUT_FORMATS = {"PNG", "WEBP"}',
+              'def _encode_webp(',
+              'format="WEBP"',
+              'def _encode_logo_webp(',
+              '.webp"',
+          ]:
+              assert marker in app, f'missing server conversion marker: {marker}'
+          for marker in [
+              'PNG 会自动转 WebP',
+              'PNG → WebP 自动转换',
+              'png-auto-webp.js',
+          ]:
+              assert marker in page, f'missing workbench PNG marker: {marker}'
+          for marker in ['data-auto-convert-webp', 'PNG → WebP（发布时自动转换）']:
+              assert marker in js, f'missing PNG detection UI marker: {marker}'
+          print('PNG -> WebP contract OK')
+          PY

--- a/hero-admin/static/png-auto-webp.js
+++ b/hero-admin/static/png-auto-webp.js
@@ -1,0 +1,39 @@
+(function(){
+  const PNG_RE=/\.png$/i;
+
+  function isPngName(value){
+    return PNG_RE.test(String(value||'').trim());
+  }
+
+  function decorateRow(row){
+    const name=row.querySelector('.file-name')?.textContent||'';
+    if(!isPngName(name)){
+      row.removeAttribute('data-auto-convert-webp');
+      row.querySelector('.png-webp-note')?.remove();
+      return;
+    }
+
+    row.setAttribute('data-auto-convert-webp','png-to-webp');
+    const facts=row.querySelector('.file-facts');
+    if(facts&&!facts.querySelector('.png-webp-note')){
+      const note=document.createElement('span');
+      note.className='png-webp-note';
+      note.textContent=`${facts.textContent?' · ':''}PNG → WebP（发布时自动转换）`;
+      facts.appendChild(note);
+    }
+  }
+
+  function decorateQueue(root){
+    root.querySelectorAll('.queue-row').forEach(decorateRow);
+  }
+
+  globalThis.__evPngAutoWebpTest={isPngName};
+  if(typeof document==='undefined')return;
+
+  const root=document.getElementById('resourceQueue');
+  if(!root)return;
+
+  decorateQueue(root);
+  const observer=new MutationObserver(()=>decorateQueue(root));
+  observer.observe(root,{childList:true,subtree:true});
+})();

--- a/hero-admin/static/resource-workbench.html
+++ b/hero-admin/static/resource-workbench.html
@@ -49,15 +49,15 @@
       <div>
         <div class="eyebrow">STEP 2 · ALL IMAGES</div>
         <h2>Logo + Hero 统一投递</h2>
-        <p>一个入口即可。推荐文件名：<code>brand_&lt;brandId&gt;_light.webp</code>、<code>brand_&lt;brandId&gt;_dark.webp</code>、<code>hero_&lt;heroKey&gt;_dark.webp</code>、<code>hero_&lt;heroKey&gt;_light.webp</code>。后缀中的 v2 / 日期 / final 不影响匹配。</p>
+        <p>一个入口即可。推荐文件名：<code>brand_&lt;brandId&gt;_light.webp</code>、<code>brand_&lt;brandId&gt;_dark.webp</code>、<code>hero_&lt;heroKey&gt;_dark.webp</code>、<code>hero_&lt;heroKey&gt;_light.webp</code>。如果源图是 PNG 也可以直接上传：工作台会识别 PNG，发布端自动转换成 WebP，无需手工转格式。后缀中的 v2 / 日期 / final 不影响匹配。</p>
       </div>
     </div>
 
     <div class="drop-zone" id="resourceDrop" tabindex="0" role="button">
       <input id="resourceFiles" type="file" multiple accept="image/png,image/webp,.png,.webp" />
       <strong>拖入整套图片，或点击多选</strong>
-      <span>品牌 Logo 与车型 Hero 可以混在一起上传；前端先校验和匹配，再统一发布。</span>
-      <small>PNG / WebP · Logo 校验透明背景与对比度 · Hero 校验尺寸与 1.45:1 比例</small>
+      <span>品牌 Logo 与车型 Hero 可以混在一起上传；PNG 会自动转 WebP，前端先校验和匹配，再统一发布。</span>
+      <small>PNG → WebP 自动转换 · WebP 直接标准化 · Logo 校验透明背景与对比度 · Hero 校验尺寸与 1.45:1 比例</small>
     </div>
 
     <div class="queue-toolbar">
@@ -76,7 +76,7 @@
     <div>
       <div class="eyebrow">STEP 3 · REVIEW & PUBLISH</div>
       <h2>确认并发布整套资源</h2>
-      <p>执行顺序：品牌配置 → 车型配置 → Logo → Hero。任何未匹配、校验失败或未确认的重复 Hero 都会阻止误发布；图片原始文件名不会直接落盘。</p>
+      <p>执行顺序：品牌配置 → 车型配置 → Logo → Hero。任何未匹配、校验失败或未确认的重复 Hero 都会阻止误发布；PNG / WebP 都会由发布端输出成规范 WebP，图片原始文件名不会直接落盘。</p>
     </div>
     <div class="publish-actions">
       <button id="refreshState" class="secondary">刷新线上状态</button>
@@ -86,5 +86,6 @@
   </section>
 </main>
 <script src="resource-workbench.js"></script>
+<script src="png-auto-webp.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Makes the existing server-side PNG -> WebP conversion explicit in the vehicle resource workbench.

- PNG and WebP remain accepted inputs for Logo and Hero
- PNG rows are visibly marked `PNG -> WebP (auto convert on publish)`
- workbench copy now states that PNG can be uploaded directly without manual conversion
- published assets still use the existing authoritative WebP pipelines:
  - Hero -> 1600x1100 WebP
  - Logo -> standardized transparent WebP
- adds a CI contract that checks PNG detection plus the server WebP output path

This does not add a second encoder; it exposes and guards the existing server conversion behavior.