### PR TITLE
docs: sync Trip location authority after monotonic timing

### DIFF
--- a/docs/LOCATION_TRIP.md
+++ b/docs/LOCATION_TRIP.md
@@ -1,36 +1,55 @@
 # EV Charge Book Location / Map / Trip Tracking Design
 
-版本: v1.4.0
-更新时间: 2026-08-27
-状态: Authority Subdocument
+版本: v1.5.0
+更新时间: 2026-09-02
+状态: Authority Subdocument / Current Main + Physical Acceptance Pending
 
 ## 1. 目标
 
-为 EV Charge Book 增加低成本、Local First 的定位与行程记录能力，记录真实驾驶轨迹并形成可解释的数据资产。
+为 EV Charge Book 提供低成本、Local First、可诊断的定位与行程记录能力，记录真实驾驶轨迹并形成可解释的数据资产。
 
-核心原则:
+核心原则：
 
 1. 定位记录与地图展示解耦。
 2. 原始轨迹默认保存在本地 Room。
 3. 不依赖单一地图厂商才能完成行程记录。
-4. 用户必须明确启动记录；v0.2 不做无感后台自动追踪。
+4. 用户必须明确启动记录；自动化只能在显式 opt-in 和 Android 后台限制允许的范围内演进。
 5. 位置信息属于敏感数据，权限、通知和数据保留必须透明。
-6. 记录可靠性优先于采样频率，必须控制耗电和数据库体积。
-7. 不能用两端 GPS 点直连来伪造缺失路线；GPS gap 必须显式表达。
-8. 在没有道路类型/限速/交通数据前，速度颜色只能表达本车速度分布，不能宣称真实拥堵等级。
-9. 速度值必须保留来源语义；GNSS、位置差分和未来 OBD 不得混成一个无来源数字。
+6. 记录可靠性优先于视觉完整度；真实缺失必须暴露，不能补造。
+7. 不能用两端 GPS 点直连来伪造缺失路线；GPS gap / capture-clock rebase 必须显式断开。
+8. 在没有道路类型、限速、map matching 或交通数据前，速度颜色只能表达本车可信速度分布，不能宣称真实拥堵等级。
+9. GNSS、点间派生速度和未来 OBD 数据必须保留来源语义，不混成一个无来源数字。
+10. Android civil time 与 monotonic time 分工明确：epoch 用于人类可读时间，elapsed realtime 用于新 Trip 的区间/顺序/健康判断。
 
-详细可靠性与速度可视化方案见 `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`。
+详细可靠性与速度可视化方案见 `TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md`。当前物理可靠性 owner 为 #77。
 
 ---
 
 ## 2. 技术决策
 
-### 定位核心
+### 2.1 定位核心
 
-优先使用 Android 系统 Location API / GNSS 能力，并封装 `LocationProvider` 接口。
+当前 production acquisition path：
 
-记录能力不要求地图 SDK。Android Location 可提供:
+```text
+TripTrackingService (location foreground service)
+  -> FusedLocationProviderClient / HIGH_ACCURACY / ~1Hz / minDistance=0
+  -> 约 12s primary silent watchdog
+  -> Platform GPS + Network fallback
+  -> Trip continuity / quality / sampling rules
+  -> Room TripPoint
+```
+
+关键边界：
+
+- Google Fused 是 production 首选来源；
+- non-GMS 或 Fused 注册失败/持续 silent 时回退 Android platform GPS/network；
+- platform fallback 明确不信任某些 ROM 暴露但不回调的 framework `fused` provider；
+- `LocationAvailability` 只作为诊断信号，不单独触发 Trip 中断、不伪造位置；
+- provider fallback 只改变获取来源，不改变已经持久化的位置事实；
+- 当前 source recovery 仍以 `Fused -> platform` 单向 failover 为基线；是否需要 bounded re-probe 由 #283 的真机证据决定。
+
+Android Location 可提供：
 
 - latitude / longitude
 - altitude（设备支持时）
@@ -38,467 +57,441 @@
 - bearing
 - horizontal accuracy
 - speed / altitude accuracy（系统支持时）
-- timestamp
+- epoch timestamp
+- elapsed realtime timestamp
 
-统一保存 WGS84 原始坐标；若未来接入国内地图厂商需要 GCJ-02，仅在地图/provider adapter 层转换，数据库不混存坐标系。
+统一保存 WGS84 原始坐标；未来接入国内地图厂商需要 GCJ-02 时，仅在地图/provider adapter 层转换，数据库不混存坐标系。
 
-### 地图展示
+### 2.2 TripPoint 双时间
 
-首选开源 `MapLibre Native` 作为地图渲染层，并建立 `MapProvider` 接口。
+Room v17 起，TripPoint 同时保存：
 
-MapLibre 本身开源免费，但瓦片/地图数据服务不是天然无限免费。正式公开分发前必须选择合规、可持续的 tile provider 或自托管方案。
+- `capturedAtEpochMillis`：来自 `Location.time`，用于日期、时钟展示、导出以及 legacy fallback；
+- `capturedAtElapsedRealtimeNanos`：来自 `Location.elapsedRealtimeNanos`，在同一 boot 内用于新 Trip 的区间、顺序、长 gap 与显示派生时间轴。
 
-高德作为可选中国地图 adapter，而不是核心记录依赖。
+原因：epoch/civil time 可能因用户校时、NTP/网络校时等前跳或后跳；它不适合成为新数据的首选 interval clock。Android elapsed realtime 在单次 boot 内单调递增，并包含 deep sleep 时间，更适合判断“两个 fix 实际相隔多久”。
+
+v16 历史行与可移植备份恢复点没有可信的 boot-relative monotonic time，因此 v17 migration **不反推、不伪造** elapsed realtime；该字段保持 `NULL`，显式走 epoch fallback。
+
+### 2.3 地图展示
+
+地图 SDK 不是可靠记录成立的前提。MapLibre 仍可作为未来 basemap renderer；高德可作为可选中国地图 adapter，而不是核心记录依赖。
+
+正式公开分发前，tile/provider 合规、成本和长期可用性必须单独评估。
 
 ---
 
-## 3. v0.2 行程流程
+## 3. 行程流程
 
 ```text
 用户选择车辆
-  -> 点击“开始行程”
-  -> 请求精确定位权限
+  -> Trip 准备页
+  -> 检查定位权限 / 后台记录保护提示
+  -> 用户明确开始
   -> 启动 location foreground service
-  -> 持续采样 Location
+  -> Fused / platform acquisition
+  -> callback diagnostics + power/background diagnostics
+  -> quality / continuity / stationary sampling
   -> 写入 Room TripPoint
-  -> 实时更新耗时 / 距离 / 当前速度
-  -> 用户点击“结束行程”
-  -> 计算 TripSession 汇总
-  -> 保存并展示轨迹
+  -> 实时更新可信距离 / 速度 / GPS health
+  -> 用户结束
+  -> completion flow
+  -> 保存并展示概览 / 轨迹 / 数据
 ```
 
-持续记录时显示常驻通知，并提供“结束记录”动作。
+Android 13+ notification permission 拒绝不会阻止已经启动的 Trip；但用户会被告知锁屏时可能看不到 ongoing 状态。
+
+仅获得 approximate/coarse location 时，Trip 准备页会提示开启精确定位。当前提示不强制阻塞用户显式开始，但汽车轨迹产品应把 precise location 视为推荐状态。
 
 ---
 
-## 4. 采样策略
+## 4. 采样与 callback 策略
 
-### 4.1 callback 与持久化必须分层
+### 4.1 callback 与持久化分层
 
-2026-08-27 真机数据证明，不能同时在 Android LocationManager 层和业务层使用较大的位移门槛，否则停车时可能没有 callback，业务层也就无法证明“定位仍健康但车辆静止”。
+历史真机数据证明，不能同时在系统 Location 层和业务层使用较大的位移门槛，否则停车时可能没有 callback，业务层也无法区分“车辆静止”与“定位回调死亡”。
 
-当前实现明确分为两层：
+当前系统 acquisition 层：
 
-**系统 callback 层：**
+- Fused high-accuracy 目标约 1 Hz；
+- min update distance = 0m；
+- max update delay = 0；
+- Fused 首次/后续持续约 12 秒 silent 时切 platform fallback；
+- platform 直接注册 enabled GPS/network provider；
+- callback 活性与写库频率解耦。
 
-- `TripTrackingService` 请求间隔约 4 秒。
-- `SAMPLE_DISTANCE_METERS = 0f`，不再要求至少移动 8m 才允许 callback。
-- 目标是保持时间维度的定位活性与可诊断性，不代表每 4 秒都必须写 Room。
+业务采样/写库层：
 
-**业务采样 / 写库层：**
+- `TripSamplingRules` 负责 accuracy、移动/静止、异常点和写库节流；
+- 移动判定优先使用可信 reported speed，并结合距离证据；
+- stationary GNSS drift 不应累计成行驶距离；
+- 静止阶段约 15 秒级 heartbeat 保留必要事实，不要求每次 ~1Hz callback 都写 Room；
+- moving -> stationary 的首个可信变化应及时落地，避免 UI 长时间残留旧速度。
 
-- `TripSamplingRules` 继续负责 accuracy、跳点、移动/静止判断与写库节流。
-- 移动判定当前以约 `1 m/s` 报告速度或约 `5m` 位移作为基础条件。
-- 静止状态默认约 15 秒保留一个 heartbeat，避免 4 秒一次永久高频写库。
-- accuracy 过差或不可信跳点不参与可信统计。
-
-因此当前设计不是“0m 高频永久采样”，而是：
+所以当前不是“1Hz 永久写库”，而是：
 
 ```text
-Location callback 保活
-  -> 业务质量过滤
-  -> 移动点正常记录 / 静止 heartbeat 降频
+~1Hz acquisition/callback
+  -> quality + continuity
+  -> moving points / stationary heartbeat throttle
   -> Room
 ```
 
-目的:
+### 4.2 callback delivery 与 capture continuity 是不同维度
 
-- 让红灯/停车仍能证明 tracking callback 健康；
-- 降低定位耗电和 Room 数据量；
-- 降低 GPS 抖动造成的假距离；
-- 为后台 callback starvation 提供可诊断证据。
+OEM/锁屏可能延迟派发真实 fix。因此 callback 到达晚不等于 capture gap。
 
-结束行程后可增加轨迹简化用于地图展示；原始点是否长期保留由数据保留策略决定。
+当前：
 
