### PR TITLE
fix(admin): make resource publish scope explicit

### DIFF
--- a/.github/workflows/admin-resource-publish-guidance.yml
+++ b/.github/workflows/admin-resource-publish-guidance.yml
@@ -1,0 +1,31 @@
+name: Admin Resource Publish Guidance
+
+on:
+  pull_request:
+    paths:
+      - 'hero-admin/static/resource-workbench.html'
+      - 'hero-admin/static/resource-publish-guidance.js'
+      - '.github/workflows/admin-resource-publish-guidance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'hero-admin/static/resource-workbench.html'
+      - 'hero-admin/static/resource-publish-guidance.js'
+      - '.github/workflows/admin-resource-publish-guidance.yml'
+
+jobs:
+  publish-guidance-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate publish guidance JavaScript syntax
+        run: node --check hero-admin/static/resource-publish-guidance.js
+      - name: Verify new-vehicle and image-only contracts
+        run: |
+          grep -F '新增车型首次发布时必须提供' hero-admin/static/resource-workbench.html
+          grep -F '图片维护模式，不会创建或更新车型配置' hero-admin/static/resource-workbench.html
+          grep -F '本次发布计划' hero-admin/static/resource-publish-guidance.js
+          grep -F '车型配置：不会创建/更新（未提供 STEP 1 JSON）' hero-admin/static/resource-publish-guidance.js
+          grep -F '仅发布 ${images.pendingAssets} 个图片资源' hero-admin/static/resource-publish-guidance.js
+          grep -F "setText(button,'已发布完成')" hero-admin/static/resource-publish-guidance.js
+          grep -F '本次发布已完成，无待发布项' hero-admin/static/resource-publish-guidance.js

