### PR TITLE
fix(android): guide reliable background Trip recording

### DIFF
--- a/android/app/src/main/java/com/evchargebook/trip/TripBackgroundExecutionDiagnostics.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripBackgroundExecutionDiagnostics.kt
@@ -4,7 +4,6 @@ import android.app.ActivityManager
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
-import android.location.LocationManager
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
@@ -40,7 +39,6 @@ object TripBackgroundExecutionDiagnostics {
         val appContext = context.applicationContext
         val power = appContext.getSystemService(PowerManager::class.java)
         val activity = appContext.getSystemService(ActivityManager::class.java)
-        val location = appContext.getSystemService(LocationManager::class.java)
         val usage = appContext.getSystemService(UsageStatsManager::class.java)
         val processInfo = ActivityManager.RunningAppProcessInfo()
         ActivityManager.getMyMemoryState(processInfo)
@@ -64,8 +62,8 @@ object TripBackgroundExecutionDiagnostics {
             } else {
                 null
             },
-            locationPowerSaveMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                runCatching { location.locationPowerSaveMode }.getOrNull()
+            locationPowerSaveMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching { power.locationPowerSaveMode }.getOrNull()
             } else {
                 null
             },

--- a/android/app/src/main/java/com/evchargebook/trip/TripBackgroundExecutionDiagnostics.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripBackgroundExecutionDiagnostics.kt
@@ -1,0 +1,93 @@
+package com.evchargebook.trip
+
+import android.app.ActivityManager
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.location.LocationManager
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+
+data class TripBackgroundExecutionState(
+    val powerSave: Boolean,
+    val deviceIdle: Boolean,
+    val interactive: Boolean,
+    val ignoringBatteryOptimizations: Boolean,
+    val backgroundRestricted: Boolean,
+    val appStandbyBucket: Int?,
+    val locationPowerSaveMode: Int?,
+    val processImportance: Int,
+) {
+    val needsUserAttention: Boolean
+        get() = backgroundRestricted || !ignoringBatteryOptimizations
+
+    fun diagnosticDetail(): String = buildString {
+        append("powerSave=$powerSave")
+        append(" deviceIdle=$deviceIdle")
+        append(" interactive=$interactive")
+        append(" ignoringBatteryOptimizations=$ignoringBatteryOptimizations")
+        append(" backgroundRestricted=$backgroundRestricted")
+        append(" appStandbyBucket=${appStandbyBucket ?: -1}")
+        append(" locationPowerSaveMode=${locationPowerSaveMode ?: -1}")
+        append(" processImportance=$processImportance")
+    }
+}
+
+object TripBackgroundExecutionDiagnostics {
+    fun read(context: Context): TripBackgroundExecutionState {
+        val appContext = context.applicationContext
+        val power = appContext.getSystemService(PowerManager::class.java)
+        val activity = appContext.getSystemService(ActivityManager::class.java)
+        val location = appContext.getSystemService(LocationManager::class.java)
+        val usage = appContext.getSystemService(UsageStatsManager::class.java)
+        val processInfo = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(processInfo)
+
+        return TripBackgroundExecutionState(
+            powerSave = power.isPowerSaveMode,
+            deviceIdle = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) power.isDeviceIdleMode else false,
+            interactive = power.isInteractive,
+            ignoringBatteryOptimizations = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                runCatching { power.isIgnoringBatteryOptimizations(appContext.packageName) }.getOrDefault(false)
+            } else {
+                true
+            },
+            backgroundRestricted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                activity.isBackgroundRestricted
+            } else {
+                false
+            },
+            appStandbyBucket = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                runCatching { usage.appStandbyBucket }.getOrNull()
+            } else {
+                null
+            },
+            locationPowerSaveMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                runCatching { location.locationPowerSaveMode }.getOrNull()
+            } else {
+                null
+            },
+            processImportance = processInfo.importance,
+        )
+    }
+
+    fun appDetailsIntent(context: Context): Intent =
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.parse("package:${context.packageName}")
+        }
+
+    fun manufacturerGuidance(): String? {
+        val manufacturer = Build.MANUFACTURER.lowercase()
+        val brand = Build.BRAND.lowercase()
+        val isColorOsFamily = listOf("oneplus", "oppo", "realme").any { marker ->
+            manufacturer.contains(marker) || brand.contains(marker)
+        }
+        return if (isColorOsFamily) {
+            "建议在电池/耗电管理中允许后台活动，并在最近任务中锁定 EV Charge Book。"
+        } else {
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripBackgroundRecordingGuidance.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripBackgroundRecordingGuidance.kt
@@ -1,6 +1,5 @@
 package com.evchargebook.ui.trip
 
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -20,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.evchargebook.trip.TripBackgroundExecutionDiagnostics
 import com.evchargebook.trip.TripBackgroundExecutionState
 import com.evchargebook.ui.theme.spacing

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripBackgroundRecordingGuidance.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripBackgroundRecordingGuidance.kt
@@ -1,0 +1,110 @@
+package com.evchargebook.ui.trip
+
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.evchargebook.trip.TripBackgroundExecutionDiagnostics
+import com.evchargebook.trip.TripBackgroundExecutionState
+import com.evchargebook.ui.theme.spacing
+
+@Composable
+internal fun TripBackgroundRecordingGuidance() {
+    val context = LocalContext.current
+    val preferences = remember(context) {
+        context.getSharedPreferences(PREFERENCES_NAME, 0)
+    }
+    var acknowledged by remember {
+        mutableStateOf(preferences.getBoolean(KEY_ACKNOWLEDGED, false))
+    }
+    var state by remember {
+        mutableStateOf(TripBackgroundExecutionDiagnostics.read(context))
+    }
+    val settingsLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        state = TripBackgroundExecutionDiagnostics.read(context)
+    }
+
+    if (acknowledged || !state.needsUserAttention) return
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+        ) {
+            Text(
+                "后台记录保护",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                backgroundGuidanceText(state),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            TripBackgroundExecutionDiagnostics.manufacturerGuidance()?.let { guidance ->
+                Text(
+                    guidance,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(
+                    onClick = {
+                        settingsLauncher.launch(
+                            TripBackgroundExecutionDiagnostics.appDetailsIntent(context)
+                        )
+                    },
+                ) {
+                    Text("去设置")
+                }
+                TextButton(
+                    onClick = {
+                        preferences.edit().putBoolean(KEY_ACKNOWLEDGED, true).apply()
+                        acknowledged = true
+                    },
+                ) {
+                    Text("已完成")
+                }
+            }
+        }
+    }
+}
+
+private fun backgroundGuidanceText(state: TripBackgroundExecutionState): String = when {
+    state.backgroundRestricted ->
+        "系统已限制 EV Charge Book 的后台活动。锁屏或切换 App 后可能出现轨迹中断，建议解除后台限制后再开始长途记录。"
+    !state.ignoringBatteryOptimizations ->
+        "部分手机会在锁屏或切换 App 后限制持续定位。为减少轨迹缺口，建议允许 EV Charge Book 持续后台运行。"
+    else ->
+        "为减少锁屏或切换 App 后的轨迹缺口，建议允许 EV Charge Book 持续后台运行。"
+}
+
+private const val PREFERENCES_NAME = "trip_background_recording_guidance"
+private const val KEY_ACKNOWLEDGED = "acknowledged"

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -335,6 +335,9 @@ private fun TripPreparationContentV06(
             )
         }
         item {
+            TripBackgroundRecordingGuidance()
+        }
+        item {
             TripSlideAction(
                 label = "滑动开始行程",
                 enabled = vehicle != null,


### PR DESCRIPTION
## Summary
- add a Trip preparation card that warns when Android reports background restrictions or battery optimization is still active
- route the user to the app's system settings without adding a new sensitive permission or blocking Trip start
- add explicit OnePlus / OPPO / realme guidance to allow background activity and lock EV Charge Book in recent tasks
- keep the guidance one-time once the user confirms setup
- centralize background execution diagnostics so future exports can include standby / location power-save / process importance signals

## Why
Physical-device A/B evidence from 2026-09-02 on the same OnePlus device and app version shows the failure is not a `TripTrackingService` destroy/restart. The failing Trip had two in-motion long gaps (445s / 6.89 km and 261s / 4.55 km) while the next Trip, after locking the app in recent tasks, had no comparable in-motion gap. Android's standard `backgroundRestricted` flag remained false, which points to OEM background/location scheduling rather than the existing GPS sampling algorithm.

## Scope
This intentionally does **not** change Fused/Platform location sampling, continuity rules, foreground-service lifecycle, or request `ACCESS_BACKGROUND_LOCATION` / direct battery-optimization exemption.

Refs #26 #77