-### 4.2 GPS gap 不是普通降频
-
-静止降频只能解释正常 heartbeat 间隔，不能解释十分钟级位置空洞。
-
-真实行程已经观察到 12 分钟、15 分钟，以及 2026-08-27 第二轮实机中的约 10 分 43 秒 / 7 分 45 秒移动空洞。因此必须继续区分：
-
-- lastLocationCallbackAt
-- lastAcceptedPointAt
-- lastGpsPointAt / lastNetworkPointAt
-- accepted / rejected point count
-- longest gap
-- service lifecycle / re-delivery evidence
-
-PR #36 已实现运行时 GPS health 与 ongoing notification，并在长 gap 时把轨迹拆成多个可信 segment。
-
-PR #80 进一步移除 LocationManager 的 8m callback 位移门槛，让现有 15s stationary heartbeat 有机会在停车状态真正执行。该代码已进入 `main`；“切换其他 App 后是否持续回调”仍属于 #77 真机验收项，不能由 CI 代替。
+- callback freshness 允许有限延迟，使用 `Location.elapsedRealtimeNanos` 与当前 `SystemClock.elapsedRealtimeNanos()` 判断年龄；
+- callback delivery gap 使用 `SystemClock.elapsedRealtime()`；
+- accepted TripPoint 之间的 continuity 使用 persisted capture elapsed realtime；
+- 真正 `>=120s` 的 capture interval 继续硬断开；
+- delayed historical point 若在 monotonic/epoch 证据上都落后于已经 accepted 的新点，继续拒绝。
 
 ---
 
-## 5. 时间、距离与速度口径
+## 5. 时间、连续性、距离与速度口径
 
-Trip 至少区分:
+### 5.1 Capture-time authority
 
-- elapsed time: 开始到结束总耗时
-- moving time: 有效移动时间
-- stopped time: 停车/静止时间
+相邻点的时间判断由 `TripCaptureTimeRules` 统一管理：
 
-首版停车识别采用简单可信规则，不把阈值写成不可变产品事实。当前静止 heartbeat 会把可信静止区间累积到 `stoppedSeconds`；后续仍需用城市道路真机数据继续校准。
+1. 两点都有有效 elapsed realtime 且 current > previous：使用 elapsed realtime delta，哪怕 civil clock 发生回拨；
+2. elapsed 相等：视为 duplicate capture，拒绝；
+3. elapsed 回退、但 epoch 前进：视为 reboot/monotonic-clock rebase，接受当前点作为新 baseline，但跨边界强制断段；
+4. elapsed 与 epoch 都回退：视为 out-of-order historical point，拒绝；
+5. 任一点缺少 elapsed（v16 历史/备份恢复）：显式回退 epoch interval；
+6. legacy epoch fallback 若不递增，同样拒绝。
 
-### 5.1 当前距离如何计算
+`LONG_GAP_SECONDS = 120` 不变。
 
-当前 `distanceMeters` 来自连续 accepted point 之间的可信地理直线距离累计。
+capture-clock rebase 与真实 long gap 的共同原则：
 
-因此它不是道路里程，也不是车辆轮速里程；在以下场景仍会存在偏差：
+- 当前点可以建立新的真实 baseline；
+- 不跨边界累计距离；
+- 不跨边界累计 moving/stopped duration；
+- 不跨边界产生 aggregate/max speed；
+- route / playback / trend / elevation accumulation 均保持断开；
+- 不生成 synthetic point。
 
-- 道路连续弯曲但采样点较稀
-- GPS 漂移
-- GPS / Network provider 切换
-- 长时间 GPS callback/usable-location 缺失
+### 5.2 GPS health time
 
-`TripContinuityRules` 当前已对 `>=120s` 的长 gap 建立 baseline：恢复后的点可以作为新的轨迹起点，但 gap 两端 **不计可信距离、不计该段 moving/stopped duration，也不允许该 gap 直接贡献速度统计**。
+运行中的 GOOD / DEGRADED / LOST / LONG_GAP 是“多久没有 callback / accepted point”的状态，应使用 monotonic delivery clock，而不是 wall clock。
 
-因此“长 gap 两端不得直接累计直线距离”的 P0 规则已经落地，不再是 future follow-up。
+PR #281 后，live GPS health 使用 `SystemClock.elapsedRealtime()` 计算 callback/accepted age，因此手机校时不应制造假 LOST/LONG_GAP。
 
-平均速度仍必须被理解为基于“已记录可信 GPS 距离”的派生值，而不是车辆仪表级道路里程事实。
+### 5.3 当前距离如何计算
 
-### 5.2 当前速度到底来自哪里
+`distanceMeters` 来自连续 accepted point 之间的可信地理直线距离累计。
 
-当前存在不同层次的速度概念：
+它不是道路里程、轮速里程或 map-matched distance。在以下场景仍有误差：
 
-1. `Location.speed`：Android Location 提供的定位时刻速度，原始值保存在 TripPoint `speedMps`。
-2. point-to-point distance / time：用于连续性、距离和速度可信度校验证据，不冒充车辆瞬时速度。
-3. route visualization speed：首版使用相邻两端都通过可信 GPS 质量门的 `Location.speed` 做显示派生。
+- 弯曲道路采样离散；
+- GPS 漂移；
+- provider 切换；
+- 长时间 callback/usable-location 缺失；
+- coarse/approximate location。
 
-PR #82 后，“最高已记录速度”不再允许任意 provider 的原始 `Location.speed` 直接刷新。当前 max-speed candidate 必须满足：
+`>=120s` real gap 或 capture-clock rebase 两端不计可信距离。
+
+### 5.4 时间口径
+
+Trip 区分：
+
+- elapsed time：Trip 开始到结束的产品总耗时；
+- moving time：可信连续区间内有效移动时间；
+- stopped time：可信连续区间内静止时间。
+
+moving/stopped 的 interval evidence 使用 monotonic capture delta；真实 gap/rebase 不被伪装成 moving/stopped。
+
+### 5.5 当前速度来源
+
+1. `Location.speed`：原始定位速度，保存在 TripPoint `speedMps`；
+2. point-to-point distance/time：作为 continuity / quality corroboration，不冒充车辆瞬时速度；
+3. route/trend：只使用通过 measured-speed trust gate 的 GPS 速度派生显示。
+
+可信最高速度 candidate：
 
 - provider = GPS；
 - horizontal accuracy <= 25m；
-- Android 提供 speed accuracy 时，speed accuracy <= 3 m/s；
-- 同时通过现有连续距离/时间 corroboration。
+- speed accuracy 存在时 <= 3 m/s；
+- 同时通过连续距离/时间 corroboration；
+- finite 且非负。
 
-Network fallback 原始速度仍保存在 TripPoint 便于审计，但不能制造新的 `maxSpeedMps`。这正是 2026-08-27 真机中约 122.4 km/h / 142.6 km/h network 粗定位峰值后的修正。
-
-短时速度峰值仍存在漏采可能。例如真实峰值只持续约 4 秒，而定位 callback/accepted point 没有覆盖峰值，则产品不能自行推算。UI 应理解为“最高已记录可信 GNSS 速度”，不是车辆真实最高速度的绝对证明。
-
-### 5.3 速度 UI
-
-必须区分：
-
-1. 全程平均速度：total recorded distance / elapsed time
-2. 行驶平均速度：total recorded distance / moving time
-3. 分段/轨迹速度：可信 route segment 的显示派生
-4. 最高已记录速度：经异常过滤后的可信 GPS `Location.speed` 峰值
-
-PR #36 已把详情页原先模糊的“平均速度”拆成全程均速 / 行驶均速 / 最高速度 / 移动时间。
-
-PR #85 已实现第一版彩色 route preview，不新增 Room 表：
-
-- 只有相邻两点的速度都通过可信 measured-speed 质量门时，该线段才按速度上色；
-- 任一端速度缺失或不可信时保持中性灰色，不把未知速度当成 0 km/h；
-- 长 GPS gap 继续保持断开；
-- 颜色连续映射为深红 -> 红 -> 黄 -> 绿 -> 蓝。
-
-当前颜色语义只代表本车可信 GPS 速度分布：
-
-- 0-5 km/h：深红
-- 5-15 km/h：红
-- 15-30 km/h：红 -> 黄
-- 30-50 km/h：黄 -> 绿
-- 50-70 km/h：绿
-- 70-90 km/h：绿 -> 蓝
-- 90+ km/h：蓝 / 深蓝
-
-在未接道路类型 / 限速 / map matching / 实时交通数据前，不展示“严重拥堵 / 拥堵 / 畅通”等交通事实标签。
-
-更长窗口的 `TripSpeedSegmentBuilder`（例如 20-30 秒 / 200-300m 综合 segment）仍属于后续分析能力，不能把 #85 的相邻可信点颜色渲染误写成已经完成完整分段统计模型。
+Network/coarse 原始速度可保留用于诊断，但不能刷新可信 max speed 或彩色速度 route。
 
 ---
 
-## 6. 速度数据源演进
+## 6. GPS health 与诊断
 
-保持简单的可替换接口思想，不提前做复杂基础设施：
+PR #275/#280/#281 后，selected Trip 的自包含 CSV 能覆盖：
 
-```text
-VehicleSpeedSource
-├── GnssSpeedSource       当前默认，来自 Location.speed
-├── DerivedSpeedSource    GPS 点距离/时间，只做分段派生与校验
-└── ObdSpeedSource        P3 可选，外接 OBD-II 设备
-```
+- Trip summary；
+- 全部 persisted TripPoint；
+- epoch + elapsed realtime capture time；
+- 相邻点 delta / `timeAuthority` / `timeDecision`；
+- long gaps；
+- callback gaps；
+- accepted/rejected/provider/source changes；
+- Fused `LocationAvailability`；
+- Fused registration / silent fallback reason；
+- GPS health transitions；
+- service start / redelivery / destroy；
+- permission/provider failure；
+- POWER_STATE：power save、device idle、interactive、battery optimization allowlist、background restricted、app standby bucket、location power-save mode、process importance；
+- app/Android/OEM/device metadata。
 
-数据来源原则：
-
-- GNSS speed 与 derived speed 必须可区分。
-- future OBD speed 必须保留 `source=OBD`，不得覆盖原始 GNSS 事实。
-- 多来源可以互相校验，但首版不做“智能融合成唯一真值”。
-
-### OBD-II 边界
-
-OBD-II 作为 P3 可选增强方向，优先只验证标准 Vehicle Speed 数据是否可读。
-
-可行的最小实验：
+诊断目标是回答：
 
 ```text
-车辆 OBD-II 口
-  -> Bluetooth/BLE/Wi-Fi adapter
-  -> 查询标准支持能力
-  -> 读取 Vehicle Speed
-  -> 与 GNSS speed 对照
+Service 死了吗？
+callback 根本没来？
+Fused 是否认为 location unavailable？
+是否切到 platform？为什么？
+callback 来了但 point 被拒绝？为什么？
+是 civil clock 变化、真实 long gap，还是 monotonic rebase？
+当时 Android 标准 power/background state 是什么？
 ```
 
-当前不进入产品主线的内容：
-
-- 厂商私有 CAN ID 逆向
-- 私有 BMS PID 逆向
-- 为单一车型维护复杂协议表
-- 以 OBD 作为 Trip 必需依赖
-
-如果未来 OBD 验证出稳定价值，再逐步考虑 SOC / 电压 / 电流 / 电池温度等车辆事实；这些不应阻塞当前 GPS Trip 产品完善。
+诊断数据不授权产品补造缺失轨迹。
 
 ---
 
-## 7. 中断与恢复
+## 7. 中断、恢复与 source failover
 
-真实设备必须考虑:
+真实设备必须考虑：
 
