### PR TITLE
feat(charging): add start and active charging UI

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -38,6 +38,7 @@ import com.evchargebook.ui.dashboard.DashboardScreen
 import com.evchargebook.ui.records.AddRecordScreen
 import com.evchargebook.ui.records.RecordEditScreen
 import com.evchargebook.ui.records.RecordsScreen
+import com.evchargebook.ui.records.StartChargingScreen
 import com.evchargebook.ui.stats.StatsScreen
 import com.evchargebook.ui.theme.EvChargeTheme
 import com.evchargebook.ui.theme.LocalAppThemeController
@@ -121,6 +122,8 @@ fun MainApp(
     var openBluetoothAfterNotificationPermission by remember { mutableStateOf(false) }
     var catalogSelection by remember { mutableStateOf<com.evchargebook.data.entity.VehicleCatalogEntity?>(null) }
     var addRecord by remember { mutableStateOf(false) }
+    var startCharging by remember { mutableStateOf(false) }
+    var editActiveCharging by remember { mutableStateOf(false) }
     var editingRecord by remember { mutableStateOf<ChargingRecordEntity?>(null) }
     var pendingExportContent by remember { mutableStateOf<String?>(null) }
     var pendingCsvContent by remember { mutableStateOf<String?>(null) }
@@ -305,7 +308,7 @@ fun MainApp(
         showTripCompletion = true
     }
 
-    val hasOverlayPage = showTripCompletion || editVehicle || addVehicle || selectCatalogVehicle || bluetoothPrompt || addRecord || editingRecord != null || state.selectedTripId != null
+    val hasOverlayPage = showTripCompletion || editVehicle || addVehicle || selectCatalogVehicle || bluetoothPrompt || addRecord || startCharging || editActiveCharging || editingRecord != null || state.selectedTripId != null
     val themeController = LocalAppThemeController.current
     SideEffect {
         (context as? Activity)?.window?.let { window ->
@@ -320,6 +323,8 @@ fun MainApp(
             showTripCompletion -> showTripCompletion = false
             state.selectedTripId != null -> viewModel.closeTripDetail()
             editingRecord != null -> editingRecord = null
+            editActiveCharging -> editActiveCharging = false
+            startCharging -> startCharging = false
             addRecord -> addRecord = false
             bluetoothPrompt -> bluetoothPrompt = false
             selectCatalogVehicle -> selectCatalogVehicle = false
@@ -411,6 +416,26 @@ fun MainApp(
     ) { padding ->
         Surface(Modifier.padding(padding), color = MaterialTheme.colorScheme.background) {
             when {
+                startCharging || editActiveCharging -> state.vehicle?.let { vehicle ->
+                    StartChargingScreen(
+                        vehicle = vehicle,
+                        currentSoc = state.currentSoc,
+                        commonPlaces = state.chargingPlaceSummary.map { it.displayName },
+                        existingSession = state.activeChargingSession.takeIf { editActiveCharging },
+                        onBack = {
+                            startCharging = false
+                            editActiveCharging = false
+                        },
+                        onStart = { request ->
+                            viewModel.startChargingSession(request)
+                            startCharging = false
+                        },
+                        onUpdate = { session ->
+                            viewModel.updateActiveChargingSession(session)
+                            editActiveCharging = false
+                        },
+                    )
+                }
                 addRecord -> AddRecordScreen(
                     vehicleId = state.vehicle?.id ?: 0L,
                     records = state.chargingRecords,
@@ -490,7 +515,22 @@ fun MainApp(
                         onOpenChargingRecords = { tab = 1 },
                         onEditChargingRecord = { editingRecord = it }
                     )
-                    1 -> RecordsScreen(state.chargingRecords, viewModel::deleteChargingRecord, { addRecord = true }, { editingRecord = it })
+                    1 -> RecordsScreen(
+                        records = state.chargingRecords,
+                        activeSession = state.activeChargingSession,
+                        onDelete = viewModel::deleteChargingRecord,
+                        onStartCharging = {
+                            if (state.vehicle == null) {
+                                scope.launch { snackbarHostState.showSnackbar("请先添加并选择车辆") }
+                            } else if (state.activeChargingSession == null) {
+                                startCharging = true
+                            }
+                        },
+                        onMaintainRecord = { addRecord = true },
+                        onEdit = { editingRecord = it },
+                        onEditActive = { editActiveCharging = true },
+                        onCancelActive = { session -> viewModel.cancelChargingSession(session.id) },
+                    )
                     2 -> StatsScreen(state)
                     3 -> {
                         if (state.activeTrip == null && state.selectedTripId == null) {
@@ -563,7 +603,7 @@ fun MainApp(
         AlertDialog(
             onDismissRequest = { pendingRestoreContent = null },
             title = { Text("覆盖当前本地数据？") },
-            text = { Text("恢复备份会删除当前车辆、充电记录和行程数据，再写入备份内容。此操作不可撤销，建议先导出当前备份。") },
+            text = { Text("恢复备份会删除当前车辆、充电记录、充电会话和行程数据，再写入备份内容。此操作不可撤销，建议先导出当前备份。") },
             confirmButton = { TextButton(onClick = { pendingRestoreContent = null; viewModel.restoreBackup(content) }) { Text("确认恢复", color = MaterialTheme.colorScheme.error) } },
             dismissButton = { TextButton(onClick = { pendingRestoreContent = null }) { Text("取消") } }
         )

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -18,24 +18,26 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -45,9 +47,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.ChargingSessionEntity
 import com.evchargebook.ui.components.EmptyState
 import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
+import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -57,11 +61,16 @@ import java.util.Locale
 @Composable
 fun RecordsScreen(
     records: List<ChargingRecordEntity>,
+    activeSession: ChargingSessionEntity?,
     onDelete: (ChargingRecordEntity) -> Unit,
-    onAdd: () -> Unit,
-    onEdit: (ChargingRecordEntity) -> Unit
+    onStartCharging: () -> Unit,
+    onMaintainRecord: () -> Unit,
+    onEdit: (ChargingRecordEntity) -> Unit,
+    onEditActive: (ChargingSessionEntity) -> Unit,
+    onCancelActive: (ChargingSessionEntity) -> Unit,
 ) {
     var pendingDelete by remember { mutableStateOf<ChargingRecordEntity?>(null) }
+    var pendingCancel by remember { mutableStateOf<ChargingSessionEntity?>(null) }
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
@@ -70,37 +79,57 @@ fun RecordsScreen(
                 title = {
                     Text("充电记录", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
             )
         },
-        floatingActionButton = {
-            SmallFloatingActionButton(onClick = onAdd) {
-                Icon(Icons.Default.Add, contentDescription = "记录充电")
-            }
-        }
     ) { padding ->
-        if (records.isEmpty()) {
-            Box(Modifier.fillMaxSize().padding(padding)) {
-                EmptyState("还没有充电记录", "从第一笔充电开始建立你的能耗账本。", "记录第一次充电", onAdd)
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+        ) {
+            item {
+                ChargingEntryActions(
+                    hasActiveSession = activeSession != null,
+                    onStartCharging = onStartCharging,
+                    onMaintainRecord = onMaintainRecord,
+                )
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(padding),
-                contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-            ) {
+
+            activeSession?.let { session ->
+                item {
+                    ActiveChargingCard(
+                        session = session,
+                        onEdit = { onEditActive(session) },
+                        onCancel = { pendingCancel = session },
+                    )
+                }
+            }
+
+            if (records.isEmpty()) {
+                item {
+                    Box(Modifier.fillMaxWidth().height(260.dp)) {
+                        EmptyState(
+                            "还没有已完成的充电记录",
+                            if (activeSession != null) "当前充电仍在进行；完成后会进入历史账本。" else "可以开始记录充电，也可以补录已有账单。",
+                            "补录历史充电",
+                            onMaintainRecord,
+                        )
+                    }
+                }
+            } else {
                 item { LedgerSummaryV06(records) }
                 item {
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(top = MaterialTheme.spacing.xs),
-                        verticalAlignment = Alignment.CenterVertically
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text("最近记录", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                         Spacer(Modifier.weight(1f))
                         Text(
                             "${records.size} 笔",
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
@@ -108,11 +137,11 @@ fun RecordsScreen(
                     RecordTimelineItemV06(
                         record = record,
                         onEdit = { onEdit(record) },
-                        onDelete = { pendingDelete = record }
+                        onDelete = { pendingDelete = record },
                     )
                 }
-                item { Spacer(Modifier.height(64.dp)) }
             }
+            item { Spacer(Modifier.height(MaterialTheme.spacing.lg)) }
         }
     }
 
@@ -126,8 +155,130 @@ fun RecordsScreen(
                     Text("删除", color = MaterialTheme.colorScheme.error)
                 }
             },
-            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("取消") } }
+            dismissButton = { TextButton(onClick = { pendingDelete = null }) { Text("取消") } },
         )
+    }
+
+    pendingCancel?.let { session ->
+        AlertDialog(
+            onDismissRequest = { pendingCancel = null },
+            title = { Text("取消这次充电？") },
+            text = { Text("取消只结束本地进行中会话，不会生成一笔已完成充电记录。") },
+            confirmButton = {
+                TextButton(onClick = { onCancelActive(session); pendingCancel = null }) {
+                    Text("取消本次充电", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = { TextButton(onClick = { pendingCancel = null }) { Text("继续记录") } },
+        )
+    }
+}
+
+@Composable
+private fun ChargingEntryActions(
+    hasActiveSession: Boolean,
+    onStartCharging: () -> Unit,
+    onMaintainRecord: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+    ) {
+        Button(
+            onClick = onStartCharging,
+            enabled = !hasActiveSession,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(if (hasActiveSession) "充电进行中" else "开始充电")
+        }
+        OutlinedButton(
+            onClick = onMaintainRecord,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text("充电记录维护")
+        }
+    }
+}
+
+@Composable
+private fun ActiveChargingCard(
+    session: ChargingSessionEntity,
+    onEdit: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    var now by remember(session.id) { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(session.id) {
+        while (true) {
+            delay(30_000)
+            now = System.currentTimeMillis()
+        }
+    }
+    val elapsed = (now - session.startedAtEpochMillis).coerceAtLeast(0L)
+    val facts = listOfNotNull(
+        session.chargerType?.takeIf { it.isNotBlank() },
+        session.startSoc?.let { "开始 $it%" },
+        session.targetSoc?.let { "目标 $it%" },
+        session.unitPricePerKwh?.let { "¥${two(it)}/kWh" },
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(Modifier.size(8.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("充电中", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.weight(1f))
+                Text(
+                    formatElapsed(elapsed),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Text(
+                session.location?.takeIf { it.isNotBlank() } ?: "未记录充电地点",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                "开始于 ${format(session.startedAtEpochMillis)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (facts.isNotEmpty()) {
+                Text(
+                    facts.joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            session.remark?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onCancel) { Text("取消") }
+                TextButton(onClick = onEdit) { Text("编辑") }
+            }
+        }
     }
 }
 
@@ -139,17 +290,17 @@ private fun LedgerSummaryV06(records: List<ChargingRecordEntity>) {
     val metrics = listOf(
         "电网补能" to "${one(totalEnergy)} kWh",
         "记录" to "${records.size} 笔",
-        "桩端均价" to "¥ ${two(averagePrice)}"
+        "桩端均价" to "¥ ${two(averagePrice)}",
     )
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
@@ -157,16 +308,14 @@ private fun LedgerSummaryV06(records: List<ChargingRecordEntity>) {
                 Text(
                     "累计账本",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text("累计支出", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(
-                    "¥ ${two(totalCost)}",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
+            Row(verticalAlignment = Alignment.Bottom) {
+                Column {
+                    Text("累计支出", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("¥ ${two(totalCost)}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
+                }
             }
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .24f))
             ResponsiveMetricGrid(metrics.size) { index, modifier ->
@@ -189,20 +338,20 @@ private fun LedgerMetricV06(label: String, value: String, modifier: Modifier) {
 private fun RecordTimelineItemV06(
     record: ChargingRecordEntity,
     onEdit: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onEdit)
             .padding(vertical = MaterialTheme.spacing.xs),
-        verticalAlignment = Alignment.Top
+        verticalAlignment = Alignment.Top,
     ) {
         ChargingRailV06()
         Spacer(Modifier.width(MaterialTheme.spacing.sm))
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(5.dp)
+            verticalArrangement = Arrangement.spacedBy(5.dp),
         ) {
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
                 Column(Modifier.weight(1f)) {
@@ -211,25 +360,21 @@ private fun RecordTimelineItemV06(
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.SemiBold,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         format(record.chargeTimeEpochMillis),
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Spacer(Modifier.width(MaterialTheme.spacing.sm))
                 Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        "¥ ${two(record.cost)}",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    Text("¥ ${two(record.cost)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                     Text(
                         "+${one(record.energyKwh)} kWh",
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary
+                        color = MaterialTheme.colorScheme.primary,
                     )
                 }
             }
@@ -238,11 +383,11 @@ private fun RecordTimelineItemV06(
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
                         "SOC ${record.startSoc}% → ${record.endSoc}% · ¥ ${two(record.pricePerKwh)}/kWh",
-                        style = MaterialTheme.typography.bodySmall
+                        style = MaterialTheme.typography.bodySmall,
                     )
                     val extras = listOfNotNull(
                         record.chargerType?.takeIf { it.isNotBlank() },
-                        record.odometerKm?.let { "里程 ${formatKm(it)} km" }
+                        record.odometerKm?.let { "里程 ${formatKm(it)} km" },
                     )
                     if (extras.isNotEmpty()) {
                         Text(
@@ -250,7 +395,7 @@ private fun RecordTimelineItemV06(
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                 }
@@ -259,7 +404,7 @@ private fun RecordTimelineItemV06(
                         Icons.Default.DeleteOutline,
                         contentDescription = "删除此记录",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(18.dp),
                     )
                 }
             }
@@ -274,14 +419,14 @@ private fun ChargingRailV06() {
         Surface(
             modifier = Modifier.size(28.dp),
             shape = CircleShape,
-            color = MaterialTheme.colorScheme.primary.copy(alpha = .10f)
+            color = MaterialTheme.colorScheme.primary.copy(alpha = .10f),
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
                     Icons.Default.Bolt,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(15.dp)
+                    modifier = Modifier.size(15.dp),
                 )
             }
         }
@@ -289,7 +434,7 @@ private fun ChargingRailV06() {
             Modifier
                 .width(1.dp)
                 .height(66.dp)
-                .background(MaterialTheme.colorScheme.outline.copy(alpha = .32f))
+                .background(MaterialTheme.colorScheme.outline.copy(alpha = .32f)),
         )
     }
 }
@@ -298,6 +443,13 @@ private fun format(value: Long) = DateTimeFormatter.ofPattern("M月d日 HH:mm")
     .withLocale(Locale.SIMPLIFIED_CHINESE)
     .withZone(ZoneId.systemDefault())
     .format(Instant.ofEpochMilli(value))
+
+private fun formatElapsed(milliseconds: Long): String {
+    val totalMinutes = milliseconds / 60_000L
+    val hours = totalMinutes / 60L
+    val minutes = totalMinutes % 60L
+    return if (hours > 0L) "${hours}小时${minutes}分" else "${minutes}分钟"
+}
 
 private fun formatKm(value: Double) =
     if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)

--- a/android/app/src/main/java/com/evchargebook/ui/records/StartChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/StartChargingScreen.kt
@@ -1,0 +1,511 @@
+package com.evchargebook.ui.records
+
+import android.Manifest
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.pm.PackageManager
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.evchargebook.data.entity.ChargingSessionEntity
+import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.data.repository.StartChargingSessionRequest
+import com.evchargebook.location.AndroidGeocoderAddressResolver
+import com.evchargebook.location.AndroidLocationProvider
+import com.evchargebook.ui.theme.spacing
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+private val ActiveChargingTypes = listOf("家充", "公共慢充", "公共快充", "超充", "闪充")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StartChargingScreen(
+    vehicle: VehicleEntity,
+    currentSoc: Int?,
+    commonPlaces: List<String>,
+    existingSession: ChargingSessionEntity? = null,
+    onBack: () -> Unit,
+    onStart: (StartChargingSessionRequest) -> Unit,
+    onUpdate: (ChargingSessionEntity) -> Unit,
+) {
+    val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
+    val scope = rememberCoroutineScope()
+    val locationProvider = remember(context) { AndroidLocationProvider(context.applicationContext) }
+    val addressResolver = remember(context) { AndroidGeocoderAddressResolver(context.applicationContext) }
+    val defaultStartedAt = remember { System.currentTimeMillis() }
+    val initialStartedAt = existingSession?.startedAtEpochMillis ?: defaultStartedAt
+    val initialLocation = existingSession?.location.orEmpty()
+    val initialStartSoc = existingSession?.startSoc?.toString().orEmpty()
+    val initialTargetSoc = existingSession?.targetSoc?.toString().orEmpty()
+    val initialType = existingSession?.chargerType.orEmpty()
+    val initialPrice = existingSession?.unitPricePerKwh?.toEditableChargingNumber().orEmpty()
+    val initialRemark = existingSession?.remark.orEmpty()
+
+    var startedAt by remember(existingSession?.id) { mutableLongStateOf(initialStartedAt) }
+    var startSoc by remember(existingSession?.id) { mutableStateOf(initialStartSoc) }
+    var targetSoc by remember(existingSession?.id) { mutableStateOf(initialTargetSoc) }
+    var chargerType by remember(existingSession?.id) { mutableStateOf(initialType) }
+    var unitPrice by remember(existingSession?.id) { mutableStateOf(initialPrice) }
+    var location by remember(existingSession?.id) { mutableStateOf(initialLocation) }
+    var latitude by remember(existingSession?.id) { mutableStateOf(existingSession?.latitude) }
+    var longitude by remember(existingSession?.id) { mutableStateOf(existingSession?.longitude) }
+    var accuracyMeters by remember(existingSession?.id) { mutableStateOf(existingSession?.locationAccuracyMeters) }
+    var remark by remember(existingSession?.id) { mutableStateOf(initialRemark) }
+    var locating by remember { mutableStateOf(false) }
+    var locationMessage by remember { mutableStateOf<String?>(null) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var showDiscardConfirm by remember { mutableStateOf(false) }
+
+    val isEditing = existingSession != null
+    val isDirty = startedAt != initialStartedAt ||
+        startSoc != initialStartSoc || targetSoc != initialTargetSoc || chargerType != initialType ||
+        unitPrice != initialPrice || location != initialLocation || remark != initialRemark ||
+        latitude != existingSession?.latitude || longitude != existingSession?.longitude ||
+        accuracyMeters != existingSession?.locationAccuracyMeters
+
+    fun clearCoordinateEvidence() {
+        latitude = null
+        longitude = null
+        accuracyMeters = null
+        locationMessage = null
+    }
+
+    fun requestBack() {
+        if (isDirty) showDiscardConfirm = true else onBack()
+    }
+
+    BackHandler(enabled = isDirty) { showDiscardConfirm = true }
+
+    fun requestCurrentLocation() {
+        locating = true
+        locationMessage = null
+        scope.launch {
+            runCatching { locationProvider.currentLocation() }
+                .onSuccess { fix ->
+                    latitude = fix.latitude
+                    longitude = fix.longitude
+                    accuracyMeters = fix.accuracyMeters.toDouble()
+                    val resolved = addressResolver.reverse(fix.latitude, fix.longitude)
+                    if (!resolved.isNullOrBlank()) {
+                        location = resolved
+                        locationMessage = "已使用当前位置"
+                    } else {
+                        locationMessage = "已保存当前位置坐标；地址解析暂不可用"
+                    }
+                }
+                .onFailure { locationMessage = it.message ?: "暂时无法获取当前位置" }
+            locating = false
+        }
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) requestCurrentLocation()
+        else locationMessage = "未授予精确定位权限，可继续手动填写地点"
+    }
+
+    LaunchedEffect(existingSession?.id) {
+        if (existingSession == null) {
+            if (
+                ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+            ) requestCurrentLocation()
+            else locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    val dateText = remember(startedAt) {
+        SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(startedAt)
+    }
+    val timeText = remember(startedAt) {
+        SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(startedAt)
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(
+                            if (isEditing) "编辑充电中" else "开始充电",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            if (isEditing) "ACTIVE CHARGE" else "START CHARGE",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = ::requestBack) { Icon(Icons.Default.ArrowBack, "返回") }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg),
+        ) {
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+
+            ChargingStartSection("车辆", "VEHICLE") {
+                Text(vehicle.displayName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    "${vehicle.brand} · ${vehicle.model}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                currentSoc?.let {
+                    Text(
+                        "账本当前 SOC $it% · 仅供参考，不自动写入本次开始 SOC",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            ChargingStartSection("开始时间", "START TIME") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    OutlinedButton(
+                        onClick = {
+                            val calendar = Calendar.getInstance().apply { timeInMillis = startedAt }
+                            DatePickerDialog(
+                                context,
+                                { _, year, month, day ->
+                                    calendar.set(Calendar.YEAR, year)
+                                    calendar.set(Calendar.MONTH, month)
+                                    calendar.set(Calendar.DAY_OF_MONTH, day)
+                                    startedAt = calendar.timeInMillis
+                                },
+                                calendar.get(Calendar.YEAR),
+                                calendar.get(Calendar.MONTH),
+                                calendar.get(Calendar.DAY_OF_MONTH),
+                            ).show()
+                        },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.Default.CalendarMonth, null)
+                        Spacer(Modifier.width(6.dp))
+                        Text(dateText)
+                    }
+                    OutlinedButton(
+                        onClick = {
+                            val calendar = Calendar.getInstance().apply { timeInMillis = startedAt }
+                            TimePickerDialog(
+                                context,
+                                { _, hour, minute ->
+                                    calendar.set(Calendar.HOUR_OF_DAY, hour)
+                                    calendar.set(Calendar.MINUTE, minute)
+                                    calendar.set(Calendar.SECOND, 0)
+                                    startedAt = calendar.timeInMillis
+                                },
+                                calendar.get(Calendar.HOUR_OF_DAY),
+                                calendar.get(Calendar.MINUTE),
+                                true,
+                            ).show()
+                        },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.Default.Schedule, null)
+                        Spacer(Modifier.width(6.dp))
+                        Text(timeText)
+                    }
+                }
+            }
+
+            ChargingStartSection("SOC", "BATTERY FACTS") {
+                Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+                    ChargingOptionalNumberField(
+                        value = startSoc,
+                        onChange = { startSoc = it.filter(Char::isDigit) },
+                        label = "开始 SOC",
+                        suffix = "%",
+                        modifier = Modifier.weight(1f),
+                        keyboardType = KeyboardType.Number,
+                    )
+                    ChargingOptionalNumberField(
+                        value = targetSoc,
+                        onChange = { targetSoc = it.filter(Char::isDigit) },
+                        label = "目标 SOC",
+                        suffix = "%",
+                        modifier = Modifier.weight(1f),
+                        keyboardType = KeyboardType.Number,
+                    )
+                }
+                Text(
+                    "没有可靠来源时可留空；这里不会显示伪造的实时 SOC。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            ChargingStartSection("充电环境", "CHARGER") {
+                Row(
+                    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+                ) {
+                    ActiveChargingTypes.forEach { type ->
+                        FilterChip(
+                            selected = chargerType == type,
+                            onClick = { chargerType = if (chargerType == type) "" else type },
+                            label = { Text(type) },
+                        )
+                    }
+                }
+                ChargingOptionalNumberField(
+                    value = unitPrice,
+                    onChange = { unitPrice = it },
+                    label = "当前电价",
+                    suffix = "元/kWh",
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardType = KeyboardType.Decimal,
+                )
+                Text(
+                    "电价是可复用的环境输入；最终费用与实际电量仍在结束补录时确认。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            ChargingStartSection("地点", "LOCATION") {
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = { newValue ->
+                        if (newValue != location) clearCoordinateEvidence()
+                        location = newValue
+                    },
+                    label = { Text("充电地点") },
+                    placeholder = { Text("家 / 公司地库 / 充电站，可留空") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                if (commonPlaces.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+                    ) {
+                        commonPlaces.take(5).forEach { place ->
+                            FilterChip(
+                                selected = location == place && latitude == null,
+                                onClick = {
+                                    clearCoordinateEvidence()
+                                    location = place
+                                },
+                                label = { Text(place) },
+                            )
+                        }
+                    }
+                }
+                TextButton(
+                    onClick = {
+                        if (
+                            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+                        ) requestCurrentLocation()
+                        else locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                    },
+                    enabled = !locating,
+                    contentPadding = PaddingValues(0.dp),
+                ) {
+                    Icon(Icons.Default.LocationOn, null)
+                    Text(if (locating) "正在获取位置…" else " 使用当前位置")
+                }
+                locationMessage?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                if (latitude != null && longitude != null) {
+                    Text(
+                        accuracyMeters?.let { "已保存真实坐标 · 精度约 ${it.toInt()} m" } ?: "已保存真实坐标",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            ChargingStartSection("备注", "NOTE") {
+                OutlinedTextField(
+                    value = remark,
+                    onValueChange = { remark = it },
+                    label = { Text("备注") },
+                    placeholder = { Text("可选") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                )
+            }
+
+            errorMessage?.let {
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Button(
+                onClick = {
+                    focusManager.clearFocus()
+                    val startValue = startSoc.takeIf { it.isNotBlank() }?.toIntOrNull()
+                    val targetValue = targetSoc.takeIf { it.isNotBlank() }?.toIntOrNull()
+                    val priceValue = unitPrice.takeIf { it.isNotBlank() }?.toDoubleOrNull()
+                    errorMessage = when {
+                        startSoc.isNotBlank() && (startValue == null || startValue !in 0..100) -> "开始 SOC 需要在 0~100 之间"
+                        targetSoc.isNotBlank() && (targetValue == null || targetValue !in 0..100) -> "目标 SOC 需要在 0~100 之间"
+                        startValue != null && targetValue != null && targetValue < startValue -> "目标 SOC 不能低于开始 SOC"
+                        unitPrice.isNotBlank() && (priceValue == null || priceValue < 0.0) -> "请输入有效电价"
+                        else -> null
+                    }
+                    if (errorMessage == null) {
+                        val request = StartChargingSessionRequest(
+                            vehicleId = vehicle.id,
+                            startedAtEpochMillis = startedAt,
+                            startSoc = startValue,
+                            targetSoc = targetValue,
+                            chargerType = chargerType.trim().takeIf { it.isNotEmpty() },
+                            unitPricePerKwh = priceValue,
+                            location = location.trim().takeIf { it.isNotEmpty() },
+                            remark = remark.trim().takeIf { it.isNotEmpty() },
+                            latitude = latitude,
+                            longitude = longitude,
+                            locationAccuracyMeters = accuracyMeters,
+                        )
+                        if (existingSession == null) {
+                            onStart(request)
+                        } else {
+                            onUpdate(
+                                existingSession.copy(
+                                    startedAtEpochMillis = request.startedAtEpochMillis,
+                                    startSoc = request.startSoc,
+                                    targetSoc = request.targetSoc,
+                                    chargerType = request.chargerType,
+                                    unitPricePerKwh = request.unitPricePerKwh,
+                                    location = request.location,
+                                    remark = request.remark,
+                                    latitude = request.latitude,
+                                    longitude = request.longitude,
+                                    locationAccuracyMeters = request.locationAccuracyMeters,
+                                )
+                            )
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (isEditing) "保存充电信息" else "开始充电")
+            }
+            Spacer(Modifier.height(MaterialTheme.spacing.lg))
+        }
+    }
+
+    if (showDiscardConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDiscardConfirm = false },
+            title = { Text("放弃未保存修改？") },
+            text = { Text(if (isEditing) "当前对进行中充电的修改还没有保存。" else "当前填写的开始充电信息还没有保存。") },
+            confirmButton = {
+                TextButton(onClick = { showDiscardConfirm = false; onBack() }) {
+                    Text("放弃", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = { TextButton(onClick = { showDiscardConfirm = false }) { Text("继续填写") } },
+        )
+    }
+}
+
+@Composable
+private fun ChargingStartSection(
+    title: String,
+    eyebrow: String,
+    content: @Composable () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(eyebrow, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+        content()
+    }
+}
+
+@Composable
+private fun ChargingOptionalNumberField(
+    value: String,
+    onChange: (String) -> Unit,
+    label: String,
+    suffix: String,
+    modifier: Modifier,
+    keyboardType: KeyboardType,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        label = { Text(label) },
+        suffix = { Text(suffix) },
+        modifier = modifier,
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        singleLine = true,
+    )
+}
+
+private fun Double.toEditableChargingNumber(): String {
+    val text = String.format(Locale.US, "%.3f", this)
+    return text.trimEnd('0').trimEnd('.')
+}

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -6,11 +6,13 @@ import androidx.lifecycle.viewModelScope
 import com.evchargebook.bluetooth.BluetoothPromptSettings
 import com.evchargebook.bluetooth.PairedBluetoothDevice
 import com.evchargebook.data.entity.ChargingRecordEntity
+import com.evchargebook.data.entity.ChargingSessionEntity
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.data.repository.StartChargingSessionRequest
 import com.evchargebook.domain.ChargerCategorySummary
 import com.evchargebook.domain.ChargerTypeAnalytics
 import com.evchargebook.domain.ChargingIntervalAnalytics
@@ -38,6 +40,7 @@ data class MainUiState(
     val bluetoothSettings: BluetoothPromptSettings = BluetoothPromptSettings(),
     val pairedBluetoothDevices: List<PairedBluetoothDevice> = emptyList(),
     val chargingRecords: List<ChargingRecordEntity> = emptyList(),
+    val activeChargingSession: ChargingSessionEntity? = null,
     val trips: List<TripSessionEntity> = emptyList(),
     val activeTrip: TripSessionEntity? = null,
     val selectedTripId: Long? = null,
@@ -76,6 +79,7 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
         viewModelScope.launch { repository.ensureDefaultVehicle() }
         viewModelScope.launch { repository.bluetoothSettings.collect { settings -> _uiState.value = _uiState.value.copy(bluetoothSettings = settings) } }
         viewModelScope.launch { repository.activeTrip.collect { trip -> _uiState.value = _uiState.value.copy(activeTrip = trip) } }
+        viewModelScope.launch { repository.activeChargingSession.collect { session -> _uiState.value = _uiState.value.copy(activeChargingSession = session) } }
         viewModelScope.launch {
             repository.vehicleState.collect { vehicleState ->
                 _uiState.value = _uiState.value.copy(
@@ -144,8 +148,9 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
         viewModelScope.launch {
             runCatching { repository.exportBackup(appVersion) }
                 .onSuccess { content ->
-                    if (_uiState.value.activeTrip != null) {
-                        _uiState.value = _uiState.value.copy(successMessage = "已生成备份；当前行程仍在进行，这是进行中快照")
+                    when {
+                        _uiState.value.activeTrip != null -> _uiState.value = _uiState.value.copy(successMessage = "已生成备份；当前行程仍在进行，这是进行中快照")
+                        _uiState.value.activeChargingSession != null -> _uiState.value = _uiState.value.copy(successMessage = "已生成备份；当前充电会话已包含在快照中")
                     }
                     onReady(content)
                 }
@@ -154,14 +159,38 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
     }
 
     fun restoreBackup(content: String) {
-        if (_uiState.value.activeTrip != null) {
-            _uiState.value = _uiState.value.copy(errorMessage = "行程进行中，结束行程后才能恢复备份")
+        if (_uiState.value.activeTrip != null || _uiState.value.activeChargingSession != null) {
+            _uiState.value = _uiState.value.copy(errorMessage = "有进行中的行程或充电，请结束后再恢复备份")
             return
         }
         viewModelScope.launch {
             runCatching { repository.restoreBackup(content) }
                 .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "本地备份已恢复") }
                 .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "备份恢复失败") }
+        }
+    }
+
+    fun startChargingSession(request: StartChargingSessionRequest) {
+        viewModelScope.launch {
+            runCatching { repository.startChargingSession(request) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "充电已开始记录") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法开始充电") }
+        }
+    }
+
+    fun updateActiveChargingSession(session: ChargingSessionEntity) {
+        viewModelScope.launch {
+            runCatching { repository.updateActiveChargingSession(session) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "充电信息已更新") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法更新充电信息") }
+        }
+    }
+
+    fun cancelChargingSession(sessionId: String) {
+        viewModelScope.launch {
+            runCatching { repository.cancelChargingSession(sessionId) }
+                .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "已取消本次充电记录") }
+                .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法取消充电") }
         }
     }
 
@@ -209,11 +238,13 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
 
     fun selectVehicle(vehicleId: Long) {
         val activeTrip = _uiState.value.activeTrip
+        val activeCharging = _uiState.value.activeChargingSession
         viewModelScope.launch {
             runCatching { repository.selectVehicle(vehicleId) }
                 .onSuccess {
-                    if (activeTrip != null && activeTrip.vehicleId != vehicleId) {
-                        _uiState.value = _uiState.value.copy(successMessage = "已切换当前车辆；正在进行的行程仍归属原车辆")
+                    when {
+                        activeTrip != null && activeTrip.vehicleId != vehicleId -> _uiState.value = _uiState.value.copy(successMessage = "已切换当前车辆；正在进行的行程仍归属原车辆")
+                        activeCharging != null && activeCharging.vehicleId != vehicleId -> _uiState.value = _uiState.value.copy(successMessage = "已切换当前车辆；正在进行的充电仍归属原车辆")
                     }
                 }
                 .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message) }
@@ -221,8 +252,8 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
     }
 
     fun archiveVehicle(vehicleId: Long) {
-        if (_uiState.value.activeTrip?.vehicleId == vehicleId) {
-            _uiState.value = _uiState.value.copy(errorMessage = "该车辆正在记录行程，请结束行程后再归档")
+        if (_uiState.value.activeTrip?.vehicleId == vehicleId || _uiState.value.activeChargingSession?.vehicleId == vehicleId) {
+            _uiState.value = _uiState.value.copy(errorMessage = "该车辆有进行中的行程或充电，请结束后再归档")
             return
         }
         viewModelScope.launch {


### PR DESCRIPTION
## Superseded only for Draft metadata workaround

The Start + Active UI implementation passed its final automated merge gate and remains on the exact same branch/head:

- branch `feat/charging-v0.7-active-ui`
- head `f6b60384c100c244dfed05f2b0b134c05810b051`
- base audited against `main@f796fdb4cea0bdbb3307262c0d3504fef649a485`
- ahead 1 / behind 0
- exactly 4 intended UI/wiring files
- Android Build #688 Green on this exact head/base
- no unresolved review threads/comments
- GitHub reported mergeable

This Draft is closed **only** because the connected Draft -> Ready mutation still fails by querying nonexistent GraphQL field `Repository.fullDatabaseId`. No code or branch is discarded.

A non-Draft replacement PR will use this exact same branch/head.

#253 remains Open. This slice does not claim completion UI, process-restart/device migration acceptance, exactly-once physical completion, or final device usability.