--- a/hero-admin/static/resource-publish-guidance.js
+++ b/hero-admin/static/resource-publish-guidance.js
@@ -1,0 +1,170 @@
+(function(){
+  const $=id=>document.getElementById(id);
+  const plan=$('publishPlan'), log=$('publishLog'), button=$('publishBundle'), queue=$('resourceQueue');
+  const bundleInput=$('bundleJson'), bundleSummary=$('bundleSummary');
+  if(!plan||!log||!button||!queue||!bundleInput||!bundleSummary)return;
+
+  const BRAND_FIELDS=['name','englishName','isActive'];
+  const VEHICLE_FIELDS=['brandId','series','modelName','modelYear','trimName','powertrainType','batteryCapacityKwh','rangeKm','rangeStandard','heroArtworkKey','isActive'];
+  let catalog=null;
+  let publishStarted=false;
+  let scheduled=false;
+  let refreshing=false;
+
+  function same(a,b){return JSON.stringify(a??null)===JSON.stringify(b??null)}
+  function changed(current,next,fields){return !current||fields.some(field=>!same(current?.[field],next?.[field]))}
+  function setText(el,text){if(el.textContent!==text)el.textContent=text}
+
+  function parsedBundle(){
+    const text=bundleInput.value.trim();
+    if(!text)return {hasJson:false,valid:false,info:null};
+    if(!/校验通过/.test(bundleSummary.textContent||''))return {hasJson:true,valid:false,info:null};
+    try{
+      const raw=JSON.parse(text);
+      const catalogImport=raw.format==='ev-charge-book-resource-bundle'?raw.catalogImport:raw;
+      const brand=catalogImport?.brands?.[0]||null;
+      const vehicle=catalogImport?.vehicles?.[0]||null;
+      if(!brand||!vehicle)return {hasJson:true,valid:false,info:null};
+      return {hasJson:true,valid:true,info:{brand,vehicle}};
+    }catch(_){
+      return {hasJson:true,valid:false,info:null};
+    }
+  }
+
+  function configPlan(bundleState){
+    if(!bundleState.hasJson)return {pending:false,label:'车型配置：不会创建/更新（未提供 STEP 1 JSON）'};
+    if(!bundleState.valid)return {pending:true,label:'车型配置：JSON 尚未通过校验'};
+    if(!catalog)return {pending:true,label:'车型配置：正在读取线上 Catalog…'};
+
+    const {brand,vehicle}=bundleState.info;
+    const currentBrand=(catalog.brands||[]).find(item=>item.brandId===brand.brandId);
+    const currentVehicle=(catalog.vehicles||[]).find(item=>item.catalogId===vehicle.catalogId);
+    const brandPending=changed(currentBrand,brand,BRAND_FIELDS);
+    const vehiclePending=changed(currentVehicle,vehicle,VEHICLE_FIELDS);
+    const brandAction=!currentBrand?`创建品牌 ${brand.brandId}`:brandPending?`更新品牌 ${brand.brandId}`:`复用品牌 ${brand.brandId}`;
+    const logoReuse=currentBrand&&!brandPending
+      ? `；Logo 复用 Light v${Number(currentBrand.logoLightVersion||0)} / Dark v${Number(currentBrand.logoDarkVersion||0)}`
+      : '';
+    const vehicleAction=!currentVehicle?`创建车型 ${vehicle.catalogId}`:vehiclePending?`更新车型 ${vehicle.catalogId}`:`车型 ${vehicle.catalogId} 配置无变动`;
+    return {pending:brandPending||vehiclePending,label:`品牌：${brandAction}${logoReuse} · 车型：${vehicleAction}`};
+  }
+
+  function imagePlan(){
+    const rowEls=[...queue.querySelectorAll('.queue-row')];
+    const result={rows:rowEls.length,pendingRows:0,doneRows:0,badRows:0,pendingAssets:0,doneAssets:0,logoPending:0,heroPending:0};
+    for(const row of rowEls){
+      const state=['ready','update','done','blocked','invalid'].find(name=>row.classList.contains(name))||'';
+      const kind=row.querySelector('.kind-select')?.value||'';
+      const variant=row.querySelector('.variant-select')?.value||'';
+      const units=kind==='logo'&&variant==='both'?2:1;
+      if(state==='ready'||state==='update'){
+        result.pendingRows++;
+        result.pendingAssets+=units;
+        if(kind==='logo')result.logoPending+=units;
+        if(kind==='hero')result.heroPending+=units;
+      }else if(state==='done'){
+        result.doneRows++;
+        result.doneAssets+=units;
+      }else if(state==='blocked'||state==='invalid')result.badRows++;
+    }
+    return result;
+  }
+
+  function render(){
+    scheduled=false;
+    const bundleState=parsedBundle();
+    const config=configPlan(bundleState);
+    const images=imagePlan();
+    const parts=[config.label];
+
+    if(images.pendingAssets){
+      parts.push(`待发布图片 ${images.pendingAssets} 项（Logo ${images.logoPending} / Hero ${images.heroPending}）`);
+    }else if(images.doneAssets){
+      parts.push(`图片已发布 ${images.doneAssets} 项，无待发布图片`);
+    }else{
+      parts.push('本次没有待发布图片');
+    }
+    if(images.badRows)parts.push(`仍有 ${images.badRows} 行需要处理`);
+    setText(plan,`本次发布计划：${parts.join(' · ')}`);
+
+    if(!bundleState.hasJson){
+      const current=bundleSummary.textContent||'';
+      if(!current||current==='未载入资源包。只批量上传图片时可以跳过本步骤。'){
+        setText(bundleSummary,'未载入资源包：当前是图片维护模式，不会创建或更新车型配置。新增车型请先粘贴并校验单车型 JSON。');
+      }
+    }
+
+    const completed=publishStarted&&!config.pending&&images.pendingRows===0&&images.badRows===0&&(
+      (images.rows>0&&images.doneRows===images.rows)||(images.rows===0&&bundleState.valid)
+    );
+
+    if(completed){
+      button.disabled=true;
+      setText(button,'已发布完成');
+      if((log.textContent||'').includes('预检通过'))setText(log,'本次发布已完成，无待发布项。');
+      log.className='publish-log ok';
+      return;
+    }
+
+    if(!bundleState.hasJson&&images.pendingAssets>0){
+      if(!button.disabled)setText(button,`仅发布 ${images.pendingAssets} 个图片资源`);
+      if((log.textContent||'')==='预检通过，可以发布'){
+        setText(log,`图片维护模式预检通过：本次只发布 ${images.pendingAssets} 个图片资源，不会创建或更新车型。新增车型请先在 STEP 1 提供 JSON。`);
+        log.className='publish-log warn';
+      }
+      return;
+    }
+
+    if(bundleState.valid&&(config.pending||images.pendingAssets>0)){
+      if(!button.disabled)setText(button,'确认并发布整套资源');
+      if((log.textContent||'')==='预检通过，可以发布'){
+        setText(log,`预检通过：${config.label}；待发布图片 ${images.pendingAssets} 项。`);
+        log.className='publish-log ok';
+      }
+    }
+  }
+
+  function schedule(){
+    if(scheduled)return;
+    scheduled=true;
+    queueMicrotask(render);
+  }
+
+  async function refreshCatalog(){
+    if(refreshing)return;
+    refreshing=true;
+    try{
+      const response=await fetch('../api/catalog/state',{headers:{Accept:'application/json'}});
+      if(response.ok)catalog=await response.json();
+    }catch(_){
+      // The core workbench already owns runtime error reporting.
+    }finally{
+      refreshing=false;
+      schedule();
+    }
+  }
+
+  button.addEventListener('click',()=>{
+    publishStarted=true;
+    schedule();
+    setTimeout(refreshCatalog,800);
+    setTimeout(refreshCatalog,3000);
+  },true);
+  bundleInput.addEventListener('input',()=>{publishStarted=false;schedule()});
+  $('validateBundle')?.addEventListener('click',()=>setTimeout(schedule,0));
+  $('refreshState')?.addEventListener('click',()=>setTimeout(refreshCatalog,300));
+
+  const observer=new MutationObserver(()=>{
+    if(publishStarted){
+      const images=imagePlan();
+      if(images.pendingRows===0&&!refreshing)void refreshCatalog();
+    }
+    schedule();
+  });
+  observer.observe(queue,{subtree:true,childList:true,attributes:true,attributeFilter:['class','value']});
+  observer.observe(log,{subtree:true,childList:true,characterData:true});
+  observer.observe(bundleSummary,{subtree:true,childList:true,characterData:true});
+
+  void refreshCatalog();
+  schedule();
+})();