-- App 进程被杀
-- 定位短暂丢失
-- 手机重启
-- 地库/隧道无 GPS
-- foreground service 异常退出
-- foreground service 仍存活但 LocationManager 长时间无 callback
-- foreground service 存活但切换其他 App 后 ROM / 系统限制导致 callback starvation
+- App/Service 被系统销毁；
+- foreground service 仍在但 callback starvation；
+- Fused 注册成功但 silent；
+- provider/location 权限被用户关闭；
+- 地库/隧道无定位；
+- 手机重启；
+- OEM 后台管理导致定位调度变化。
 
-TripSession 使用 `RECORDING / INTERRUPTED / COMPLETED` 状态。
+TripSession 使用 `RECORDING / INTERRUPTED / COMPLETED`。
 
-App 启动时发现未正常结束的 Trip:
+权限或无可用 provider 时：
 
 ```text
-检测到未结束行程
-[继续记录] [结束并保存] [删除]
+RECORDING
+  -> INTERRUPTED
+  -> repair notification / settings
+  -> 用户明确恢复
 ```
 
-禁止静默创建第二条并发 Trip。
+不自动偷偷 resume，不静默创建第二条 Trip。
 
-同一时刻同一设备默认只允许一个活动 Trip。
+当前 source acquisition recovery：
 
-注意：`COMPLETED` 只表示最终正常收口，不代表中间 GPS 连续。因此 GPS continuity 必须独立统计。
+```text
+FUSED
+  -> registration failure / ~12s silence / no GMS
+  -> PLATFORM GPS + NETWORK
+```
+
+是否需要 `PLATFORM -> re-register -> optional FUSED re-probe` 的 bounded recovery 由 #283 管理。没有 current-main 真机失败证据前，不主动增加双向 provider complexity。
 
 ---
 
-## 8. GPS / Network Provider 质量
+## 8. 后台与 OEM 保护
 
-当前允许 GPS + Network provider fallback，但不同 provider 不具备同等统计权限。
+2026-09-02 同一 OnePlus PLU110 / Android API 36 / app 0.7.39 的 A/B：
 
-当前原则与已实现基线：
+- 普通后台 Trip：出现约 445s / 6.89km 与 261s / 4.55km 两个行驶中真实断流；
+- 没有 `SERVICE_DESTROY` / `SERVICE_REDELIVERED`；
+- standard Android snapshot 仍为 `backgroundRestricted=false`；
+- 把 EV Charge Book 锁定在最近任务后，下一次长行程没有同类行驶中 gap。
 
-- GPS 高质量点优先作为主轨迹事实。
-- Network point 可作为 fallback / continuity evidence。
-- 时间非常接近的 GPS / Network point 通过 continuity rule 做去重/择优基线，避免重复计距离。
-- Network / coarse speed 不允许刷新最高速度。
-- PR #85 后，Network / coarse speed 也不允许给 route speed segment 上色。
-- provider switch 与 rejected point 继续保留诊断价值。
+因此当前 evidence 更符合 OEM/background location scheduling，而不是 Service 被直接杀死。
+
+#278/#280 已实现：
+
+- Trip 准备页 `后台记录保护`；
+- 标准 Android background/battery state 检查；
+- OnePlus/OPPO/realme 提示“允许后台活动 + 最近任务锁定”；
+- 用户 acknowledgement 不会掩盖后来真正出现的 `backgroundRestricted=true`；
+- acknowledgement 按 manufacturer/brand/API 作用，系统环境改变后可重新提示；
+- 不申请 `ACCESS_BACKGROUND_LOCATION`；
+- 不直接请求 battery-optimization exemption；
+- 不使用大量 OEM 私有 deep link。
+
+其他 OEM 的专项文案按 #283 真机矩阵逐步增加，不凭想象堆兼容代码。
+
+---
+
+## 9. GPS / Network Provider 质量
+
+当前原则：
+
+- GPS 高质量点优先作为主轨迹事实；
+- Network point 可作为 fallback / continuity evidence；
+- 近期 GPS/network 重复点由 continuity rule 去重/择优；
+- Network/coarse speed 不刷新可信最高速度；
+- Network/coarse speed 不给可信速度 route 上色；
+- source/provider switch 保留诊断；
 - 原始 TripPoint 不因派生统计过滤而被重写。
 
-GPS 海拔:
+Fused 的 provider name 不等于“来源永远健康”；因此当前 watchdog 检测的是 callback silence，而不是“注册成功”这一布尔事实。
 
-- 保存 raw altitude + vertical accuracy（有则保存）。
-- PR #83 已在 Trip 详情展示起点 / 终点 / 最低 / 最高海拔。
-- 累计爬升/下降仍必须经过平滑后计算，当前未实现。
+---
+
+## 10. 海拔与轨迹可视化
+
+海拔：
+
+- 保存 raw altitude + vertical accuracy；
+- 展示 start/end/min/max；
+- cumulative ascent/descent 使用 vertical-accuracy filtering、jitter suppression；
+- real long gap / capture-time rebase 两侧不拼接累计爬升/下降；
 - 不宣称测绘级精度。
 
----
+轨迹：
 
-## 9. 后台与通知
+- `>=120s` real gap / rebase 拆成 disconnected segments；
+- 无 basemap 时也必须断开；
+- MapLibre 未来只负责 renderer，不负责 road snapping 或补造缺失路线；
+- playback、trend X-axis 与 route segmentation 使用与 tracking 相同的 monotonic/legacy-fallback timing policy。
 
-当前前台定位服务持续显示 ongoing notification。
-
-PR #36 已增加：
-
-- GPS health：WAITING / GOOD / DEGRADED / LOST / LONG_GAP
-- 最近有效定位时间
-- 最近 accepted provider
-- rejected point count
-- 同一条通知周期刷新，不刷屏
-- 不显示经纬度或精确地址
-
-PR #80 已增加 callback-liveness 修正：
-
-- LocationManager `minDistance` 从 8m 调整为 0m；
-- 系统 callback 与业务写库节流解耦；
-- 业务层继续使用 stationary heartbeat 控制 Room 写入。
-
-诊断事件已经覆盖 service start / START_REDELIVER_INTENT redelivery / destroy / provider disabled / permission missing / location registration failure 等核心生命周期证据。
-
-仍需继续补或真机确认：
-
-- provider counters
-- longest gap / cumulative gap summary
-- 切换其他 App 5-10 分钟后的真实 callback continuity
-- Android 厂商后台限制/电池优化导致 starvation 时的修复引导
-
-该方向由 #77 与 #26 分别承担数据可靠性和后台修复 UX。
-
----
-
-## 10. GPS Gap 可视化
-
-禁止将长时间缺失的两个 GPS 点直接画成可信实线。
-
-当前按 `>=120s` gap 将路线几何拆成多个可信 segment；预览只绘制 segment 内部连续轨迹。
-
-```text
-已知轨迹 ━━━━━     ━━━━━ 已知轨迹
-             GPS 缺失
-```
-
-同时，距离统计已与该语义对齐：长 gap 两端不再直接累计可信直线距离，也不计算该 gap 的移动/静止时长和 aggregate speed。
-
-无 basemap 阶段即可做断开表达；MapLibre 后续只负责更好的 renderer，不负责补造缺失事实。
+速度颜色只表示本车可信 GPS speed：深红 -> 红 -> 黄 -> 绿 -> 蓝；未知/不可信保持中性。
 
 ---
 
 ## 11. 自动化演进
 
-v0.2 不默认实现“检测开车后自动偷偷开始记录”。
+当前已存在“指定车辆蓝牙连接 -> detection/prompt / 用户 opt-in auto-start”基础，但蓝牙连接不是“车辆正在移动”的事实。
 
-后续顺序:
+原则：
 
-1. 连接指定车载蓝牙时提示开始
-2. Activity Recognition / in_vehicle 作为辅助提示
-3. 用户主动开启“连接车辆后自动记录”后再实现
+- 手动/自动启动统一通过 Trip start coordinator；
+- active Trip 存在时禁止创建第二条；
+- Android 后台 FGS 限制必须真实验证；
+- 蓝牙断开不直接静默结束 Trip；
+- Activity Recognition / 可信连续位移只能作为未来第二证据；
+- 不把普通 App 描述成拥有高德/OEM 系统级白名单能力。
 
-自动开始必须有清晰开关和可见通知。
-
----
-
-## 12. 地点与地址展示
-
-新增充电记录支持:
-
-- 使用当前位置
-- 经纬度保存
-- 地点名称人工编辑
-
-逆地理编码属于独立 provider，不成为保存记录的硬依赖。
-
-PR #83 已把相同的 coordinate-first 原则应用到 Trip 详情：
-
-- WGS84 起终点坐标仍是权威事实；
-- 已完成/中断 Trip 可通过现有 `AndroidGeocoderAddressResolver` 解析起终点地址用于展示；
-- 地址作为主阅读文本，坐标作为技术参数保留；
-- geocoder 失败显示“地址暂不可用”，不得阻止 Trip 完成或虚构地点；
-- RECORDING 中不反复解析实时 endpoint 地址。
-
-后续 ChargingPlace 设计见 `DATA_QUALITY_BACKUP.md`。
+详见 #235。
 
 ---
 
-## 13. 隐私
+## 12. 地点、地址与隐私
 
-- 首次启用解释定位用途
-- 默认本地保存
-- 持续记录必须有通知
-- 云同步轨迹需单独同意
-- 支持单条/全部轨迹清理
-
-后续分享轨迹支持 Privacy Zone:
-
-- HOME 等隐私区域
-- 导出/分享时裁掉隐私区域内精确起终点
-- 本地原始数据可保留
+- WGS84 坐标是原始位置事实；
+- reverse geocoder 是展示派生，不是保存硬依赖；
+- geocoder 失败显示 unavailable，不虚构地址；
+- RECORDING 中不高频反查实时 endpoint；
+- ongoing notification 默认不显示精确经纬度、HOME/WORK 地址；
+- 云同步/分享精确轨迹必须另行获得用户同意；
+- Privacy Zone 仍是后续分享能力。
 
 ---
 
-## 14. 验收目标
+## 13. 当前验收目标
 
-Core 已完成：
+### Code baseline 已完成
 
-- [x] 获取当前位置
-- [x] 充电记录可绑定当前位置
-- [x] 用户手动开始/结束行程
-- [x] 经纬度 / GPS 海拔 / 速度 / 精度 / 时间
-- [x] elapsed / moving / stopped time 数据结构与基础累计
-- [x] 距离 / 平均速度 / 最高速度
-- [x] Trip 绑定具体 Vehicle
-- [x] 中断行程恢复
-- [x] 删除 Trip 同步处理 TripPoint
-- [x] Trip 起终点地址展示 + 坐标技术参数
-- [x] Trip 起点圆形 / 终点方形语义标记
-- [x] Trip 起点 / 终点 / 最低 / 最高海拔展示
+- [x] location foreground service
+- [x] Fused high-accuracy + platform GPS/network fallback
+- [x] ~1Hz acquisition baseline + stationary write throttle
+- [x] user-started Trip / interrupted resume / completion
+- [x] TripPoint raw coordinate/speed/accuracy/altitude/provider
+- [x] Room v17 epoch + nullable elapsed realtime
+- [x] 120s hard continuity boundary
+- [x] no synthetic GPS points / no gap distance bridging
+- [x] stationary drift protection
+- [x] trusted max-speed gate
+- [x] speed-colored route / playback / trend
+- [x] trusted elevation analysis
+- [x] ongoing GPS health + repair notification
+- [x] per-Trip diagnostic CSV
+- [x] Fused LocationAvailability / fallback diagnostics
+- [x] extended Android power/background diagnostics
+- [x] background recording guidance / approximate-location guidance
 
