### PR TITLE
fix(android): make dashboard light mode theme-aware

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/DashboardRecentTripCard.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.sp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.location.AndroidGeocoderAddressResolver
-import com.evchargebook.ui.theme.EVDesignTokens
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -97,7 +96,7 @@ fun DashboardRecentTripCard(
         isInterrupted -> Icons.Default.ErrorOutline
         else -> Icons.Default.CheckCircle
     }
-    val statusColor = if (isInterrupted) MaterialTheme.colorScheme.error else EVDesignTokens.Energy.green
+    val statusColor = if (isInterrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
     val endText = if (isActive) {
         if (trip.endLatitude != null && trip.endLongitude != null) "当前位置 · 持续更新" else "等待当前位置"
     } else {
@@ -107,7 +106,7 @@ fun DashboardRecentTripCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = Color(0xFF0A1210)
+        color = MaterialTheme.colorScheme.surfaceContainerLow
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
@@ -223,13 +222,13 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
             Box(
                 modifier = Modifier
                     .size(34.dp)
-                    .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     Icons.Default.Route,
                     contentDescription = null,
-                    tint = EVDesignTokens.Energy.green,
+                    tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(18.dp)
                 )
             }
@@ -253,7 +252,7 @@ private fun RecentTripHeader(onViewAll: () -> Unit) {
             Text(
                 "查看全部",
                 style = MaterialTheme.typography.bodySmall,
-                color = EVDesignTokens.Energy.green
+                color = MaterialTheme.colorScheme.primary
             )
             Icon(
                 Icons.Default.ChevronRight,
@@ -285,7 +284,7 @@ private fun TripRouteRail() {
         Icon(
             imageVector = Icons.Default.PlayArrow,
             contentDescription = "起点",
-            tint = EVDesignTokens.Energy.green,
+            tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.size(17.dp)
         )
         Box(
@@ -341,7 +340,7 @@ private fun RecentTripEmptyState(onViewAll: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = Color(0xFF0A1210)
+        color = MaterialTheme.colorScheme.surfaceContainerLow
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/EnergyCockpitCard.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.viewmodel.MainUiState
 import java.util.Locale
 
@@ -37,7 +36,10 @@ fun EnergyCockpitCard(
     onOpenRecords: () -> Unit = {}
 ) {
     val surfaceBrush = Brush.verticalGradient(
-        listOf(Color(0xFF0D1512), Color(0xFF09100E))
+        listOf(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            MaterialTheme.colorScheme.surfaceContainerLow
+        )
     )
 
     Surface(
@@ -60,13 +62,13 @@ fun EnergyCockpitCard(
                     Box(
                         modifier = Modifier
                             .size(34.dp)
-                            .background(EVDesignTokens.Energy.green.copy(alpha = 0.12f), CircleShape),
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f), CircleShape),
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
                             Icons.Default.Bolt,
                             contentDescription = null,
-                            tint = EVDesignTokens.Energy.green,
+                            tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(18.dp)
                         )
                     }
@@ -95,7 +97,7 @@ fun EnergyCockpitCard(
                     Text(
                         "${state.chargingCount} 次充电",
                         style = MaterialTheme.typography.bodySmall,
-                        color = EVDesignTokens.Energy.green,
+                        color = MaterialTheme.colorScheme.primary,
                         maxLines = 1
                     )
                     Icon(
@@ -172,7 +174,7 @@ private fun EnergyMetric(
                 Text(
                     unit,
                     style = MaterialTheme.typography.bodySmall,
-                    color = if (highlightUnit) EVDesignTokens.Energy.green else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (highlightUnit) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Clip
                 )

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -58,6 +58,8 @@ import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
 import com.evchargebook.ui.theme.EVDesignTokens
+import com.evchargebook.ui.theme.HeroMediaColors
+import com.evchargebook.ui.theme.LocalAppThemeController
 import com.evchargebook.ui.theme.LocalCockpitColors
 import com.evchargebook.ui.vehicle.HeroArtworkManifestRepository
 import com.evchargebook.ui.vehicle.ManagedBrandLogo
@@ -80,6 +82,8 @@ fun HeroVehicleCard(
     edgeToEdgeTop: Boolean = false
 ) {
     val context = LocalContext.current
+    val appTheme = LocalAppThemeController.current
+    val media = EVDesignTokens.Media.forTheme(appTheme.darkTheme)
     val catalogId = vehicle?.catalogVehicleId?.trim()?.takeIf { it.isNotEmpty() }
     val localArtworkKey by remember(catalogId, context.applicationContext) {
         catalogId?.let {
@@ -111,18 +115,24 @@ fun HeroVehicleCard(
                         .fillMaxWidth()
                         .aspectRatio(1.24f)
                 ) {
-                    VehicleStage(vehicle, effectiveArtworkKey, Modifier.fillMaxSize())
+                    VehicleStage(
+                        vehicle = vehicle,
+                        artworkKey = effectiveArtworkKey,
+                        preferLightArtwork = !appTheme.darkTheme,
+                        media = media,
+                        modifier = Modifier.fillMaxSize(),
+                    )
                     Box(
                         Modifier
                             .fillMaxSize()
                             .background(
                                 Brush.verticalGradient(
                                     listOf(
-                                        EVDesignTokens.Media.scrimStrong,
-                                        EVDesignTokens.Media.scrimSoft,
+                                        media.scrimStrong,
+                                        media.scrimSoft,
                                         Color.Transparent,
-                                        EVDesignTokens.Media.scrimLower,
-                                        EVDesignTokens.Media.scrimBottom
+                                        media.scrimLower,
+                                        media.scrimBottom
                                     )
                                 )
                             )
@@ -140,7 +150,7 @@ fun HeroVehicleCard(
                         style = MaterialTheme.typography.titleMedium,
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Medium,
-                        color = EVDesignTokens.Media.primaryText,
+                        color = media.primaryText,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -155,8 +165,8 @@ fun HeroVehicleCard(
                                 modifier = Modifier
                                     .size(42.dp)
                                     .clip(CircleShape)
-                                    .background(EVDesignTokens.Media.controlSurface)
-                                    .border(1.dp, EVDesignTokens.Media.controlOutline, CircleShape)
+                                    .background(media.controlSurface)
+                                    .border(1.dp, media.controlOutline, CircleShape)
                                     .clickable(enabled = canSwitchVehicle) {
                                         vehicleMenuExpanded = true
                                     },
@@ -165,7 +175,7 @@ fun HeroVehicleCard(
                                 ManagedBrandLogo(
                                     catalogVehicleId = vehicle.catalogVehicleId,
                                     modifier = Modifier.size(22.dp),
-                                    darkSurface = true,
+                                    darkSurface = media.darkSurface,
                                 )
                             }
 
@@ -232,25 +242,44 @@ fun HeroVehicleCard(
 private fun VehicleStage(
     vehicle: VehicleEntity?,
     artworkKey: String? = null,
+    preferLightArtwork: Boolean,
+    media: HeroMediaColors,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     val artwork = OfficialVehicleImageCatalog.resolve(vehicle, artworkKey)
-    var remoteArtwork by remember(artwork?.key) {
+    var remoteArtwork by remember(artwork?.key, preferLightArtwork) {
         mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null)
     }
 
-    LaunchedEffect(artwork?.key) {
-        remoteArtwork = artwork?.let { HeroArtworkManifestRepository.resolve(context, it.key) }
+    LaunchedEffect(artwork?.key, preferLightArtwork) {
+        remoteArtwork = artwork?.let {
+            HeroArtworkManifestRepository.resolve(
+                context = context,
+                artworkKey = it.key,
+                preferLight = preferLightArtwork,
+            )
+        }
     }
 
     val imageUrl = remoteArtwork?.url ?: artwork?.remoteFallbackUrl
     val cacheVersion = remoteArtwork?.version ?: 0
 
-    remember(vehicle?.catalogVehicleId, vehicle?.brand, vehicle?.model, artworkKey, artwork?.key, imageUrl) {
+    remember(
+        vehicle?.catalogVehicleId,
+        vehicle?.brand,
+        vehicle?.model,
+        artworkKey,
+        artwork?.key,
+        preferLightArtwork,
+        remoteArtwork?.resolvedKey,
+        imageUrl,
+    ) {
         Log.d(
             VEHICLE_ARTWORK_TAG,
-            "vehicle=${vehicle?.brand}/${vehicle?.model} catalog=${vehicle?.catalogVehicleId} artwork=${artwork?.key} remote=${imageUrl != null}"
+            "vehicle=${vehicle?.brand}/${vehicle?.model} catalog=${vehicle?.catalogVehicleId} " +
+                "artwork=${artwork?.key} resolved=${remoteArtwork?.resolvedKey} " +
+                "theme=${if (preferLightArtwork) "light" else "dark"} remote=${imageUrl != null}"
         )
         true
     }
@@ -259,9 +288,9 @@ private fun VehicleStage(
         modifier = modifier.background(
             Brush.verticalGradient(
                 listOf(
-                    EVDesignTokens.Media.stageTop,
-                    EVDesignTokens.Media.stageMiddle,
-                    EVDesignTokens.Media.stageBottom
+                    media.stageTop,
+                    media.stageMiddle,
+                    media.stageBottom
                 )
             )
         ),
@@ -270,7 +299,7 @@ private fun VehicleStage(
         Icon(
             imageVector = Icons.Default.DirectionsCar,
             contentDescription = null,
-            tint = EVDesignTokens.Energy.green.copy(alpha = 0.42f),
+            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.42f),
             modifier = Modifier.size(72.dp)
         )
 

--- a/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/dashboard/HeroVehicleCard.kt
@@ -79,7 +79,6 @@ fun HeroVehicleCard(
     artworkKey: String? = null,
     edgeToEdgeTop: Boolean = false
 ) {
-    val cockpit = LocalCockpitColors.current
     val context = LocalContext.current
     val catalogId = vehicle?.catalogVehicleId?.trim()?.takeIf { it.isNotEmpty() }
     val localArtworkKey by remember(catalogId, context.applicationContext) {
@@ -103,7 +102,7 @@ fun HeroVehicleCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        color = Color(0xFF06100C)
+        color = MaterialTheme.colorScheme.background
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.fillMaxWidth()) {
@@ -119,11 +118,11 @@ fun HeroVehicleCard(
                             .background(
                                 Brush.verticalGradient(
                                     listOf(
-                                        Color(0x98020806),
-                                        Color(0x20020806),
+                                        EVDesignTokens.Media.scrimStrong,
+                                        EVDesignTokens.Media.scrimSoft,
                                         Color.Transparent,
-                                        Color(0x10020806),
-                                        Color(0x4806100C)
+                                        EVDesignTokens.Media.scrimLower,
+                                        EVDesignTokens.Media.scrimBottom
                                     )
                                 )
                             )
@@ -141,7 +140,7 @@ fun HeroVehicleCard(
                         style = MaterialTheme.typography.titleMedium,
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Medium,
-                        color = cockpit.primaryText,
+                        color = EVDesignTokens.Media.primaryText,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -156,8 +155,8 @@ fun HeroVehicleCard(
                                 modifier = Modifier
                                     .size(42.dp)
                                     .clip(CircleShape)
-                                    .background(Color(0x6607110F))
-                                    .border(1.dp, Color.White.copy(alpha = 0.14f), CircleShape)
+                                    .background(EVDesignTokens.Media.controlSurface)
+                                    .border(1.dp, EVDesignTokens.Media.controlOutline, CircleShape)
                                     .clickable(enabled = canSwitchVehicle) {
                                         vehicleMenuExpanded = true
                                     },
@@ -260,9 +259,9 @@ private fun VehicleStage(
         modifier = modifier.background(
             Brush.verticalGradient(
                 listOf(
-                    Color(0xFF07110D),
-                    Color(0xFF0A1712),
-                    Color(0xFF06100C)
+                    EVDesignTokens.Media.stageTop,
+                    EVDesignTokens.Media.stageMiddle,
+                    EVDesignTokens.Media.stageBottom
                 )
             )
         ),
@@ -302,6 +301,7 @@ private fun HeroDynamicStatePanel(
     latestTrip: TripSessionEntity?,
     modifier: Modifier = Modifier
 ) {
+    val cockpit = LocalCockpitColors.current
     val safeSoc = currentSoc?.coerceIn(0, 100)
     val targetProgress = safeSoc?.div(100f) ?: 0f
     val animatedProgress by animateFloatAsState(
@@ -324,16 +324,15 @@ private fun HeroDynamicStatePanel(
             .shadow(
                 elevation = 6.dp,
                 shape = panelShape,
-                ambientColor = Color.Black.copy(alpha = 0.20f),
-                spotColor = Color.Black.copy(alpha = 0.26f)
+                ambientColor = Color.Black.copy(alpha = 0.16f),
+                spotColor = Color.Black.copy(alpha = 0.22f)
             )
             .clip(panelShape)
             .background(
                 Brush.verticalGradient(
                     listOf(
-                        Color.White.copy(alpha = 0.045f),
-                        Color(0x9013211C),
-                        Color(0xB0091411)
+                        cockpit.surfaceElevated,
+                        cockpit.surface
                     )
                 )
             )
@@ -341,9 +340,9 @@ private fun HeroDynamicStatePanel(
                 width = 1.dp,
                 brush = Brush.linearGradient(
                     listOf(
-                        Color.White.copy(alpha = 0.15f),
-                        Color.White.copy(alpha = 0.05f),
-                        EVDesignTokens.Energy.green.copy(alpha = 0.07f)
+                        cockpit.outline.copy(alpha = 0.90f),
+                        cockpit.outline.copy(alpha = 0.55f),
+                        cockpit.accent.copy(alpha = 0.10f)
                     )
                 ),
                 shape = panelShape
@@ -355,9 +354,9 @@ private fun HeroDynamicStatePanel(
                 .background(
                     Brush.horizontalGradient(
                         listOf(
-                            Color(0x181D6D49),
+                            cockpit.accent.copy(alpha = 0.06f),
                             Color.Transparent,
-                            Color(0x0C174634)
+                            cockpit.accent.copy(alpha = 0.03f)
                         )
                     )
                 )
@@ -408,7 +407,7 @@ private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modi
                     safeSoc.toString(),
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.SemiBold,
-                    color = EVDesignTokens.Energy.green
+                    color = cockpit.accent
                 )
                 Text(
                     "%",
@@ -439,7 +438,7 @@ private fun HeroSocMetric(safeSoc: Int?, animatedProgress: Float, modifier: Modi
                     Modifier
                         .fillMaxWidth(animatedProgress)
                         .fillMaxSize()
-                        .background(EVDesignTokens.Energy.green)
+                        .background(cockpit.accent)
                 )
             }
         }
@@ -518,7 +517,7 @@ private fun MetricDivider() {
     Box(
         Modifier
             .size(width = 1.dp, height = 44.dp)
-            .background(LocalCockpitColors.current.secondaryText.copy(alpha = .20f))
+            .background(LocalCockpitColors.current.outline.copy(alpha = 0.70f))
     )
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/theme/CockpitTheme.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/CockpitTheme.kt
@@ -1,30 +1,49 @@
 package com.evchargebook.ui.theme
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
 /**
- * Product-level colors for EV cockpit surfaces.
+ * Theme-aware semantic colors for dashboard/cockpit data surfaces.
  *
- * Keep this separate from Material inverse colors so dashboard,
- * trip and charging cockpit surfaces remain stable across theme changes.
+ * Normal cards and metrics must follow the active Material color scheme. Fixed dark colors
+ * belong only to media overlays such as the vehicle artwork stage.
  */
 data class CockpitColors(
     val background: Color,
+    val surface: Color,
+    val surfaceElevated: Color,
     val primaryText: Color,
     val secondaryText: Color,
+    val outline: Color,
     val accent: Color,
     val warning: Color,
     val danger: Color
 )
 
+internal fun cockpitColorsFor(colorScheme: ColorScheme) = CockpitColors(
+    background = colorScheme.background,
+    surface = colorScheme.surfaceContainerLow,
+    surfaceElevated = colorScheme.surfaceContainerHigh,
+    primaryText = colorScheme.onSurface,
+    secondaryText = colorScheme.onSurfaceVariant,
+    outline = colorScheme.outlineVariant,
+    accent = colorScheme.primary,
+    warning = EVDesignTokens.Energy.warning,
+    danger = colorScheme.error
+)
+
 val LocalCockpitColors = staticCompositionLocalOf {
     CockpitColors(
-        background = Color(0xFF11171B),
-        primaryText = Color(0xFFF4F8F6),
-        secondaryText = Color(0xFFB7C2BD),
-        accent = Color(0xFF45E6A8),
-        warning = Color(0xFFFFC56B),
-        danger = Color(0xFFFFB4AB)
+        background = EVDesignTokens.Dark.background,
+        surface = EVDesignTokens.Dark.surfaceLow,
+        surfaceElevated = EVDesignTokens.Dark.surfaceElevated,
+        primaryText = EVDesignTokens.Dark.primaryText,
+        secondaryText = EVDesignTokens.Dark.secondaryText,
+        outline = EVDesignTokens.Dark.outlineVariant,
+        accent = EVDesignTokens.Energy.green,
+        warning = EVDesignTokens.Energy.warning,
+        danger = EVDesignTokens.Energy.danger
     )
 }

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
@@ -74,16 +74,17 @@ object EVDesignTokens {
             stageTop = Color(0xFFF2F6F4),
             stageMiddle = Color(0xFFE8EFEB),
             stageBottom = Color(0xFFF7F9F8),
-            primaryText = Light.primaryText,
-            controlSurface = Color.White.copy(alpha = 0.78f),
-            controlOutline = Color.Black.copy(alpha = 0.10f),
-            // A pale scrim guarantees dark title/status chrome remains readable even when the
-            // light-specific vehicle artwork has mixed brightness near the top edge.
-            scrimStrong = Color(0xB8F4F7F5),
-            scrimSoft = Color(0x42F4F7F5),
-            scrimLower = Color(0x18F4F7F5),
-            scrimBottom = Color(0x8AF4F7F5),
-            darkSurface = false,
+            // Both Hero variants reserve a dark top safe-area for white status/title chrome.
+            // Light mode becomes bright through the artwork itself and the lower transition rather
+            // than flipping system-bar contrast on every image.
+            primaryText = Color(0xFFF4F8F6),
+            controlSurface = Color(0x6607110F),
+            controlOutline = Color.White.copy(alpha = 0.14f),
+            scrimStrong = Color(0x98020806),
+            scrimSoft = Color(0x28020806),
+            scrimLower = Color.White.copy(alpha = 0.05f),
+            scrimBottom = Light.background.copy(alpha = 0.66f),
+            darkSurface = true,
         )
 
         fun forTheme(darkTheme: Boolean): HeroMediaColors = if (darkTheme) dark else light

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
@@ -3,19 +3,52 @@ package com.evchargebook.ui.theme
 import androidx.compose.ui.graphics.Color
 
 /**
- * EV Charge Book v0.5 design tokens.
+ * Product-level visual tokens for EV Charge Book.
  *
- * Dark First visual foundation.
- * Keep tokens independent from MaterialTheme so screens can share a stable product language.
+ * Theme-sensitive UI should consume MaterialTheme.colorScheme. These raw palette values
+ * only define the app light/dark schemes and intentional media-only overlays in one place.
  */
 object EVDesignTokens {
+    object Light {
+        val background = Color(0xFFF4F7F5)
+        val surface = Color(0xFFFFFFFF)
+        val surfaceLow = Color(0xFFF0F4F2)
+        val surfaceHigh = Color(0xFFE7EDE9)
+        val surfaceHighest = Color(0xFFDDE6E1)
+        val primaryText = Color(0xFF101512)
+        val secondaryText = Color(0xFF5F6D66)
+        val outline = Color(0xFFC9D5CF)
+        val outlineVariant = Color(0xFFDCE5E0)
+    }
+
     object Dark {
         val background = Color(0xFF090D0C)
+        val surfaceLowest = Color(0xFF060908)
+        val surfaceLow = Color(0xFF0D1311)
         val surface = Color(0xFF121716)
         val surfaceElevated = Color(0xFF19201D)
+        val surfaceHighest = Color(0xFF202925)
         val primaryText = Color(0xFFEAF3EE)
         val secondaryText = Color(0xFF9AA6A0)
         val outline = Color(0xFF26302C)
+        val outlineVariant = Color(0xFF1B2521)
+    }
+
+    /**
+     * Fixed dark media colors used only on top of vehicle artwork where contrast must stay
+     * predictable regardless of the surrounding app theme.
+     */
+    object Media {
+        val stageTop = Color(0xFF07110D)
+        val stageMiddle = Color(0xFF0A1712)
+        val stageBottom = Color(0xFF06100C)
+        val primaryText = Color(0xFFF4F8F6)
+        val controlSurface = Color(0x6607110F)
+        val controlOutline = Color.White.copy(alpha = 0.14f)
+        val scrimStrong = Color(0x98020806)
+        val scrimSoft = Color(0x20020806)
+        val scrimLower = Color(0x10020806)
+        val scrimBottom = Color(0x4806100C)
     }
 
     object Energy {

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EVDesignTokens.kt
@@ -3,10 +3,31 @@ package com.evchargebook.ui.theme
 import androidx.compose.ui.graphics.Color
 
 /**
+ * Theme-aware colors used only by the vehicle artwork stage.
+ *
+ * Unlike normal cards, Hero media needs its own palette so the photo/scrim/title treatment can
+ * remain legible while still having a real light and dark presentation.
+ */
+data class HeroMediaColors(
+    val stageTop: Color,
+    val stageMiddle: Color,
+    val stageBottom: Color,
+    val primaryText: Color,
+    val controlSurface: Color,
+    val controlOutline: Color,
+    val scrimStrong: Color,
+    val scrimSoft: Color,
+    val scrimLower: Color,
+    val scrimBottom: Color,
+    val darkSurface: Boolean,
+)
+
+/**
  * Product-level visual tokens for EV Charge Book.
  *
- * Theme-sensitive UI should consume MaterialTheme.colorScheme. These raw palette values
- * only define the app light/dark schemes and intentional media-only overlays in one place.
+ * Theme-sensitive normal UI should consume MaterialTheme.colorScheme. These raw palette values
+ * define the app light/dark schemes, product accents and the intentional Hero media treatment in
+ * one place so screens do not invent their own Color(0x...) values.
  */
 object EVDesignTokens {
     object Light {
@@ -34,21 +55,38 @@ object EVDesignTokens {
         val outlineVariant = Color(0xFF1B2521)
     }
 
-    /**
-     * Fixed dark media colors used only on top of vehicle artwork where contrast must stay
-     * predictable regardless of the surrounding app theme.
-     */
     object Media {
-        val stageTop = Color(0xFF07110D)
-        val stageMiddle = Color(0xFF0A1712)
-        val stageBottom = Color(0xFF06100C)
-        val primaryText = Color(0xFFF4F8F6)
-        val controlSurface = Color(0x6607110F)
-        val controlOutline = Color.White.copy(alpha = 0.14f)
-        val scrimStrong = Color(0x98020806)
-        val scrimSoft = Color(0x20020806)
-        val scrimLower = Color(0x10020806)
-        val scrimBottom = Color(0x4806100C)
+        val dark = HeroMediaColors(
+            stageTop = Color(0xFF07110D),
+            stageMiddle = Color(0xFF0A1712),
+            stageBottom = Color(0xFF06100C),
+            primaryText = Color(0xFFF4F8F6),
+            controlSurface = Color(0x6607110F),
+            controlOutline = Color.White.copy(alpha = 0.14f),
+            scrimStrong = Color(0x98020806),
+            scrimSoft = Color(0x20020806),
+            scrimLower = Color(0x10020806),
+            scrimBottom = Color(0x4806100C),
+            darkSurface = true,
+        )
+
+        val light = HeroMediaColors(
+            stageTop = Color(0xFFF2F6F4),
+            stageMiddle = Color(0xFFE8EFEB),
+            stageBottom = Color(0xFFF7F9F8),
+            primaryText = Light.primaryText,
+            controlSurface = Color.White.copy(alpha = 0.78f),
+            controlOutline = Color.Black.copy(alpha = 0.10f),
+            // A pale scrim guarantees dark title/status chrome remains readable even when the
+            // light-specific vehicle artwork has mixed brightness near the top edge.
+            scrimStrong = Color(0xB8F4F7F5),
+            scrimSoft = Color(0x42F4F7F5),
+            scrimLower = Color(0x18F4F7F5),
+            scrimBottom = Color(0x8AF4F7F5),
+            darkSurface = false,
+        )
+
+        fun forTheme(darkTheme: Boolean): HeroMediaColors = if (darkTheme) dark else light
     }
 
     object Energy {

--- a/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/theme/EvChargeTheme.kt
@@ -42,29 +42,24 @@ val LocalAppThemeController = staticCompositionLocalOf { AppThemeController(true
 val MaterialTheme.spacing: AppSpacing
     @Composable get() = LocalAppSpacing.current
 
-private val LightBackground = Color(0xFFF4F7F5)
-private val LightSurface = Color(0xFFFFFFFF)
-private val LightSurfaceLow = Color(0xFFF0F4F2)
-private val LightSurfaceHigh = Color(0xFFE7EDE9)
-
 private val BrandLight = lightColorScheme(
     primary = Color(0xFF087A3B),
     onPrimary = Color.White,
     primaryContainer = Color(0xFFD6F8E2),
     onPrimaryContainer = Color(0xFF082414),
-    background = LightBackground,
-    onBackground = Color(0xFF101512),
-    surface = LightSurface,
-    onSurface = Color(0xFF101512),
-    surfaceVariant = LightSurfaceLow,
-    onSurfaceVariant = Color(0xFF5F6D66),
-    surfaceContainerLowest = Color.White,
-    surfaceContainerLow = Color(0xFFF4F7F5),
-    surfaceContainer = LightSurfaceLow,
-    surfaceContainerHigh = LightSurfaceHigh,
-    surfaceContainerHighest = Color(0xFFDDE6E1),
-    outline = Color(0xFFC9D5CF),
-    outlineVariant = Color(0xFFDCE5E0),
+    background = EVDesignTokens.Light.background,
+    onBackground = EVDesignTokens.Light.primaryText,
+    surface = EVDesignTokens.Light.surface,
+    onSurface = EVDesignTokens.Light.primaryText,
+    surfaceVariant = EVDesignTokens.Light.surfaceLow,
+    onSurfaceVariant = EVDesignTokens.Light.secondaryText,
+    surfaceContainerLowest = EVDesignTokens.Light.surface,
+    surfaceContainerLow = EVDesignTokens.Light.background,
+    surfaceContainer = EVDesignTokens.Light.surfaceLow,
+    surfaceContainerHigh = EVDesignTokens.Light.surfaceHigh,
+    surfaceContainerHighest = EVDesignTokens.Light.surfaceHighest,
+    outline = EVDesignTokens.Light.outline,
+    outlineVariant = EVDesignTokens.Light.outlineVariant,
     error = Color(0xFFBA1A1A),
     onError = Color.White
 )
@@ -80,13 +75,13 @@ private val BrandDark = darkColorScheme(
     onSurface = EVDesignTokens.Dark.primaryText,
     surfaceVariant = EVDesignTokens.Dark.surfaceElevated,
     onSurfaceVariant = EVDesignTokens.Dark.secondaryText,
-    surfaceContainerLowest = Color(0xFF060908),
-    surfaceContainerLow = Color(0xFF0D1311),
+    surfaceContainerLowest = EVDesignTokens.Dark.surfaceLowest,
+    surfaceContainerLow = EVDesignTokens.Dark.surfaceLow,
     surfaceContainer = EVDesignTokens.Dark.surface,
     surfaceContainerHigh = EVDesignTokens.Dark.surfaceElevated,
-    surfaceContainerHighest = Color(0xFF202925),
+    surfaceContainerHighest = EVDesignTokens.Dark.surfaceHighest,
     outline = EVDesignTokens.Dark.outline,
-    outlineVariant = Color(0xFF1B2521),
+    outlineVariant = EVDesignTokens.Dark.outlineVariant,
     error = EVDesignTokens.Energy.danger,
     onError = Color(0xFF220001),
     inverseSurface = Color(0xFFEAF3EE),
@@ -138,7 +133,8 @@ fun EvChargeTheme(
 
     CompositionLocalProvider(
         LocalAppSpacing provides AppSpacing(),
-        LocalAppThemeController provides controller
+        LocalAppThemeController provides controller,
+        LocalCockpitColors provides cockpitColorsFor(colors)
     ) {
         MaterialTheme(
             colorScheme = colors,

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/HeroArtworkManifestRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/HeroArtworkManifestRepository.kt
@@ -1,7 +1,6 @@
 package com.evchargebook.ui.vehicle
 
 import android.content.Context
-import android.content.res.Configuration
 import com.evchargebook.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +32,10 @@ import java.net.URL
  * - <base>-light
  *
  * Existing <base> entries remain a supported legacy fallback.
+ *
+ * The caller supplies the active app-theme preference. Do not infer it from Android's system
+ * uiMode because EV Charge Book supports an in-app theme that may intentionally differ from the
+ * device theme.
  */
 object HeroArtworkManifestRepository {
     data class RemoteArtwork(
@@ -55,16 +58,21 @@ object HeroArtworkManifestRepository {
     @Volatile private var artworks: Map<String, RemoteArtwork> = emptyMap()
 
     /**
-     * Resolve the best Hero for the current Android UI mode.
+     * Resolve the best Hero for the active EV Charge Book theme.
      *
      * Dark: <base>-dark -> legacy <base>
      * Light: <base>-light -> <base>-dark -> legacy <base>
+     *
+     * Light intentionally falls back to the dark or legacy artwork instead of showing an empty
+     * Hero while a light-specific asset is still being published.
      */
-    suspend fun resolve(context: Context, artworkKey: String): RemoteArtwork? {
+    suspend fun resolve(
+        context: Context,
+        artworkKey: String,
+        preferLight: Boolean,
+    ): RemoteArtwork? {
         val appContext = context.applicationContext
         ensureCachedManifestLoaded(appContext)
-        val preferLight = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) !=
-            Configuration.UI_MODE_NIGHT_YES
 
         resolveCached(artworkKey, preferLight)?.let { cached ->
             startRemoteRefresh(appContext)
@@ -98,8 +106,8 @@ object HeroArtworkManifestRepository {
         val base = artworkKey.trim().removeSuffix("-dark").removeSuffix("-light")
         return candidateKeys(base, preferLight).firstNotNullOfOrNull { key ->
             entries[key]?.let { artwork ->
-                // HeroVehicleCard historically uses RemoteArtwork.version as an explicit Coil cache key.
-                // Encode only the resolved semantic variant into that cache version so light/dark v1
+                // HeroVehicleCard uses RemoteArtwork.version as an explicit Coil cache key.
+                // Encode the resolved semantic variant into that cache version so light/dark v1
                 // cannot collide in memory/disk cache. manifestVersion remains the authoritative vN.
                 val marker = when {
                     key.endsWith("-light") -> 2

--- a/android/app/src/test/java/com/evchargebook/ui/theme/CockpitThemeContractTest.kt
+++ b/android/app/src/test/java/com/evchargebook/ui/theme/CockpitThemeContractTest.kt
@@ -1,0 +1,38 @@
+package com.evchargebook.ui.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CockpitThemeContractTest {
+    @Test
+    fun lightCockpitColorsFollowActiveMaterialScheme() {
+        val scheme = lightColorScheme()
+        val cockpit = cockpitColorsFor(scheme)
+
+        assertEquals(scheme.background, cockpit.background)
+        assertEquals(scheme.surfaceContainerLow, cockpit.surface)
+        assertEquals(scheme.surfaceContainerHigh, cockpit.surfaceElevated)
+        assertEquals(scheme.onSurface, cockpit.primaryText)
+        assertEquals(scheme.onSurfaceVariant, cockpit.secondaryText)
+        assertEquals(scheme.outlineVariant, cockpit.outline)
+        assertEquals(scheme.primary, cockpit.accent)
+        assertEquals(scheme.error, cockpit.danger)
+    }
+
+    @Test
+    fun darkCockpitColorsFollowActiveMaterialScheme() {
+        val scheme = darkColorScheme()
+        val cockpit = cockpitColorsFor(scheme)
+
+        assertEquals(scheme.background, cockpit.background)
+        assertEquals(scheme.surfaceContainerLow, cockpit.surface)
+        assertEquals(scheme.surfaceContainerHigh, cockpit.surfaceElevated)
+        assertEquals(scheme.onSurface, cockpit.primaryText)
+        assertEquals(scheme.onSurfaceVariant, cockpit.secondaryText)
+        assertEquals(scheme.outlineVariant, cockpit.outline)
+        assertEquals(scheme.primary, cockpit.accent)
+        assertEquals(scheme.error, cockpit.danger)
+    }
+}

--- a/hero-admin/README.md
+++ b/hero-admin/README.md
@@ -35,6 +35,26 @@ The operator is responsible for uploading an official brand asset with appropria
 
 ## Hero contract
 
+The vehicle catalog stores one stable semantic **base Hero key** such as `leapmotor-c16-2026`. Theme variants belong in the Hero manifest, not in the catalog row:
+
+```text
+<base>-dark
+<base>-light
+```
+
+For example:
+
+```text
+leapmotor-c16-2026-dark
+leapmotor-c16-2026-light
+```
+
+Android resolves the variant from the **EV Charge Book in-app theme**, which may differ from the device/system theme. Dark mode prefers `<base>-dark`; light mode prefers `<base>-light`. Legacy `<base>` entries remain a compatibility fallback while an older asset set is being migrated.
+
+A newly published supported Hero should provide **both** light and dark variants. Publishing only the base key is legacy-compatible but does not constitute complete light/dark visual acceptance.
+
+Both variants must preserve the Hero safe-area contract: the top status/title zone remains contrast-safe for white system/title chrome, while the light variant uses a brighter vehicle/background treatment and a light lower transition into the dashboard surface.
+
 Hero publishing:
 
 - PNG/WebP source;
@@ -118,7 +138,7 @@ No public container port is required; Nginx reaches `hero-admin:8080` on the exi
 
 ## Nginx
 
-The existing `/ev-charge-book/releases/` static location serves both `hero-assets/` and `brand-logos/` immutable files.
+The existing `/ev-charge-book/releases/` static location serves both `hero-assets/` and `brand-logos` immutable files.
 
 The mutable runtime pointers must not be cached as immutable:
 


### PR DESCRIPTION
Closes #287

## Summary

- centralize light, dark, and Hero-media palette tokens
- derive cockpit/data-surface semantic colors from the active Material3 color scheme
- migrate recent-trip and energy dashboard cards away from fixed dark surfaces
- make the Hero SOC / mileage / recent-trip panel follow light/dark mode
- make the Hero artwork stage itself theme-aware instead of dark-invariant
- resolve `<base>-light` / `<base>-dark` from the EV Charge Book in-app theme, not Android system `uiMode`
- re-resolve the Hero immediately when the in-app theme is toggled so a system-dark/app-light combination still selects the light Hero
- keep a contrast-safe dark top safe-area for status/title chrome in both Hero variants while light mode transitions into a bright lower surface
- add a unit contract test so cockpit colors continue to derive from the active scheme
- document the managed Hero base-key + light/dark variant publishing contract

## Hero asset contract

The vehicle catalog continues to store one stable semantic base key, for example `leapmotor-c16-2026`. The Hero manifest may publish:

- `leapmotor-c16-2026-dark`
- `leapmotor-c16-2026-light`

Dark mode resolves `-dark -> legacy base`; light mode resolves `-light -> -dark -> legacy base`. The fallback avoids an empty Hero while assets are migrated, but a supported Hero is not considered fully light/dark-complete until both variants are published.

The repository seed manifest currently still contains legacy base-only entries, so visual light-Hero acceptance also depends on the deployed runtime manifest having a `-light` asset. This PR fixes Android selection/rendering; it does not fabricate missing vehicle artwork.

## Intentional boundary

Normal dashboard chrome and data panels follow `MaterialTheme.colorScheme`. Hero photo treatment follows a dedicated light/dark media palette because image scrims and title contrast are not ordinary Material surfaces. No data/business behavior or navigation/layout flow is changed.

## Automated evidence

- Android Build #733: green on current head `5fafe46d8054db6cabf153f67c0955f1a41a88de`
- Hero Admin validation: green on current head
- Hero Admin Deploy workflow PR validation: green; production deploy step is push-to-main only

## Test plan / physical acceptance

- physical-device check with device theme and app theme intentionally mismatched, especially system dark + app light
- verify Dashboard switches Hero from `<base>-dark` to `<base>-light` without app restart when both assets exist
- verify fallback remains non-empty when a light-specific asset is not yet published
- verify dashboard background, recent-trip card, energy card, Hero data panel, status/navigation bar contrast in both modes
- record the resolved Hero manifest key in acceptance evidence

## Current branch state

- branch started from `6741054727c53bc3b5c28fda5ae88bdeb39066b9`
- `main` has since advanced by two charging-only commits; compare shows their changed files are disjoint from this PR
- branch is currently behind `main` by 2 and must be synchronized, then current-head CI reconfirmed, before leaving Draft / merging
- no stacked PR dependency