--- a/hero-admin/static/resource-workbench.html
+++ b/hero-admin/static/resource-workbench.html
@@ -26,9 +26,9 @@
   <section class="card">
     <div class="section-head">
       <div>
-        <div class="eyebrow">STEP 1 · OPTIONAL CONFIG</div>
+        <div class="eyebrow">STEP 1 · NEW VEHICLE CONFIG</div>
         <h2>单车型资源包 JSON</h2>
-        <p>可直接粘贴「全量资产包 Prompt」返回的 JSON。也兼容单条 <code>ev-charge-book-vehicle-catalog v1</code> JSON。</p>
+        <p><strong>新增车型首次发布时必须提供。</strong>已有车型只维护 Logo / Hero 时可以跳过。可直接粘贴「全量资产包 Prompt」返回的 JSON，也兼容单条 <code>ev-charge-book-vehicle-catalog v1</code> JSON；图片文件名不会被用来猜测年款、电池、续航等标准参数。</p>
       </div>
       <div class="actions">
         <button id="readClipboard" class="secondary">从剪贴板读取</button>
@@ -36,7 +36,7 @@
       </div>
     </div>
     <textarea id="bundleJson" spellcheck="false" placeholder='粘贴 { "format": "ev-charge-book-resource-bundle", ... }'></textarea>
-    <div class="bundle-summary" id="bundleSummary">未载入资源包。只批量上传图片时可以跳过本步骤。</div>
+    <div class="bundle-summary" id="bundleSummary">未载入资源包：当前是图片维护模式，不会创建或更新车型配置。</div>
     <div class="diff-list" id="bundleDiff"></div>
     <label class="confirm-line hidden" id="configUpdateConfirmWrap">
       <input type="checkbox" id="configUpdateConfirm" />
@@ -76,16 +76,18 @@
     <div>
       <div class="eyebrow">STEP 3 · REVIEW & PUBLISH</div>
       <h2>确认并发布整套资源</h2>
-      <p>执行顺序：品牌配置 → 车型配置 → Logo → Hero。任何未匹配、校验失败或未确认的重复 Hero 都会阻止误发布；PNG / WebP 都会由发布端输出成规范 WebP，图片原始文件名不会直接落盘。</p>
+      <p>只有 STEP 1 已载入并校验 JSON 时才会写入品牌 / 车型配置；没有 JSON 时仅发布图片资源。Logo → Hero 图片继续按队列发布，PNG / WebP 都会由发布端输出成规范 WebP。</p>
     </div>
     <div class="publish-actions">
       <button id="refreshState" class="secondary">刷新线上状态</button>
       <button id="publishBundle" disabled>确认并发布整套资源</button>
     </div>
-    <div class="publish-log" id="publishLog">等待校验。</div>
+    <div class="status-strip" id="publishPlan">正在计算本次发布计划…</div>
+    <div class="publish-log" id="publishLog">尚未开始发布。</div>
   </section>
 </main>
 <script src="resource-workbench.js"></script>
 <script src="png-auto-webp.js"></script>
+<script src="resource-publish-guidance.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the confusing post-publish state in the vehicle resource workbench and makes vehicle-config publishing explicit.

- new vehicle creation now clearly requires a validated single-vehicle JSON bundle
- image-only mode explicitly says it will not create/update vehicle catalog entries
- STEP 3 shows a concrete publish plan: brand action, vehicle action, reused logo versions, and pending image counts
- image-only button label becomes `仅发布 N 个图片资源`
- after all queued work is complete the publish button becomes `已发布完成` and stays disabled
- avoids the previous bug where completed rows returned to `预检通过，可以发布`
- adds a CI contract for these states

No vehicle specs are inferred from Hero filenames; filenames remain resource matching hints only.