-P0 reliability：
+### #77 physical acceptance 仍未完成
 
-- [x] 运行时 GPS health / accepted point heartbeat
-- [x] GPS LOST / LONG_GAP ongoing notification
-- [x] long gap 路线断开，不画可信实线
-- [x] 长 gap 两端不参与可信距离/时长/aggregate speed
-- [x] GPS/Network 时间邻近去重/择优基线
-- [x] service start / destroy / re-delivery 等诊断事件
-- [x] Network / coarse point 不得制造最高速度峰值
-- [ ] longest gap / provider counters / rejected reason 持久摘要
-- [ ] 切换其他 App 后后台 callback / 距离连续性真机复验（#77）
-- [ ] 2-3 分钟红灯 stationary heartbeat / stoppedSeconds 真机复验（#77）
-- [ ] 最高已记录速度与车辆实际峰值真机复验（#78）
+- [ ] 在已有 v16 真机数据库上升级到 v17 并正常打开，历史 Trip/Charging 数据不丢失；
+- [ ] 锁屏后继续行驶；
+- [ ] 另一 App 前台 5–10 分钟继续行驶；
+- [ ] 2–3 分钟停车/红灯；
+- [ ] 一次真实 provider/location interruption + 手工恢复；
+- [ ] no unexplained in-motion callback gap；
+- [ ] 真正 >=120s gap 保持断开；
+- [ ] new Trip CSV 常规 interval 主要显示 `ELAPSED_REALTIME` authority；
+- [ ] civil clock 校时/回拨不制造假 LONG_GAP / LOST / route reversal；
+- [ ] reboot/rebase 若发生则记录 `CAPTURE_TIME_REBASE` 且跨边界不造距离；
+- [ ] precise/background guidance 真机可理解且不阻塞正常 Trip。
 
-P1 speed visualization：
+CI/JVM tests/Debug APK 不能替代这些结论。
 
-- [x] 全程平均 / 行驶平均 / 最高速度明确区分
-- [x] 可信 GPS 速度连续颜色 route preview
-- [x] 不可信/未知速度 segment 保持中性灰色
-- [x] 长 GPS gap 不跨缺口上色或画可信实线
-- [x] UI 明确“本车速度分布”，不宣称真实道路拥堵
-- [ ] `TripSpeedSegmentBuilder` 长窗口派生模型
-- [ ] 20-30s / 200-300m 等综合 segment 平均速度与 JVM tests
-- [ ] 短时峰值与综合 segment speed 的进一步分析展示
-- [ ] 彩色 route dark/light 真机视觉验收（#67）
+---
 
-P3 optional vehicle data：
+## 14. Future / evidence-driven only
 
-- [ ] OBD-II Vehicle Speed 最小 PoC
-- [ ] GNSS vs OBD 对照验证
-- [ ] 证明稳定价值后再评估更多车辆数据
+以下不作为当前代码 blocker：
 
-Optional：
+- #283 多 OEM 真机矩阵；
+- 只有证据证明需要时才做 bounded platform re-register / Fused re-probe；
+- persistent longest-gap/provider/rejected summary；
+- MapLibre basemap；
+- 更长窗口的 TripSpeedSegmentBuilder；
+- OBD-II Vehicle Speed 最小 PoC；
+- Activity Recognition 作为自动 Trip 第二证据。
 
-- [ ] MapLibre 显示真实 basemap 路线
+明确不做：
+
+- 第二 tracking Service；
+- WorkManager/Alarm 心跳保活；
+- 长期 WakeLock；
+- 跨 gap synthetic points；
+- 无证据的 OEM 私有 deep-link 大全；
+- 用放宽 trust threshold 掩盖 callback loss。
 
 ---
 
 ## 15. 变更记录
 
+### v1.5.0
+
+- 同步 2026-09-02 current `main`：Fused high-accuracy ~1Hz + 12s silent platform fallback。
+- 同步 #275：per-Trip 自包含 GPS diagnostics。
+- 同步 OnePlus A/B 证据与 #278：后台记录保护 / ColorOS-family 指引。
+- 同步 #280：Fused `LocationAvailability`、source/fallback reason、扩展 POWER_STATE、approximate-location warning。
+- 同步 #281 / Room v17：TripPoint 保存 epoch + elapsed realtime；新 Trip 的 interval/order/gap、callback gap、live GPS health、route/playback/trend/elevation/CSV timing 优先使用 monotonic time。
+- 明确 v16/backup restored legacy points 使用 epoch fallback，不伪造 elapsed realtime。
+- 明确 reboot/monotonic reset 使用 `CAPTURE_TIME_REBASE` 断开 baseline。
+- `LONG_GAP_SECONDS = 120`、no synthetic points、no gap distance bridging 均未改变。
+- current physical acceptance owner 仍为 #77；bounded source recovery / OEM matrix 由 #283 evidence-driven 管理。
+
 ### v1.4.0
 
-- 同步 2026-08-27 第二轮真机 Trip 证据与 #77/#78 新 P0 reliability ownership。
-- 同步 PR #80：LocationManager 取消 8m callback 位移门槛，系统 callback 与 15s stationary heartbeat 写库节流解耦。
-- 修正长 gap 状态：`>=120s` 已不计可信距离、duration 与 aggregate speed，不再是 future follow-up。
-- 同步 PR #82：最高已记录速度只允许通过可信 GPS 质量门的 candidate，Network 粗速度保留原始事实但不更新 max。
-- 同步 PR #83：Trip 详情展示起/终/最低/最高海拔，起终点地址作为派生展示、坐标保持权威技术参数，起点圆形/终点方形避免只靠颜色区分。
-- 同步 PR #85：相邻两端都可信时按本车 GPS 速度连续着色；未知/不可信段保持灰色；交通拥堵语义继续禁止。
-- 明确上述 CI/代码完成不等于后台连续性、最高速或彩色轨迹的最终真机验收。
+- 同步 2026-08-27 第二轮真机 Trip 证据与 #77/#78 P0 reliability ownership。
+- 同步 PR #80：取消旧 8m callback 位移门槛，系统 callback 与 stationary heartbeat 写库节流解耦。
+- 同步 PR #82：可信 max-speed gate。
+- 同步 PR #83/#85：海拔/address/endpoint 与 trusted speed-colored route。
+- 明确 CI/代码完成不等于最终后台真机验收。
 
 ### v1.3.0
 
-- 明确 Location.speed 是当前瞬时/最高速度主要来源，不等同于点间直线速度
-- 明确平均速度仍受 GPS 累计距离质量影响
-- 将短时速度峰值漏采作为真实采样限制记录
-- 固定 GNSS / Derived / OBD 三类速度来源语义
-- OBD-II 放入 P3 可选增强，只先验证标准 Vehicle Speed，不进入私有 CAN/BMS 逆向
-- 同步 PR #36 GPS health、通知、gap 断线及速度 UI 已实现范围
+- 明确 Location.speed / derived / OBD 速度来源语义。
+- 记录短时峰值漏采与 GPS 累计距离限制。
+- 同步早期 GPS health、notification、gap route split。
 
 ### v1.2.0
 
-- 基于真实 Trip #7 将十分钟级 GPS gap 提升为 P0 reliability 问题
-- 增加 GPS callback / provider / service lifecycle 可诊断设计
-- 明确 COMPLETED 不等于 GPS continuity 完整
-- 增加全程平均 / 行驶平均 / 分段平均速度三种口径
-- 增加连续速度颜色方案及交通语义边界
-- 明确 GPS gap 不得以实线伪造
+- 基于真实 Trip #7 将十分钟级 GPS gap 提升为 P0 reliability。
+- 建立 callback/provider/service lifecycle 可诊断设计。
+- 明确 COMPLETED 不等于 GPS continuity 完整。
+- 明确 GPS gap 不得以实线伪造。
 
 ### v1.1.0
 
-- 增加 elapsed/moving/stopped 时间口径
-- 增加中断行程恢复设计
-- 限制采样频率以控制耗电和数据库体积
-- 增加 Privacy Zone 后续设计
-- 明确自动记录演进顺序
+- 增加 elapsed/moving/stopped 时间口径。
+- 增加中断行程恢复、Privacy Zone 与自动记录演进设计。
 
 ### v1.0.0
 
-- 建立定位 / 地图 / 行程追踪权威设计
-- 确定 Android Location + MapLibre 解耦架构
-- 明确手动开始 + foreground service
+- 建立定位 / 地图 / 行程追踪权威设计。
+- 确定 Android Location + MapLibre 解耦架构。
+- 明确手动开始 + foreground service。

--- a/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
+++ b/docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md
@@ -1,39 +1,49 @@
 # Trip GPS Reliability & Speed Visualization
 
-版本: v1.3.0
-更新时间: 2026-08-29
-状态: Code Baseline Complete / Post-#184 Physical Revalidation Pending
+版本: v1.4.0
+更新时间: 2026-09-02
+状态: Code Baseline Complete / Post-#281 Physical Revalidation Pending
 
 ## 1. 文档定位
 
-本文档是 EV Charge Book 行程模块中 **GPS 可信度、轨迹连续性、速度可信度与轨迹可视化** 的实现/验收说明。
+本文档是 EV Charge Book 行程模块中 **GPS 可信度、轨迹连续性、速度可信度、后台可靠性与轨迹可视化** 的实现/验收说明。
 
-当前核心代码已经进入 `main`。2026-08-29 的新锁屏真机证据触发了一个聚焦修复 PR #184；该修复已合并，剩余主要是 Android 真机上的 post-#184 后台定位复验、轨迹可读性与无障碍/窄屏验收。
+历史 #80/#184 证据仍保留，但 current runtime authority 已继续演进到 #275/#278/#280/#281：
+
+- Fused high-accuracy ~1Hz acquisition；
+- 约 12s Fused silent watchdog -> platform GPS/network fallback；
+- per-Trip 自包含 diagnostics；
+- OEM/background recording guidance；
+- Fused `LocationAvailability` / fallback reason / extended POWER_STATE；
+- Room v17 epoch + `elapsedRealtimeNanos` dual-time TripPoint；
+- monotonic time 用于新 Trip 的 interval/order/gap、callback gap、live GPS health 和所有相关显示派生。
+
+当前 physical reliability owner 仍是 #77。CI 和 JVM tests 不能替代真机结论。
 
 相关 authority：
 
-- `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
 - `docs/LOCATION_TRIP.md`
+- `docs/TRIP_V0.6_APPROVED_UI_BASELINE.md`
 - `docs/ROADMAP.md`
-- #145 Trip v0.6 总体验收
-- #168 Trip v0.6 device-fidelity correction
-- #77 后台 callback / stationary hold / delayed callback 真机验收
-- #67 trajectory / speed-colored route 真机验收
+- #26 background/notification UX
+- #77 Trip physical reliability
+- #283 bounded source recovery / OEM matrix（evidence-driven）
 
-设计原则保持不变：
+设计原则：
 
-1. GPS / Room 中保存的原始事实优先于视觉效果。
-2. 不跨真实 GPS gap 伪造路线、距离或速度。
-3. Network/coarse provider 可以作为诊断证据，但不能污染可信最高速度或彩色轨迹。
-4. UI 的速度颜色只表达“本车可信 GPS 速度分布”，不代表道路拥堵、限速或交通状态。
+1. GPS / Room 中保存的事实优先于视觉效果。
+2. 不跨真实 GPS gap 或 capture-clock rebase 伪造路线、距离或速度。
+3. Network/coarse provider 可以作为 fallback/diagnostic evidence，但不能污染可信最高速度或可信速度彩色轨迹。
+4. UI 的速度颜色只表达本车可信 GPS 速度分布，不代表道路拥堵、限速或交通状态。
 5. 地图 SDK、road snapping、云端轨迹处理都不是当前可靠性成立的前提。
-6. **callback 派发延迟与轨迹连续性是两个不同维度**：派发较晚的真实 fix 可以被接收，但是否累计可信距离/时长仍只由原始 capture timestamp 的 continuity 决定。
+6. **callback delivery 与 location capture 是两个不同的时间维度**：delivery liveness 用 monotonic delivery clock；新 Trip 的 capture interval 优先使用 persisted `Location.elapsedRealtimeNanos`。
+7. civil/epoch timestamp 继续作为人类可读和可导出的事实，但不再是新 Trip 的首选 interval/order authority。
 
 ---
 
 ## 2. 历史真实数据证据
 
-这些数据保留作为当前 trust rules 的来源，不代表当前代码仍存在相同缺陷。
+这些数据保留作为 trust rules 的来源，不代表 current main 仍存在相同缺陷。
 
 ### 2.1 Trip #7：十分钟级 GPS 空洞
 
@@ -54,8 +64,8 @@
 
 由此确定：
 
-- `COMPLETED` 只代表行程最终收口，不代表中间 GPS 连续。
-- 大 gap 两端不得画成可信连续路线。
+- `COMPLETED` 只代表行程最终收口，不代表中间 GPS 连续；
+- 大 gap 两端不得画成可信连续路线；
 - gap 期间不得补造可信距离、移动时间或速度。
 
 ### 2.2 2026-08-27 Trip #2：后台空洞、停车误判和假最高速
@@ -70,9 +80,9 @@
 
 典型 continuity 证据：
 
-- Point 42 -> 43：约 643 秒移动空洞
-- Point 109 -> 110：约 465 秒，恢复时出现 coarse network fallback
-- 约 140 秒的红灯样本暴露旧 `8m` LocationManager gate 与 15 秒 stationary heartbeat 的冲突
+- Point 42 -> 43：约 643 秒移动空洞；
+- Point 109 -> 110：约 465 秒，恢复时出现 coarse network fallback；
+- 约 140 秒红灯样本暴露旧 `8m` LocationManager gate 与 15 秒 stationary heartbeat 的冲突。
 
 典型假速度点：
 
@@ -81,201 +91,308 @@
 - speed accuracy: null
 - reported speed: 34.005 m/s（约 122.4 km/h）
 
-上述证据推动了 PR #80、#82、#85 等后续修复。
+这些证据推动了 #80/#82/#85 等修复。
 
 ### 2.3 2026-08-29：PR #80 后仍有锁屏长缺口
 
-新的真实设备行程在锁屏后完成，Trip 详情仍出现 **2 个长缺口**。
+真实设备行程在锁屏后完成，详情仍出现 2 个长缺口。
 
-这说明：
+结论：
 
-- 仅移除 8m displacement gate 还不足以覆盖全部 OEM / screen-off 行为；
-- Android 可能已经采集真实 fix，但在 screen-off/light-idle 后延迟派发；
-- 若 service 使用很短的“callback 到达新鲜度”窗口，会在真正做 continuity 判断之前就丢掉这些历史 fix。
+- 移除 8m displacement gate 还不足以覆盖全部 OEM/screen-off 行为；
+- Android 可能已经采集真实 fix，但延迟派发；
+- callback freshness 不能和 route continuity 共用同一个极短窗口。
 
-这份新证据触发 #77 的一次聚焦代码回归修复，而不是重新设计 tracking 架构。
+这推动了 #184 的 delayed callback grace，而不是重新设计 tracking 架构。
+
+### 2.4 2026-09-02 OnePlus A/B：Service 未死但后台 callback 被压制
+
+同一 OnePlus PLU110 / Android API 36 / app 0.7.39：
+
+**Trip 30，普通后台处理：**
+
+- 278 个诊断事件；
+- 2 个真实行驶中长缺口：约 445s / 6.89km 与 261s / 4.55km；
+- 无 `SERVICE_DESTROY`；
+- 无 `SERVICE_REDELIVERED`；
+- 标准 Android snapshot 仍显示 `backgroundRestricted=false`。
+
+**Trip 31，EV Charge Book 锁定在最近任务：**
+
+- 40 个诊断事件；
+- 没有同类行驶中长缺口；
+- 唯一 >120s gap 出现在车辆已近乎静止、结束 Trip 前。
+
+当前最强证据因此指向 **OEM/background location scheduling/callback starvation**，而不是前台 Service 被 Android 直接杀掉。
+
+这组证据触发 #278/#280，不授权第二 Service、WorkManager 或 synthetic route。
 
 ---
 
-## 3. 当前 GPS callback / stationary reliability baseline
+## 3. 当前 acquisition / callback / stationary baseline
 
-### 3.1 PR #80：callback liveness 与停车 heartbeat
-
-PR #80 `fix(android): keep Trip callbacks alive while stationary` 已进入 `main`。
-
-当前实现：
-
-- LocationManager `minDistance = 0m`，不再使用旧 8m displacement gate
-- 保留约 4 秒 callback request interval
-- callback 与数据库写入分层：系统回调可以频繁，Room 写入仍由 domain sampling rules 降频
-- stationary heartbeat 约 15 秒持久化一次，而不是每个 callback 都写 TripPoint
-- stationary heartbeat 增加 `stoppedSeconds`，不增加 `movingSeconds`
-- `START_REDELIVER_INTENT` 保留
-- provider / permission / service lifecycle 诊断保留
-
-这解决了代码层“系统 8m gate 阻止业务 15s heartbeat”的冲突。
-
-### 3.2 PR #184：允许延迟派发，但不放宽轨迹 trust
-
-PR #184 `fix(android): harden lock-screen trip GPS and unify endpoint flag` 已合并为 `bae3a21`。
-Android CI run `33229162800` 在 PR head `11bd41a` 上 Green。
-
-聚焦修复：
-
-- callback-delivery freshness tolerance 从 15 秒放宽到 10 分钟；
-- `location.time` 仍作为 TripPoint 的原始 capture timestamp；
-- `TripTrackingService` 仍拒绝 `capturedAt <= previous.capturedAt` 的倒序历史点；
-- `LONG_GAP_SECONDS = 120` 完全不变；
-- 若原始 capture timestamp 之间真实相隔 >=120 秒，新点只建立新 baseline，不累计 gap 两端的可信距离 / duration / aggregate speed；
-- 增加 delayed callback freshness boundary regression。
-
-因此：
+### 3.1 当前 source path
 
 ```text
-callback delivery age
-  -> 是否允许这个真实 fix 进入后续判断
-  -> 原始 capture timestamp monotonic check
-  -> 120s continuity rule
-  -> 是否累计可信距离 / 时长 / 速度
+location foreground service
+  -> Google Fused high accuracy ~1Hz / minDistance=0
+  -> Fused silent ~12s watchdog
+  -> platform GPS + network fallback
+  -> Trip continuity / quality / sampling
+  -> Room
 ```
 
-**放宽 callback age 不是放宽 LONG_GAP。**
+当前边界：
 
-如果 OEM 在解锁后按原始时间顺序补发一批连续 GPS fix，这些 fix 不再仅因为“到达晚了”而被整体丢弃；如果系统确实没有采集到连续 fix，120 秒规则仍会保留真实断点。
+- non-GMS -> platform fallback；
+- Fused registration failure -> platform fallback；
+- Fused 注册成功但持续 silent -> platform fallback；
+- platform 只使用真实 enabled GPS/network，不依赖 framework `fused`；
+- `LocationAvailability` 只是诊断，不是 Trip truth/interruption authority；
+- 当前不自动从 platform 高频来回切回 Fused；是否需要 bounded re-probe 由 #283 的真机证据决定。
 
-### 3.3 #77 仍需 post-#184 真机复验
+### 3.2 callback 与 Room 写入分层
 
-CI 无法证明不同 Android ROM 在后台的实际 callback/batching 行为。
+系统 acquisition/callback 可以约 1Hz；Room 不要求每个 callback 都写。
 
-使用包含 PR #184 的最新 `main` 复验：
+- minDistance=0；
+- moving point 依据 trust/sampling 正常保留；
+- stationary GNSS drift 不累计行驶距离；
+- stationary heartbeat 约 15 秒级写入；
+- moving -> stationary 的首个可信变化应及时保存。
 
-- [ ] 锁屏/另一 App 前台 5–10 分钟时，连续 capture 的 delayed fixes 能恢复可信轨迹/距离
-- [ ] 2–3 分钟真实停车增加合理 `stoppedSeconds`
-- [ ] 健康 stationary callback 不产生 false LONG_GAP
-- [ ] 真正 >=120s capture-time gap 仍保持断开、不累计伪造距离
-- [ ] 真正 provider/callback loss 仍产生 LOST/LONG_GAP
-- [ ] stationary TripPoint 写入仍保持节流
-- [ ] 解锁后如果先收到新点，再补发更老点，老点会因 non-monotonic time 被拒绝
+这保持了 callback liveness 可诊断，同时控制耗电、数据量和漂移距离。
 
-如果 post-#184 仍失败，应先检查存储的 TripPoints / diagnostics / `stale_callback` / `non_monotonic_time` 证据，再决定是否调整阈值；不直接增加 WorkManager、第二 tracking service 或 cloud tracking。
+### 3.3 delayed callback freshness
 
----
+#184 后 callback-delivery freshness tolerance 放宽到 10 分钟，但这不等于 10 分钟 route continuity。
 
-## 4. GPS health 与诊断
+当前 callback freshness 使用 `Location.elapsedRealtimeNanos` 对 `SystemClock.elapsedRealtimeNanos()` 判断，而不依赖 wall clock。
 
-当前运行时已经区分：
-
-- `lastLocationCallbackAt`
-- `lastAcceptedPointAt`
-- recent accepted provider
-- rejected point evidence / sampled diagnostics
-- foreground service start / destroy / redelivery
-- provider disabled
-- permission missing
-- location registration failure
-
-UI / notification 使用的核心 health 语义仍是：
-
-- GOOD：最近有效定位约 <=10s
-- DEGRADED：约 10–30s
-- LOST：约 >30s
-- LONG_GAP：约 >=120s 的真实 continuity break
-
-注意：notification 的“最近 callback”健康状态与 delayed fix 的 capture-time continuity 不是同一个指标。设备在锁屏期间如果确实没有及时派发 callback，notification 可以进入 LOST；随后补发的历史 fix 是否能恢复已采集轨迹，由 capture timestamps 单独判断。
-
-这些阈值是产品 reliability 参数，可根据真机数据做小幅调整，但不能通过放宽阈值来隐藏真实 gap。
-
-### 可选的未来摘要
-
-以下属于 future / evidence-driven，不是当前 blocker：
-
-- Trip 级 longest gap
-- GPS / Network provider counters
-- rejected reason 汇总
-- provider switch count
-
-只有当诊断成本明显影响真实问题定位时再增加，不为了“指标齐全”扩展 schema。
+真实 `>=120s` capture gap 仍硬断开。
 
 ---
 
-## 5. Notification / interruption 状态
+## 4. Dual-time capture authority — #281 / Room v17
 
-早期文档曾把 #26 写成后续代码工作；该描述已经过期。
+### 4.1 为什么不能继续只用 `Location.time`
 
-当前必要代码已经通过 PR #130 / #131 / #132 进入 `main`：
+`Location.time`/epoch timestamp 是重要的 civil-time fact，但手机时钟可能被用户或系统校正。如果把它作为唯一 ordering/interval clock，会出现：
 
-- ongoing notification 显示真实已记录时长
-- ongoing notification 显示已持久化可信累计距离
-- 点击 ongoing notification / `打开行程` 可回当前 Trip
-- provider 不可用或 Location 权限丢失时进入 `INTERRUPTED`
-- repair notification 可进入对应设置修复
-- 修复后必须由用户明确恢复，不自动偷偷 resume
-- Android 13+ notification permission 拒绝不会回滚或阻止 Trip
-- 锁屏通知默认不暴露精确经纬度 / HOME / WORK 地址
+- wall clock 回拨 -> 假时间倒序；
+- wall clock 前跳 -> 假长 gap；
+- notification/GPS health 可能因校时误报 LOST/LONG_GAP；
+- playback/trend X-axis 可能反向或被拉长。
 
-#26 目前属于 **physical acceptance owner**，不是待实现代码清单。
+所以 #281 将时间语义拆开。
+
+### 4.2 TripPoint v17
+
+每个新 TripPoint 保存：
+
+- `capturedAtEpochMillis`：human-readable/export fact；
+- `capturedAtElapsedRealtimeNanos`：同一 boot 内 monotonic interval/order authority。
+
+v16 历史行与 portable backup restored point 无法诚实重建 boot-relative elapsed realtime，因此新列保持 `NULL` 并显式 epoch fallback。
+
+### 4.3 `TripCaptureTimeRules`
+
+相邻两点规则：
+
+1. elapsed 都存在且 current > previous -> `ELAPSED_REALTIME`；
+2. elapsed 相等 -> duplicate，拒绝；
+3. elapsed 回退但 epoch 前进 -> `ELAPSED_REALTIME_REBASE`，视为 reboot/monotonic reset，当前点只建立新 baseline；
+4. elapsed 与 epoch 都回退 -> out-of-order historical point，拒绝；
+5. elapsed 缺失 -> `EPOCH_FALLBACK`；
+6. legacy epoch fallback 不递增 -> 拒绝。
+
+### 4.4 Rebase 不等于可拼接
+
+`CAPTURE_TIME_REBASE` 是一个 hard disconnected baseline：
+
+- 接受当前真实点；
+- 不跨边界计 distance；
+- 不跨边界计 moving/stopped duration；
+- 不跨边界算 aggregate/max speed；
+- route/playback/trend/elevation 均断开；
+- 不生成 synthetic point。
+
+`LONG_GAP_SECONDS = 120` 保持不变。
 
 ---
 
-## 6. 最高速度可信度
+## 5. GPS health 与 callback gap
 
-### 6.1 PR #82 / #78 已完成
+运行时区分：
 
-历史 122.4 km/h 假峰值来自 coarse `network` point。
+- tracking start age；
+- last callback age；
+- last accepted point age；
+- recent accepted provider；
+- rejected evidence；
+- source/provider transitions；
+- service lifecycle；
+- permission/provider repair state。
 
-PR #82 已建立独立 max-speed trust gate，#78 已按 completed 关闭。
+#281 后，live GPS health 使用 `SystemClock.elapsedRealtime()`：
 
-当前最高速度 candidate 必须满足：
+- WAITING：启动后仍在等待首次 callback；
+- GOOD：最近 callback/accepted point 新鲜；
+- DEGRADED：约 15s 以上；
+- LOST：约 30s 以上；
+- LONG_GAP：约 120s 以上。
 
-- existing aggregate continuity / distance corroboration
-- provider = `gps`
-- horizontal accuracy <= 25m
-- speedAccuracy 存在时 <= 3 m/s
-- speed finite 且非负
+这些阈值代表 **delivery/accepted liveness**。它和两个 persisted capture fix 的 continuity interval 是不同维度，但两者现在都使用合适的 monotonic clock，不再依赖 civil clock 计算“多久”。
 
-Network/coarse point 的原始 `speedMps` 仍可保留在 TripPoint 作为诊断事实，但不能刷新可信 `maxSpeedMps`。
-
-JVM regression 已覆盖：
-
-- 122.4 km/h network + 100m accuracy 被拒绝
-- 合理 GPS highway peak 可以通过
-- coarse GPS peak 被拒绝
-
-因此不要再把 #78 写成当前 open blocker。
-
-产品语义仍应理解为“最高已记录可信 GNSS 速度”，不是车辆真实物理最高速度的绝对证明。
+callback gap diagnostics 同样用 `SystemClock.elapsedRealtime()`。
 
 ---
 
-## 7. 可信速度彩色轨迹
+## 6. 诊断能力 — #275/#280/#281
 
-### 7.1 PR #85 已实现
+每条 selected Trip 可以导出自包含 CSV。
 
-PR #85 `feat(android): color Trip route by trusted vehicle speed` 已合并为 `482b6e9`。
+### 6.1 TripPoint evidence
 
-Android CI run `33086126816` 在 PR head `8337d81` 上成功。
+每点包含：
 
-数据路径：
+- epoch capture timestamp；
+- elapsed realtime nanos；
+- adjacent delta；
+- `timeAuthority`；
+- `timeDecision`；
+- lat/lon/altitude；
+- speed/bearing；
+- horizontal/vertical/speed accuracy；
+- provider。
+
+### 6.2 Runtime/source evidence
+
+诊断事件包含：
+
+- SERVICE_START / REDELIVERED / DESTROY；
+- LOCATION_REGISTRATION_FAILED；
+- LOCATION_SOURCE；
+- LOCATION_AVAILABILITY；
+- LOCATION_CALLBACK_GAP；
+- CAPTURE_TIME_REBASE；
+- GPS_HEALTH_TRANSITION；
+- POWER_STATE；
+- PROVIDER_DISABLED；
+- PERMISSION_MISSING；
+- LOCATION_REJECTED。
+
+source diagnostics 可看：
+
+- Fused registration；
+- Google `LocationAvailability` transition；
+- Fused silent fallback reason；
+- platform registered providers。
+
+POWER_STATE 包含：
+
+- powerSave；
+- deviceIdle；
+- interactive；
+- ignoringBatteryOptimizations；
+- backgroundRestricted；
+- appStandbyBucket；
+- locationPowerSaveMode；
+- processImportance。
+
+目标是区分：
 
 ```text
-TripPoint[]
-  -> trusted measured-speed gate
-  -> TripGeoPoint(speed?)
-  -> TripRouteGeometryBuilder
-  -> colored route renderer
+service 被杀
+vs
+service 活着但 callback 不来
+vs
+Fused unavailable/silent
+vs
+source fallback
+vs
+callback 来了但 point 被 trust rule 拒绝
+vs
+真实 long gap
+vs
+civil clock 改变
+vs
+monotonic rebase/reboot
+vs
+Android 标准 power/background restriction
 ```
+
+---
+
+## 7. 后台记录保护 — #278/#280
+
+Trip 准备页 evidence-driven guidance：
+
+- 检查 standard background/battery state；
+- real `backgroundRestricted=true` 始终可重新提示，不被旧 acknowledgement 永久隐藏；
+- acknowledgement 按 manufacturer/brand/API 作用；
+- OnePlus/OPPO/realme 提示允许后台活动并在最近任务锁定 App；
+- approximate-only location 提示开启 precise location；
+- 不申请 `ACCESS_BACKGROUND_LOCATION`；
+- 不直接请求 battery optimization exemption；
+- 不因为 OEM 名称堆大量私有 deep link。
+
+其他 ROM 的专项 guidance 由 #283 OEM matrix 以真实设备证据逐步增加。
+
+---
+
+## 8. GPS gap 与轨迹连续性
+
+核心规则：
+
+- `>=120s` capture interval -> disconnected segment；
+- `CAPTURE_TIME_REBASE` -> disconnected segment；
+- gap/rebase 两端不累计可信直线距离；
+- gap/rebase duration 不进入 moving/stopped；
+- gap/rebase 不刷新 aggregate/max speed；
+- speed-colored route 不跨断点；
+- playback 在断点期间保持最后真实定位，不插值；
+- trend chart 不跨断点连线；
+- elevation cumulative ascent/descent 不跨断点拼高度差。
+
+```text
+已知轨迹 ━━━━━     ━━━━━ 已知轨迹
+             gap / rebase
+```
+
+MapLibre 未来也不能改变这一事实边界。
+
+---
+
+## 9. 可信最高速度
+
+历史 122.4 km/h 假峰值来自 coarse network point。
+
+当前 max-speed candidate 必须满足：
+
+- existing aggregate continuity/distance corroboration；
+- provider = GPS；
+- horizontal accuracy <= 25m；
+- speedAccuracy 存在时 <= 3 m/s；
+- speed finite 且非负。
+
+Network/coarse raw `speedMps` 可保留作为诊断事实，但不能刷新可信 `maxSpeedMps`。
+
+产品语义仍是“最高已记录可信 GNSS 速度”，不是车辆真实物理最高速度的绝对证明。
+
+---
+
+## 10. 可信速度彩色轨迹与回放
 
 规则：
 
-- 只有相邻两端都拥有可信 GPS speed，线段才使用速度颜色
-- 任一端 speed 不可信/缺失，线段保持中性灰色
-- 未知速度不能被当作 0 km/h
-- downsample / normalize 后保留可信 speed metadata
-- LONG_GAP segmentation 优先于颜色；gap 不会因为上色而重新连起来
+- 只有可信 measured GPS speed 才参与速度颜色；
+- unknown/untrusted speed 保持 neutral；
+- LONG_GAP/rebase segmentation 优先于颜色；
+- 颜色只属于 UI 派生，不写回 TripPoint；
+- playback 使用与 tracking 一致的 monotonic/legacy-fallback timeline，不自己再用 epoch 重新计算 progress。
 
-### 7.2 当前颜色语义
-
-连续映射：
+当前颜色：
 
 - 0–5 km/h：深红
 - 5–15 km/h：红
@@ -284,278 +401,254 @@ TripPoint[]
 - 50–70 km/h：绿
 - 70–90 km/h：绿 -> 蓝
 - 90+ km/h：蓝 / 深蓝
-- 未知 / 不可信：灰色
+- unknown/untrusted：灰色
 
-颜色仅属于 UI 派生，不写回原始 TripPoint。
-
-### 7.3 不允许的交通语义
-
-没有道路类型、限速、map matching、实时交通数据时：
-
-- 8 km/h 可能只是停车场
-- 15 km/h 可能只是小区道路
-- 40 km/h 在不同道路上意义完全不同
-
-因此 UI 必须继续说明：颜色代表本车可信 GPS 速度分布，不代表道路拥堵等级。
+不允许在没有道路 context 时显示“拥堵/畅通”等交通事实标签。
 
 ---
 
-## 8. GPS gap 与轨迹连续性
+## 11. 海拔 / 趋势
 
-当前核心规则：
+trusted elevation analysis 已支持：
 
-- `>=120s` 的真实 capture-time gap 拆成 disconnected segments
-- gap 两端不累计可信直线距离
-- gap duration 不进入可信 moving/stopped 统计
-- gap 不允许刷新 aggregate / max speed
-- speed-colored route 不跨 gap 画线
-- callback 到达晚本身不能把一个真实 >=120s gap 变成连续轨迹
+- start/end altitude；
+- min/max；
+- cumulative ascent/descent；
+- vertical-accuracy filtering；
+- jitter suppression；
+- gap/rebase isolation。
 
-```text
-已知轨迹 ━━━━━     ━━━━━ 已知轨迹
-             GPS 缺失
-```
+#281 后，elevation gap 判断与趋势 X-axis 也使用 monotonic/legacy-fallback timing policy，因此 civil clock 回拨不应制造假 elevation gap 或反向 trend timeline。
 
-无 basemap 阶段使用断开表达已经足够真实。
+v0.6 详情 ownership：
 
-MapLibre 如果未来接入，只负责更好的 renderer，不负责补造道路或缺失路线。
+- `轨迹`：route + speed/altitude trends；
+- `数据`：compact altitude summary + GPS diagnostics + playback/export actions。
 
 ---
 
-## 9. 海拔 / 高程分析
+## 12. Notification / interruption 状态
 
-PR #127 `feat(android): add trusted Trip elevation analysis` 已实现 #69 并进入 `main`：
+必要代码已经进入 `main`：
 
-- start / end altitude
-- min / max altitude
-- cumulative ascent / descent
-- vertical-accuracy quality filtering
-- jitter suppression
-- LONG_GAP isolation
-- Trip detail UI
-- JVM regression coverage
+- ongoing notification 显示已记录时长 + 可信累计距离；
+- deep link 回当前 Trip；
+- provider 或 Location permission 丢失 -> `INTERRUPTED`；
+- repair notification 进入对应设置；
+- 修复后必须由用户明确恢复；
+- Android 13+ notification permission 拒绝不回滚 Trip；
+- 锁屏通知默认不暴露精确经纬度/HOME/WORK。
 
-#69 已完成关闭。
-
-v0.6 详情中：
-
-- `轨迹`：速度 / 海拔趋势作为 route supporting evidence
-- `数据`：海拔摘要与 reliability / raw-point diagnostics
-- 无可信海拔时显示 truthful unavailable state，不生成合成高程
+#26 仍是 physical acceptance owner，不是待实现一套新 notification architecture。
 
 ---
 
-## 10. 地址与 endpoint 语义
+## 13. 当前验收状态
 
-### 10.1 Coordinate-first
+### P0 GPS Reliability — code
 
-#66 的 coordinate-first / geocode cache-retry code 已完成关闭。
-
-当前原则：
-
-- WGS84 latitude / longitude 是原始权威事实
-- 地址只是展示层派生数据
-- geocoder 失败不阻止 Trip 保存/完成
-- 无法解析时保留坐标或明确 unavailable，不虚构地点
-
-真实设备 Location / Geocoder 行为继续由 #14 验收，而不是重新打开 #66。
-
-### 10.2 v0.6 endpoint semantics
-
-当前 v0.6 authority：
-
-- start：compact primary-green play/start icon
-- completed end：small red flag，无 ring / halo
-- active latest point：green `当前点`
-- interrupted/non-final latest point：`最后记录点`，不能冒充 completed endpoint
-
-PR #184 将 route Canvas 的 completed endpoint 从三角 pennant 收口为与 endpoint card 更一致的四角小红旗。该变化只统一视觉语言，不改变 completed/non-final 语义。
-
-同时保留 accessibility semantics，不能只靠红/绿颜色区分状态。
-
----
-
-## 11. v0.6 详情信息架构
-
-PR #179 已将 completed Trip detail 从一个长页面拆成：
-
-- `概览`：summary + start/end card
-- `轨迹`：真实 route + trusted speed/altitude trends
-- `数据`：altitude/reliability summary + raw-point progressive disclosure
-
-PR #184 进一步移除 `概览` 内冗长的 SOC/能耗说明句，但保留 `估算能耗` 标签，因此能耗仍明确是 estimate，不冒充 BMS 实测。
-
-Raw GPS point list 默认折叠，只在用户明确点击 `查看轨迹点` 时展开。
-
----
-
-## 12. 当前验收状态
-
-### P0 GPS Reliability
-
-- [x] 最近有效定位 / provider / rejected evidence
+- [x] location FGS + ongoing notification
+- [x] Fused ~1Hz + platform fallback
+- [x] 12s Fused silent watchdog
+- [x] old 8m callback gate removed
+- [x] stationary write throttle / drift protection
+- [x] callback freshness / delayed fix handling
+- [x] 120s hard gap / no gap distance bridging
 - [x] service lifecycle diagnostics
-- [x] LOST / LONG_GAP health
-- [x] `>=120s` route gap 断开，不累计伪造可信距离
-- [x] old LocationManager 8m callback gate 已移除
-- [x] stationary heartbeat 可以在 domain layer 执行并保持写入节流
-- [x] PR #184 放宽 callback-delivery freshness，但保留原始 capture-time monotonic / 120s continuity trust
-- [x] PR #184 Android CI run `33229162800` Green
-- [ ] post-#184 锁屏/另一 App 前台 5–10 分钟真实距离与轨迹复验（#77）
-- [ ] 2–3 分钟停车不产生 false LONG_GAP，stoppedSeconds 合理（#77）
-- [ ] 真正 provider/callback loss 仍可复现 LOST/LONG_GAP（#77）
-- [ ] out-of-order delayed fix 仍按 non-monotonic evidence 被拒绝（#77 真机/诊断）
+- [x] per-Trip full diagnostics
+- [x] Fused LocationAvailability / fallback reason
+- [x] extended Android background/power diagnostics
+- [x] background/precise-location guidance
+- [x] Room v17 epoch + elapsed realtime
+- [x] monotonic callback gap / live GPS health
+- [x] monotonic route/playback/trend/elevation/CSV timing
+- [x] capture-clock rebase hard-disconnect semantics
+
+### P0 GPS Reliability — physical #77
+
+- [ ] existing v16 real-device DB opens/upgrades to v17, old Trip/Charging data intact
+- [ ] lock screen while moving
+- [ ] another app foreground 5–10 minutes while moving
+- [ ] 2–3 minute stationary hold
+- [ ] real provider/location interruption + manual resume
+- [ ] no unexplained in-motion callback gap
+- [ ] normal new intervals export `ELAPSED_REALTIME` authority
+- [ ] civil clock correction does not manufacture LONG_GAP/LOST/reverse route
+- [ ] reboot/rebase if exercised produces `CAPTURE_TIME_REBASE` and no cross-boundary distance
+- [ ] true >=120s gap remains disconnected
+- [ ] out-of-order delayed point remains rejected
 
 ### P0 Speed Trust
 
-- [x] Network/coarse speed 不刷新 maxSpeedMps
+- [x] Network/coarse speed cannot refresh maxSpeedMps
 - [x] GPS quality gate + JVM regression
-- [x] #78 completed；不再作为当前 open blocker
 
-### P1 Speed Visualization
+### P1 Speed/route UI
 
-- [x] 可信 GPS route 连续颜色映射
-- [x] unknown/untrusted speed 使用 neutral color
-- [x] LONG_GAP 不跨 gap 上色/连线
-- [x] 不宣称真实拥堵等级
-- [x] geometry metadata JVM coverage
-- [x] completed endpoint route/card red-flag language code-side unified by #184
-- [ ] real-device route / legend / endpoint Dark-Light 可读性（#67/#145/#168）
-- [ ] 320–360dp + fontScale 1.3（#67/#145/#42）
+- [x] trusted GPS speed colors
+- [x] neutral unknown speed
+- [x] gap/rebase not bridged
+- [x] playback uses same timing authority
+- [ ] Dark/Light route/legend/endpoint physical readability
+- [ ] 320–360dp + fontScale 1.3 physical pass
 
-### P1 Elevation / detail
+### P1 Elevation/detail
 
-- [x] start/end/min/max altitude
-- [x] cumulative ascent/descent
-- [x] quality/jitter/gap filtering
-- [x] v0.6 `轨迹` / `数据` section ownership
-- [ ] Location/Geocoder real-device pass（#14）
-- [ ] detail/trend/diagnostic Dark-Light + narrow-screen pass（#145/#168/#178/#42）
+- [x] trusted altitude summary/cumulative ascent/descent
+- [x] gap/rebase isolation
+- [x] data-tab compact diagnostics actions
+- [ ] Location/Geocoder physical pass
+- [ ] detail/trend/diagnostic narrow/large-font pass
 
 ---
 
-## 13. 推荐一次性真机验收脚本
+## 14. 推荐 current-main 真机验收脚本
 
-下一次必须使用包含 PR #184 的最新 `main` build：
+必须使用包含 #281 或更晚代码的 build。
 
-1. 前台开始 Trip，正常行驶 3–5 分钟。
-2. 锁屏并继续移动一段时间。
-3. 解锁后切换到其他 App，保持其前台 5–10 分钟并继续行驶。
-4. 找一次约 2–3 分钟停车/红灯场景。
-5. 如果安全且方便，可测试一次系统定位/provider 中断，再明确手工恢复。
-6. 恢复行驶并返回 EV Charge Book。
-7. 通过 slide-to-end 打开 compact completion form，填写 end SOC / mileage 并结束。
-8. 检查 completed `概览` / `轨迹` / `数据`。
+### 升级前置
+
+1. 在已有真实数据的 v16 App 上确认 Trip/Charging 可读；
+2. 安装 current-main Debug / release candidate；
+3. 启动 App，确认 Room 16->17 成功打开；
+4. 随机检查历史 Trip 与 Charging 数据未丢失。
+
+### 行程脚本
+
+1. 前台开始 Trip，正常行驶 3–5 分钟；
+2. 锁屏继续移动；
+3. 解锁，切另一 App 前台 5–10 分钟继续移动；
+4. 停车/红灯 2–3 分钟；
+5. 安全方便时测试一次系统定位/provider 中断，再手工恢复；
+6. 恢复行驶并回 EV Charge Book；
+7. 正常结束 Trip；
+8. 检查 `概览 / 轨迹 / 数据`；
+9. 若出现行驶中异常 gap，立即 `导出诊断`。
 
 必须检查：
 
-- [ ] 锁屏/后台时连续 capture 的 delayed fixes 不再因为 >15s delivery age 被整体丢弃
-- [ ] 后台/另一 App 前台期间可信距离继续增长
-- [ ] 停车期间 stoppedSeconds 合理且无 false LONG_GAP
-- [ ] 真正 GPS/callback loss 仍显示 LOST/LONG_GAP
-- [ ] 真实 >=120s capture gap 仍不补距离、不画连续线
-- [ ] route 能看到可信低/中/高速度差异，不可信段保持 neutral
-- [ ] completed end 只在真实完成后显示统一小红旗
-- [ ] speed/altitude trends 有可读 X/Y context
-- [ ] altitude / ascent / descent truthfully available or unavailable
-- [ ] raw diagnostics 默认折叠
-- [ ] Dark / Light、320–360dp、fontScale 1.3 可用
+- [ ] 后台期间可信距离/route 持续；
+- [ ] stationary stoppedSeconds 合理且不虚增距离；
+- [ ] true provider/callback loss 仍显示健康异常；
+- [ ] real >=120s gap 不补距离/线；
+- [ ] CSV points 有 elapsed realtime，新点 delta 显示 `ELAPSED_REALTIME`；
+- [ ] source/availability/power evidence 足以解释 fallback/异常；
+- [ ] route/playback/trend/altitude 对同一 gap 的断开语义一致；
+- [ ] no synthetic points。
 
 CI 不能替代上述物理设备结论。
 
 ---
 
-## 14. Future / evidence-driven only
+## 15. Future / evidence-driven only
 
-以下不属于当前 Trip v0.6 closeout blocker：
+### 15.1 #283 OEM matrix
 
-### TripSpeedSegmentBuilder
+至少覆盖：
 
-如果以后需要更稳定的区间分析，可研究 20–30 秒或 200–300 米窗口的 segment model：
+- ColorOS family；
+- HyperOS/MIUI；
+- OriginOS/vivo/iQOO；
+- Pixel/Samsung 或接近 AOSP 的主流设备。
 
-- start/end timestamp
-- distance
-- duration
-- averageSpeedKmh
-- optional min/max speed
-- quality / gap flag
+### 15.2 bounded source recovery
 
-PR #85 的“相邻可信 GPS speed 上色”不是完整 segment analytics；两者边界必须继续保持。
+只有 current-main 诊断证明需要时才研究：
 
-### Persistent reliability summary
+```text
+FUSED
+  -> PLATFORM
+  -> bounded platform re-register
+  -> optional FUSED re-probe
+```
 
-只有在真实故障分析证明需要时再考虑：
+必须有 backoff、minimum dwell/hysteresis 和 transition diagnostics，禁止 provider 抖动。
 
-- longest gap
-- provider switch count
-- rejected reason counters
+### 15.3 Explicit non-goals
 
-### MapLibre
+- 第二 tracking Service；
+- WorkManager/Alarm 心跳保活；
+- 长期 WakeLock；
+- direct battery-optimization exemption；
+- synthetic GPS points；
+- road geometry fabrication；
+- 无证据的大量 OEM 私有 deep link；
+- 用阈值放宽掩盖 callback starvation。
 
-MapLibre 继续是可选 renderer：
+其他可选：
 
-- 不阻塞当前 reliability
-- 不负责 road snapping
-- 不允许跨缺失数据补造路线
+- persistent longest-gap/provider/rejected summary；
+- longer-window `TripSpeedSegmentBuilder`；
+- MapLibre basemap renderer；
+- OBD-II Vehicle Speed PoC。
 
 ---
 
-## 15. 实施历史
+## 16. 实施历史
 
-当前主要代码链：
+主要可靠性链：
 
 ```text
-PR #36  GPS health / diagnostics / gap route split
-  -> PR #80 callback liveness + stationary heartbeat enablement
-  -> PR #82 trusted max-speed gate
-  -> PR #83 altitude/address/endpoint foundation
-  -> PR #85 trusted speed-colored route preview
-  -> PR #127 trusted elevation analysis
-  -> PR #158 / #170 v0.6 route/endpoint fidelity
-  -> PR #179 completed detail `概览` / `轨迹` / `数据`
-  -> PR #184 delayed callback grace + completed endpoint flag convergence
+#36 GPS health / diagnostics / gap route split
+  -> #80 callback liveness + stationary heartbeat enablement
+  -> #82 trusted max-speed gate
+  -> #85 trusted speed-colored route
+  -> #127 trusted elevation analysis
+  -> #184 delayed callback grace
+  -> #217 Fused production source
+  -> #220 platform fallback
+  -> #226 ~1Hz active acquisition
+  -> #231 stationary drift hardening
+  -> #234 12s silent-provider fallback
+  -> #275 self-contained diagnostic export
+  -> #278 background recording guidance
+  -> #280 LocationAvailability + background/source observability
+  -> #281 monotonic capture/delivery timing + Room v17
 ```
 
-后台通知 / repair flow：
+notification/repair：
 
 ```text
-PR #130 elapsed + trusted distance + Trip deep link
-  -> PR #131 provider/permission interruption repair
-  -> PR #132 Android 13+ non-blocking notification permission
+#130 elapsed + trusted distance + Trip deep link
+  -> #131 provider/permission interruption repair
+  -> #132 Android 13+ non-blocking notification permission
+  -> #278/#280 evidence-driven background readiness guidance
 ```
 
 ---
 
-## 16. 变更记录
+## 17. 变更记录
+
+### v1.4.0
+
+- 同步 2026-09-02 OnePlus A/B：Service 未销毁但普通后台存在 445s/261s 行驶中 callback gap，最近任务锁定后没有同类问题。
+- 同步 #275 per-Trip diagnostic export。
+- 同步 #278 background recording guidance。
+- 同步 #280 `LocationAvailability`、Fused/platform fallback reason、extended POWER_STATE、approximate-location guidance。
+- 同步 #281 / Room v17：epoch + elapsed realtime dual-time authority；callback gap、live GPS health、route/playback/trend/elevation/CSV timing 使用 monotonic time。
+- 明确 legacy/restored point epoch fallback，不伪造 elapsed realtime。
+- 明确 `CAPTURE_TIME_REBASE` hard-disconnect boundary。
+- 保留 `LONG_GAP_SECONDS = 120`、no synthetic points 和 fail-closed distance policy。
+- current physical revalidation 从 post-#184 更新为 post-#281；#77 继续 open。
 
 ### v1.3.0
 
-- 记录 2026-08-29 PR #80 后锁屏仍出现 2 个 LONG_GAP 的新真机证据。
-- 同步 PR #184：callback-delivery freshness 从 15s 放宽到 10min，但原始 capture-time monotonic check 与 120s LONG_GAP trust 完全保留。
-- 记录 PR #184 Android CI run `33229162800` Green、merge `bae3a21`。
-- 明确 delivery age 与 route continuity 是不同维度，禁止把 10min callback grace 误解为 10min 连续轨迹。
-- 同步 completed endpoint 四角小红旗视觉收口，以及移除冗长 SOC/能耗说明但保留 `估算能耗` 标签。
-- 当前 #77 回到 post-fix physical revalidation；若仍失败先读 TripPoints/diagnostics，不新增第二 tracking architecture。
+- 记录 2026-08-29 PR #80 后锁屏仍出现 LONG_GAP 的证据。
+- 同步 #184 callback-delivery grace，保留 120s continuity trust。
+- 明确 delivery age 与 route continuity 是不同维度。
 
 ### v1.2.0
 
-- 将文档状态从 `Partially Implemented` 更新为 `Code Baseline Complete / Physical Acceptance Pending`。
-- 同步 #77 / PR #80：旧 8m callback gate 已不存在，剩余 ROM/background 真机验证。
-- 修正 #78 状态：max-speed trust gate 已完成，#78 已关闭，不再是 open acceptance owner。
-- 同步 #26：必要 notification / interruption / permission code 已由 #130/#131/#132 完成，剩余真机验收。
-- 同步 #66：coordinate-first / geocode cache-retry 已完成关闭，Location/Geocoder 真机验收归 #14。
-- 同步 #69 / PR #127：trusted cumulative ascent/descent 已实现，不再写成 future。
-- 同步 #67 / PR #85 Android CI `33086126816` Green，明确代码侧已完成、仅余 physical route fidelity。
-- 同步 Trip v0.6 `概览` / `轨迹` / `数据` 详情信息架构和 endpoint semantics。
+- 更新为 Code Baseline Complete / Physical Acceptance Pending。
+- 同步 #77/#80、max-speed trust、notification repair、trusted elevation 与 v0.6 detail architecture。
 
 ### v1.1.0
 
-- 保留 Trip #7 与 2026-08-27 Trip #2 的历史可靠性证据。
-- 加入 callback/stationary、max-speed gate、altitude/address/marker、speed-colored route 第一轮实现状态。
+- 保留 Trip #7 与 2026-08-27 Trip #2 历史可靠性证据。
+- 加入 callback/stationary、max-speed、altitude/address、speed-colored route 第一轮实现状态。
 
 ### v1.0.0
 
-- 基于真实 Trip #7 建立 P0 GPS reliability 与 P1 speed visualization 方案。
+- 基于真实 Trip #7 建立 P0 GPS reliability 与 P1 speed visualization。
 - 明确 COMPLETED 不等于 GPS continuity。
-- 定义 GPS health、provider quality、速度颜色与交通语义边界。
-- 明确长 GPS gap 不得以实线伪造。
+- 定义 GPS health、provider quality、速度颜色与长 gap 不得伪造的边界。


### PR DESCRIPTION
## Summary
- sync `docs/LOCATION_TRIP.md` and `docs/TRIP_GPS_RELIABILITY_AND_SPEED_VISUALIZATION.md` with current `main`
- replace the obsolete ~4s / post-#184 runtime baseline with the current Fused ~1Hz + ~12s silent fallback chain
- document #275/#278/#280 diagnostics/background guidance and #281 Room v17 epoch + elapsed-realtime timing authority
- document explicit legacy epoch fallback, `CAPTURE_TIME_REBASE`, and post-#281 physical acceptance
- preserve the historical Trip #7 / 2026-08-27 / 2026-08-29 evidence rather than rewriting history

## Scope
Documentation only. No Android runtime, database, tracking, trust threshold, or UI code is changed.

Closes #284