### PR TITLE
feat(charging): persist pending meter backfill lifecycle

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
+++ b/android/app/src/main/java/com/evchargebook/data/backup/BackupCodec.kt
@@ -23,7 +23,7 @@ data class BackupPayload(
 )
 
 object BackupCodec {
-    const val CURRENT_SCHEMA_VERSION = 9
+    const val CURRENT_SCHEMA_VERSION = 10
 
     fun encode(payload: BackupPayload): String = JSONObject().apply {
         put("schemaVersion", payload.schemaVersion)
@@ -89,6 +89,11 @@ object BackupCodec {
                     putNullable("locationAccuracyMeters", session.locationAccuracyMeters)
                     put("status", session.status)
                     putNullable("endedAtEpochMillis", session.endedAtEpochMillis)
+                    putNullable("endSoc", session.endSoc)
+                    putNullable("odometerKm", session.odometerKm)
+                    putNullable("pendingMeterEnergyKwh", session.pendingMeterEnergyKwh)
+                    putNullable("pendingTotalCost", session.pendingTotalCost)
+                    putNullable("pendingVehicleEnergyKwh", session.pendingVehicleEnergyKwh)
                     putNullable("completedRecordId", session.completedRecordId)
                     put("updatedAtEpochMillis", session.updatedAtEpochMillis)
                 })
@@ -231,6 +236,11 @@ object BackupCodec {
                         locationAccuracyMeters = item.optNullableDouble("locationAccuracyMeters"),
                         status = item.optString("status", ChargingSessionStatus.ACTIVE),
                         endedAtEpochMillis = item.optNullableLong("endedAtEpochMillis"),
+                        endSoc = item.optNullableInt("endSoc"),
+                        odometerKm = item.optNullableDouble("odometerKm"),
+                        pendingMeterEnergyKwh = item.optNullableDouble("pendingMeterEnergyKwh"),
+                        pendingTotalCost = item.optNullableDouble("pendingTotalCost"),
+                        pendingVehicleEnergyKwh = item.optNullableDouble("pendingVehicleEnergyKwh"),
                         completedRecordId = item.optNullableLong("completedRecordId"),
                         updatedAtEpochMillis = item.optLong("updatedAtEpochMillis", startedAt),
                     )
@@ -319,13 +329,24 @@ object BackupCodec {
         require(chargingSessions.all { it.status in ChargingSessionStatus.all }) { "备份中存在未知充电会话状态" }
         require(chargingSessions.all { it.startSoc == null || it.startSoc in 0..100 }) { "备份中存在无效充电开始 SOC" }
         require(chargingSessions.all { it.targetSoc == null || it.targetSoc in 0..100 }) { "备份中存在无效充电目标 SOC" }
+        require(chargingSessions.all { it.endSoc == null || it.endSoc in 0..100 }) { "备份中存在无效充电结束 SOC" }
         require(chargingSessions.all { it.unitPricePerKwh == null || it.unitPricePerKwh >= 0.0 }) { "备份中存在无效充电单价" }
+        require(chargingSessions.all { it.odometerKm == null || it.odometerKm >= 0.0 }) { "备份中存在无效充电里程" }
+        require(chargingSessions.all { it.pendingMeterEnergyKwh == null || it.pendingMeterEnergyKwh > 0.0 }) { "备份中存在无效待补录电表电量" }
+        require(chargingSessions.all { it.pendingTotalCost == null || it.pendingTotalCost >= 0.0 }) { "备份中存在无效待补录费用" }
+        require(chargingSessions.all { it.pendingVehicleEnergyKwh == null || it.pendingVehicleEnergyKwh >= 0.0 }) { "备份中存在无效待补录车辆侧电量" }
+        require(chargingSessions.all {
+            it.pendingVehicleEnergyKwh == null || it.pendingMeterEnergyKwh == null ||
+                it.pendingVehicleEnergyKwh <= it.pendingMeterEnergyKwh + 1e-6
+        }) { "备份中车辆侧电量高于电表电量" }
         require(chargingSessions.all { (it.latitude == null) == (it.longitude == null) }) { "备份中存在不完整的充电会话坐标" }
         require(chargingSessions.all { it.endedAtEpochMillis == null || it.endedAtEpochMillis >= it.startedAtEpochMillis }) { "备份中存在无效充电会话结束时间" }
         require(chargingSessions.all { it.completedRecordId == null || it.completedRecordId in recordIds }) { "备份中存在无法关联记录的已完成充电会话" }
         require(chargingSessions.all {
             when (it.status) {
                 ChargingSessionStatus.ACTIVE -> it.endedAtEpochMillis == null && it.completedRecordId == null
+                ChargingSessionStatus.PENDING_DETAILS ->
+                    it.endedAtEpochMillis != null && it.endSoc != null && it.completedRecordId == null
                 ChargingSessionStatus.COMPLETED -> it.endedAtEpochMillis != null && it.completedRecordId != null
                 ChargingSessionStatus.CANCELLED -> it.endedAtEpochMillis != null && it.completedRecordId == null
                 else -> false

--- a/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
@@ -16,8 +16,23 @@ interface ChargingSessionDao {
     @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'ACTIVE' ORDER BY startedAtEpochMillis DESC LIMIT 1")
     suspend fun getActiveForVehicle(vehicleId: Long): ChargingSessionEntity?
 
+    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC")
+    fun observePendingForVehicle(vehicleId: Long): Flow<List<ChargingSessionEntity>>
+
+    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC")
+    suspend fun getPendingForVehicle(vehicleId: Long): List<ChargingSessionEntity>
+
+    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' AND endSoc IS NOT NULL ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC LIMIT 1")
+    suspend fun getLatestPendingWithEndSocForVehicle(vehicleId: Long): ChargingSessionEntity?
+
+    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' AND odometerKm IS NOT NULL ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC LIMIT 1")
+    suspend fun getLatestPendingWithOdometerForVehicle(vehicleId: Long): ChargingSessionEntity?
+
     @Query("SELECT * FROM charging_sessions WHERE status = 'ACTIVE' ORDER BY startedAtEpochMillis DESC LIMIT 1")
     suspend fun getAnyActive(): ChargingSessionEntity?
+
+    @Query("SELECT * FROM charging_sessions WHERE status IN ('ACTIVE', 'PENDING_DETAILS') ORDER BY updatedAtEpochMillis DESC LIMIT 1")
+    suspend fun getAnyUnfinished(): ChargingSessionEntity?
 
     @Query("SELECT * FROM charging_sessions WHERE id = :sessionId LIMIT 1")
     suspend fun get(sessionId: String): ChargingSessionEntity?

--- a/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/AppDatabase.kt
@@ -35,7 +35,7 @@ import com.evchargebook.data.entity.VehicleStateEntity
         VehicleStateEntity::class,
         AutoTripDetectionSessionEntity::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -230,6 +230,12 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                ChargingPendingMigration17To18.statements.forEach(db::execSQL)
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -257,6 +263,7 @@ abstract class AppDatabase : RoomDatabase() {
                         MIGRATION_14_15,
                         MIGRATION_15_16,
                         MIGRATION_16_17,
+                        MIGRATION_17_18,
                     )
                     .build()
                     .also { instance = it }

--- a/android/app/src/main/java/com/evchargebook/data/database/ChargingPendingMigration17To18.kt
+++ b/android/app/src/main/java/com/evchargebook/data/database/ChargingPendingMigration17To18.kt
@@ -1,0 +1,17 @@
+package com.evchargebook.data.database
+
+/**
+ * Room v17 -> v18 contract for ended charging sessions whose meter data arrives later.
+ *
+ * Every new field is nullable so existing ACTIVE / COMPLETED / CANCELLED sessions retain their
+ * original facts without inference or fake zero values.
+ */
+object ChargingPendingMigration17To18 {
+    val statements = listOf(
+        "ALTER TABLE charging_sessions ADD COLUMN endSoc INTEGER",
+        "ALTER TABLE charging_sessions ADD COLUMN odometerKm REAL",
+        "ALTER TABLE charging_sessions ADD COLUMN pendingMeterEnergyKwh REAL",
+        "ALTER TABLE charging_sessions ADD COLUMN pendingTotalCost REAL",
+        "ALTER TABLE charging_sessions ADD COLUMN pendingVehicleEnergyKwh REAL",
+    )
+}

--- a/android/app/src/main/java/com/evchargebook/data/entity/ChargingSessionEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/ChargingSessionEntity.kt
@@ -7,10 +7,11 @@ import java.util.UUID
 
 object ChargingSessionStatus {
     const val ACTIVE = "ACTIVE"
+    const val PENDING_DETAILS = "PENDING_DETAILS"
     const val COMPLETED = "COMPLETED"
     const val CANCELLED = "CANCELLED"
 
-    val all: Set<String> = setOf(ACTIVE, COMPLETED, CANCELLED)
+    val all: Set<String> = setOf(ACTIVE, PENDING_DETAILS, COMPLETED, CANCELLED)
 }
 
 /**
@@ -18,6 +19,9 @@ object ChargingSessionStatus {
  *
  * This is deliberately separate from [ChargingRecordEntity]: a charging record is a completed
  * historical fact, while a session may survive process death with completion facts still unknown.
+ *
+ * `PENDING_DETAILS` means physical charging has ended and the end facts are durable, but billing /
+ * meter facts are not complete enough to create a final historical charging record yet.
  */
 @Entity(
     tableName = "charging_sessions",
@@ -43,6 +47,15 @@ data class ChargingSessionEntity(
     val locationAccuracyMeters: Double? = null,
     val status: String = ChargingSessionStatus.ACTIVE,
     val endedAtEpochMillis: Long? = null,
+    /** Actual end SOC captured when physical charging ends. */
+    val endSoc: Int? = null,
+    /** Optional odometer captured when physical charging ends. */
+    val odometerKm: Double? = null,
+    /** Optional partial billing facts retained while waiting for final meter data. */
+    val pendingMeterEnergyKwh: Double? = null,
+    val pendingTotalCost: Double? = null,
+    /** Explicit measured vehicle-side energy only; never store the SOC-based estimate here. */
+    val pendingVehicleEnergyKwh: Double? = null,
     val completedRecordId: Long? = null,
     val updatedAtEpochMillis: Long = System.currentTimeMillis(),
 )

--- a/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
+++ b/android/app/src/main/java/com/evchargebook/data/entity/VehicleStateEntity.kt
@@ -17,6 +17,7 @@ enum class VehicleStateUpdateSource {
     UNKNOWN,
     MIGRATION,
     CHARGE_RECORD,
+    CHARGE_PENDING,
     TRIP_END,
     MANUAL_UPDATE,
     IMPORT

--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
@@ -26,9 +26,7 @@ data class StartChargingSessionRequest(
 )
 
 /**
- * Final completion facts. The completion editor must pass its final visible values, including the
- * session defaults it kept. Null coordinates intentionally mean "no coordinates" so manually
- * replacing an address never keeps stale coordinates behind the scenes.
+ * Final completion facts when billing / meter data is already known at charge end.
  */
 data class CompleteChargingSessionRequest(
     val sessionId: String,
@@ -47,6 +45,36 @@ data class CompleteChargingSessionRequest(
     val locationAccuracyMeters: Double? = null,
 )
 
+/**
+ * Physical charging has ended but final meter / billing data may still be unavailable.
+ *
+ * Optional billing values are retained only when the user already knows them. Unknown values stay
+ * null; zero is never used as an "unknown" sentinel.
+ */
+data class DeferChargingCompletionRequest(
+    val sessionId: String,
+    val startSoc: Int,
+    val endSoc: Int,
+    val endedAtEpochMillis: Long = System.currentTimeMillis(),
+    val odometerKm: Double? = null,
+    val meterEnergyKwh: Double? = null,
+    val totalCost: Double? = null,
+    val vehicleEnergyKwh: Double? = null,
+    val location: String? = null,
+    val remark: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val locationAccuracyMeters: Double? = null,
+)
+
+/** Final billing facts supplied later for a `PENDING_DETAILS` session. */
+data class BackfillChargingSessionRequest(
+    val sessionId: String,
+    val meterEnergyKwh: Double,
+    val totalCost: Double,
+    val vehicleEnergyKwh: Double? = null,
+)
+
 private data class ChargingVehicleStateFact<T>(
     val value: T,
     val timestamp: Long,
@@ -59,9 +87,9 @@ private fun <T> latestChargingFact(vararg facts: ChargingVehicleStateFact<T>?): 
 /**
  * Transaction boundary for the optional charging lifecycle.
  *
- * A session is not a completed charging record. It persists known start facts so process death does
- * not erase a user-started charge. Completion atomically inserts exactly one historical record and
- * marks the session completed; retries return the already-created record id.
+ * `ACTIVE` means physical charging is still in progress. `PENDING_DETAILS` means physical charging
+ * has ended and end facts are durable, but billing facts are not complete enough for a historical
+ * charging record. `COMPLETED` owns exactly one historical record id.
  */
 class ChargingSessionRepository(private val database: AppDatabase) {
     private val vehicleDao = database.vehicleDao()
@@ -73,8 +101,14 @@ class ChargingSessionRepository(private val database: AppDatabase) {
     fun observeActiveForVehicle(vehicleId: Long): Flow<ChargingSessionEntity?> =
         chargingSessionDao.observeActiveForVehicle(vehicleId)
 
+    fun observePendingForVehicle(vehicleId: Long): Flow<List<ChargingSessionEntity>> =
+        chargingSessionDao.observePendingForVehicle(vehicleId)
+
     suspend fun getActiveForVehicle(vehicleId: Long): ChargingSessionEntity? =
         chargingSessionDao.getActiveForVehicle(vehicleId)
+
+    suspend fun getPendingForVehicle(vehicleId: Long): List<ChargingSessionEntity> =
+        chargingSessionDao.getPendingForVehicle(vehicleId)
 
     suspend fun start(request: StartChargingSessionRequest): String {
         validateStart(request)
@@ -117,6 +151,11 @@ class ChargingSessionRepository(private val database: AppDatabase) {
                 session.copy(
                     status = ChargingSessionStatus.ACTIVE,
                     endedAtEpochMillis = null,
+                    endSoc = null,
+                    odometerKm = null,
+                    pendingMeterEnergyKwh = null,
+                    pendingTotalCost = null,
+                    pendingVehicleEnergyKwh = null,
                     completedRecordId = null,
                     chargerType = session.chargerType.cleanText(),
                     location = session.location.cleanText(),
@@ -133,6 +172,7 @@ class ChargingSessionRepository(private val database: AppDatabase) {
             when (session.status) {
                 ChargingSessionStatus.CANCELLED -> return@withTransaction
                 ChargingSessionStatus.COMPLETED -> error("已完成的充电不能取消")
+                ChargingSessionStatus.PENDING_DETAILS -> error("充电已结束并待补录；请补录或删除此次充电")
                 ChargingSessionStatus.ACTIVE -> Unit
                 else -> error("未知充电会话状态")
             }
@@ -148,6 +188,63 @@ class ChargingSessionRepository(private val database: AppDatabase) {
         }
     }
 
+    /**
+     * End physical charging without inventing missing meter facts.
+     *
+     * The pending session immediately becomes a vehicle-state fact, but it does not create a
+     * `ChargingRecordEntity` and therefore cannot enter charging cost / energy statistics.
+     */
+    suspend fun deferCompletion(request: DeferChargingCompletionRequest) {
+        database.withTransaction {
+            val session = chargingSessionDao.get(request.sessionId) ?: error("充电会话不存在")
+            when (session.status) {
+                ChargingSessionStatus.PENDING_DETAILS -> return@withTransaction
+                ChargingSessionStatus.COMPLETED -> error("本次充电已经完成")
+                ChargingSessionStatus.CANCELLED -> error("已取消的充电不能结束")
+                ChargingSessionStatus.ACTIVE -> Unit
+                else -> error("未知充电会话状态")
+            }
+            validateDeferredCompletion(session, request)
+            chargingSessionDao.update(
+                session.copy(
+                    startSoc = request.startSoc,
+                    status = ChargingSessionStatus.PENDING_DETAILS,
+                    endedAtEpochMillis = request.endedAtEpochMillis,
+                    endSoc = request.endSoc,
+                    odometerKm = request.odometerKm,
+                    pendingMeterEnergyKwh = request.meterEnergyKwh,
+                    pendingTotalCost = request.totalCost,
+                    pendingVehicleEnergyKwh = request.vehicleEnergyKwh,
+                    location = request.location.cleanText(),
+                    remark = request.remark.cleanText(),
+                    latitude = request.latitude,
+                    longitude = request.longitude,
+                    locationAccuracyMeters = request.locationAccuracyMeters,
+                    completedRecordId = null,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                )
+            )
+            rebuildVehicleStateFromEvents(session.vehicleId)
+        }
+    }
+
+    /** Delete an ended-but-unbilled session without creating a historical record. */
+    suspend fun discardPending(sessionId: String) {
+        database.withTransaction {
+            val session = chargingSessionDao.get(sessionId) ?: error("充电会话不存在")
+            if (session.status == ChargingSessionStatus.CANCELLED) return@withTransaction
+            require(session.status == ChargingSessionStatus.PENDING_DETAILS) { "只有待补录充电可以删除" }
+            chargingSessionDao.update(
+                session.copy(
+                    status = ChargingSessionStatus.CANCELLED,
+                    completedRecordId = null,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                )
+            )
+            rebuildVehicleStateFromEvents(session.vehicleId)
+        }
+    }
+
     suspend fun complete(request: CompleteChargingSessionRequest): Long {
         return database.withTransaction {
             val session = chargingSessionDao.get(request.sessionId) ?: error("充电会话不存在")
@@ -155,42 +252,125 @@ class ChargingSessionRepository(private val database: AppDatabase) {
                 return@withTransaction session.completedRecordId
                     ?: error("已完成充电缺少关联记录")
             }
-            require(session.status == ChargingSessionStatus.ACTIVE) { "只有进行中的充电可以完成" }
+            require(session.status == ChargingSessionStatus.ACTIVE) { "只有进行中的充电可以直接完成" }
             validateCompletion(session, request)
 
-            val now = System.currentTimeMillis()
-            val recordId = chargingRecordDao.insert(
-                ChargingRecordEntity(
-                    vehicleId = session.vehicleId,
-                    chargeTimeEpochMillis = session.startedAtEpochMillis,
-                    endedAtEpochMillis = request.endedAtEpochMillis,
-                    energyKwh = request.meterEnergyKwh,
-                    vehicleEnergyKwh = request.vehicleEnergyKwh,
-                    cost = request.totalCost,
-                    startSoc = request.startSoc,
-                    endSoc = request.endSoc,
-                    chargerType = request.chargerType.cleanText(),
-                    location = request.location.cleanText(),
-                    remark = request.remark.cleanText(),
-                    odometerKm = request.odometerKm,
-                    latitude = request.latitude,
-                    longitude = request.longitude,
-                    locationAccuracyMeters = request.locationAccuracyMeters,
-                    updatedAtEpochMillis = now,
-                )
+            val recordId = insertCompletedRecord(
+                session = session,
+                startSoc = request.startSoc,
+                endSoc = request.endSoc,
+                endedAtEpochMillis = request.endedAtEpochMillis,
+                meterEnergyKwh = request.meterEnergyKwh,
+                vehicleEnergyKwh = request.vehicleEnergyKwh,
+                totalCost = request.totalCost,
+                odometerKm = request.odometerKm,
+                chargerType = request.chargerType,
+                location = request.location,
+                remark = request.remark,
+                latitude = request.latitude,
+                longitude = request.longitude,
+                locationAccuracyMeters = request.locationAccuracyMeters,
             )
-
-            chargingSessionDao.update(
-                session.copy(
-                    status = ChargingSessionStatus.COMPLETED,
-                    endedAtEpochMillis = request.endedAtEpochMillis,
-                    completedRecordId = recordId,
-                    updatedAtEpochMillis = now,
-                )
-            )
-            rebuildVehicleStateFromEvents(session.vehicleId)
             recordId
         }
+    }
+
+    /** Finalize one pending session exactly once after delayed meter / billing data arrives. */
+    suspend fun backfill(request: BackfillChargingSessionRequest): Long {
+        return database.withTransaction {
+            val session = chargingSessionDao.get(request.sessionId) ?: error("充电会话不存在")
+            if (session.status == ChargingSessionStatus.COMPLETED) {
+                return@withTransaction session.completedRecordId
+                    ?: error("已完成充电缺少关联记录")
+            }
+            require(session.status == ChargingSessionStatus.PENDING_DETAILS) { "只有待补录充电可以补充电表数据" }
+            val startSoc = session.startSoc ?: error("待补录充电缺少开始 SOC")
+            val endSoc = session.endSoc ?: error("待补录充电缺少结束 SOC")
+            val endedAt = session.endedAtEpochMillis ?: error("待补录充电缺少结束时间")
+            val vehicleEnergy = request.vehicleEnergyKwh ?: session.pendingVehicleEnergyKwh
+            validateBillingFacts(request.meterEnergyKwh, request.totalCost, vehicleEnergy)
+            ChargingRecordRules.validate(startSoc, endSoc, request.meterEnergyKwh, request.totalCost, session.odometerKm)
+
+            insertCompletedRecord(
+                session = session,
+                startSoc = startSoc,
+                endSoc = endSoc,
+                endedAtEpochMillis = endedAt,
+                meterEnergyKwh = request.meterEnergyKwh,
+                vehicleEnergyKwh = vehicleEnergy,
+                totalCost = request.totalCost,
+                odometerKm = session.odometerKm,
+                chargerType = session.chargerType,
+                location = session.location,
+                remark = session.remark,
+                latitude = session.latitude,
+                longitude = session.longitude,
+                locationAccuracyMeters = session.locationAccuracyMeters,
+            )
+        }
+    }
+
+    private suspend fun insertCompletedRecord(
+        session: ChargingSessionEntity,
+        startSoc: Int,
+        endSoc: Int,
+        endedAtEpochMillis: Long,
+        meterEnergyKwh: Double,
+        vehicleEnergyKwh: Double?,
+        totalCost: Double,
+        odometerKm: Double?,
+        chargerType: String?,
+        location: String?,
+        remark: String?,
+        latitude: Double?,
+        longitude: Double?,
+        locationAccuracyMeters: Double?,
+    ): Long {
+        validateBillingFacts(meterEnergyKwh, totalCost, vehicleEnergyKwh)
+        val now = System.currentTimeMillis()
+        val recordId = chargingRecordDao.insert(
+            ChargingRecordEntity(
+                vehicleId = session.vehicleId,
+                chargeTimeEpochMillis = session.startedAtEpochMillis,
+                endedAtEpochMillis = endedAtEpochMillis,
+                energyKwh = meterEnergyKwh,
+                vehicleEnergyKwh = vehicleEnergyKwh,
+                cost = totalCost,
+                startSoc = startSoc,
+                endSoc = endSoc,
+                chargerType = chargerType.cleanText(),
+                location = location.cleanText(),
+                remark = remark.cleanText(),
+                odometerKm = odometerKm,
+                latitude = latitude,
+                longitude = longitude,
+                locationAccuracyMeters = locationAccuracyMeters,
+                updatedAtEpochMillis = now,
+            )
+        )
+
+        chargingSessionDao.update(
+            session.copy(
+                startSoc = startSoc,
+                status = ChargingSessionStatus.COMPLETED,
+                endedAtEpochMillis = endedAtEpochMillis,
+                endSoc = endSoc,
+                odometerKm = odometerKm,
+                pendingMeterEnergyKwh = meterEnergyKwh,
+                pendingTotalCost = totalCost,
+                pendingVehicleEnergyKwh = vehicleEnergyKwh,
+                completedRecordId = recordId,
+                chargerType = chargerType.cleanText(),
+                location = location.cleanText(),
+                remark = remark.cleanText(),
+                latitude = latitude,
+                longitude = longitude,
+                locationAccuracyMeters = locationAccuracyMeters,
+                updatedAtEpochMillis = now,
+            )
+        )
+        rebuildVehicleStateFromEvents(session.vehicleId)
+        return recordId
     }
 
     private fun validateStart(request: StartChargingSessionRequest) {
@@ -201,8 +381,7 @@ class ChargingSessionRepository(private val database: AppDatabase) {
             require(request.targetSoc >= request.startSoc) { "目标 SOC 不能低于开始 SOC" }
         }
         require(request.unitPricePerKwh == null || request.unitPricePerKwh >= 0.0) { "电价不能小于 0" }
-        require((request.latitude == null) == (request.longitude == null)) { "定位坐标不完整" }
-        require(request.locationAccuracyMeters == null || request.locationAccuracyMeters >= 0.0) { "定位精度不能小于 0" }
+        validateLocationFacts(request.latitude, request.longitude, request.locationAccuracyMeters)
     }
 
     private fun validateSessionFacts(session: ChargingSessionEntity) {
@@ -214,8 +393,29 @@ class ChargingSessionRepository(private val database: AppDatabase) {
             require(session.targetSoc >= session.startSoc) { "目标 SOC 不能低于开始 SOC" }
         }
         require(session.unitPricePerKwh == null || session.unitPricePerKwh >= 0.0) { "电价不能小于 0" }
-        require((session.latitude == null) == (session.longitude == null)) { "定位坐标不完整" }
-        require(session.locationAccuracyMeters == null || session.locationAccuracyMeters >= 0.0) { "定位精度不能小于 0" }
+        validateLocationFacts(session.latitude, session.longitude, session.locationAccuracyMeters)
+    }
+
+    private fun validateDeferredCompletion(
+        session: ChargingSessionEntity,
+        request: DeferChargingCompletionRequest,
+    ) {
+        require(request.startSoc in 0..100) { "开始 SOC 必须在 0 到 100 之间" }
+        require(request.endSoc in 0..100) { "结束 SOC 必须在 0 到 100 之间" }
+        require(request.endSoc >= request.startSoc) { "结束 SOC 不能低于开始 SOC" }
+        require(request.endedAtEpochMillis > session.startedAtEpochMillis) { "结束时间必须晚于开始时间" }
+        require(request.odometerKm == null || request.odometerKm >= 0.0) { "里程不能小于 0" }
+        require(request.meterEnergyKwh == null || request.meterEnergyKwh > 0.0) { "电表电量必须大于 0" }
+        require(request.totalCost == null || request.totalCost >= 0.0) { "费用不能小于 0" }
+        if (request.vehicleEnergyKwh != null) {
+            require(request.vehicleEnergyKwh >= 0.0) { "车辆侧充电量不能小于 0" }
+            if (request.meterEnergyKwh != null) {
+                require(request.vehicleEnergyKwh <= request.meterEnergyKwh + 1e-6) {
+                    "车辆侧充电量不能高于桩端 / 电表电量"
+                }
+            }
+        }
+        validateLocationFacts(request.latitude, request.longitude, request.locationAccuracyMeters)
     }
 
     private fun validateCompletion(session: ChargingSessionEntity, request: CompleteChargingSessionRequest) {
@@ -227,12 +427,30 @@ class ChargingSessionRepository(private val database: AppDatabase) {
             request.odometerKm,
         )
         require(request.endedAtEpochMillis > session.startedAtEpochMillis) { "结束时间必须晚于开始时间" }
-        require(request.vehicleEnergyKwh == null || request.vehicleEnergyKwh >= 0.0) { "车辆侧充电量不能小于 0" }
-        require(request.vehicleEnergyKwh == null || request.vehicleEnergyKwh <= request.meterEnergyKwh + 1e-6) {
+        validateBillingFacts(request.meterEnergyKwh, request.totalCost, request.vehicleEnergyKwh)
+        validateLocationFacts(request.latitude, request.longitude, request.locationAccuracyMeters)
+    }
+
+    private fun validateBillingFacts(
+        meterEnergyKwh: Double,
+        totalCost: Double,
+        vehicleEnergyKwh: Double?,
+    ) {
+        require(meterEnergyKwh > 0.0) { "充电量必须大于 0" }
+        require(totalCost >= 0.0) { "费用不能小于 0" }
+        require(vehicleEnergyKwh == null || vehicleEnergyKwh >= 0.0) { "车辆侧充电量不能小于 0" }
+        require(vehicleEnergyKwh == null || vehicleEnergyKwh <= meterEnergyKwh + 1e-6) {
             "车辆侧充电量不能高于桩端 / 电表电量"
         }
-        require((request.latitude == null) == (request.longitude == null)) { "定位坐标不完整" }
-        require(request.locationAccuracyMeters == null || request.locationAccuracyMeters >= 0.0) { "定位精度不能小于 0" }
+    }
+
+    private fun validateLocationFacts(
+        latitude: Double?,
+        longitude: Double?,
+        accuracyMeters: Double?,
+    ) {
+        require((latitude == null) == (longitude == null)) { "定位坐标不完整" }
+        require(accuracyMeters == null || accuracyMeters >= 0.0) { "定位精度不能小于 0" }
     }
 
     private suspend fun rebuildVehicleStateFromEvents(vehicleId: Long) {
@@ -240,10 +458,18 @@ class ChargingSessionRepository(private val database: AppDatabase) {
         val manualState = existing?.takeIf { it.updateSource == VehicleStateUpdateSource.MANUAL_UPDATE.name }
 
         val latestCharge = chargingRecordDao.getLatestForVehicle(vehicleId)
+        val latestPendingSoc = chargingSessionDao.getLatestPendingWithEndSocForVehicle(vehicleId)
         val latestTripSoc = tripDao.getLatestCompletedWithSocForVehicle(vehicleId)
         val socFact = latestChargingFact(
             latestCharge?.let {
                 ChargingVehicleStateFact(it.endSoc, it.endedAtEpochMillis ?: it.chargeTimeEpochMillis, VehicleStateUpdateSource.CHARGE_RECORD)
+            },
+            latestPendingSoc?.endSoc?.let {
+                ChargingVehicleStateFact(
+                    it,
+                    latestPendingSoc.endedAtEpochMillis ?: latestPendingSoc.updatedAtEpochMillis,
+                    VehicleStateUpdateSource.CHARGE_PENDING,
+                )
             },
             latestTripSoc?.let {
                 ChargingVehicleStateFact(it.endSoc!!, it.endedAtEpochMillis!!, VehicleStateUpdateSource.TRIP_END)
@@ -254,6 +480,7 @@ class ChargingSessionRepository(private val database: AppDatabase) {
         )
 
         val latestChargeMileage = chargingRecordDao.getLatestWithOdometerForVehicle(vehicleId)
+        val latestPendingMileage = chargingSessionDao.getLatestPendingWithOdometerForVehicle(vehicleId)
         val latestTripMileage = tripDao.getLatestCompletedWithMileageForVehicle(vehicleId)
         val mileageFact = latestChargingFact(
             latestChargeMileage?.odometerKm?.let {
@@ -261,6 +488,13 @@ class ChargingSessionRepository(private val database: AppDatabase) {
                     it,
                     latestChargeMileage.endedAtEpochMillis ?: latestChargeMileage.chargeTimeEpochMillis,
                     VehicleStateUpdateSource.CHARGE_RECORD,
+                )
+            },
+            latestPendingMileage?.odometerKm?.let {
+                ChargingVehicleStateFact(
+                    it,
+                    latestPendingMileage.endedAtEpochMillis ?: latestPendingMileage.updatedAtEpochMillis,
+                    VehicleStateUpdateSource.CHARGE_PENDING,
                 )
             },
             latestTripMileage?.endMileageKm?.let {

--- a/android/app/src/test/java/com/evchargebook/data/backup/ChargingBackupV9Test.kt
+++ b/android/app/src/test/java/com/evchargebook/data/backup/ChargingBackupV9Test.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 
 class ChargingBackupV9Test {
     @Test
-    fun `v9 round trip preserves active charging session and completion facts`() {
+    fun `current round trip preserves active charging session and completion facts`() {
         val vehicle = VehicleEntity(
             id = 1L,
             brand = "Test",
@@ -65,11 +65,60 @@ class ChargingBackupV9Test {
             )
         )
 
-        assertEquals(9, decoded.schemaVersion)
+        assertEquals(10, decoded.schemaVersion)
         assertEquals(1, decoded.chargingSessions.size)
         assertEquals(active, decoded.chargingSessions.single())
         assertEquals(4_600_000L, decoded.chargingRecords.single().endedAtEpochMillis)
         assertEquals(36.5, decoded.chargingRecords.single().vehicleEnergyKwh!!, 0.000001)
+    }
+
+    @Test
+    fun `v10 round trip preserves pending completion facts without fake billing values`() {
+        val vehicle = VehicleEntity(
+            id = 1L,
+            brand = "Test",
+            model = "EV",
+            batteryCapacityKwh = 80.0,
+            rangeKm = 600,
+            syncId = "vehicle-1",
+            createdAtEpochMillis = 100L,
+            updatedAtEpochMillis = 100L,
+        )
+        val pending = ChargingSessionEntity(
+            id = "session-pending",
+            vehicleId = 1L,
+            startedAtEpochMillis = 10_000L,
+            startSoc = 25,
+            targetSoc = 80,
+            chargerType = "家充",
+            unitPricePerKwh = 0.61,
+            location = "家",
+            status = ChargingSessionStatus.PENDING_DETAILS,
+            endedAtEpochMillis = 20_000L,
+            endSoc = 82,
+            odometerKm = 12_345.6,
+            pendingMeterEnergyKwh = null,
+            pendingTotalCost = null,
+            pendingVehicleEnergyKwh = null,
+            updatedAtEpochMillis = 20_000L,
+        )
+
+        val decoded = BackupCodec.decode(
+            BackupCodec.encode(
+                BackupPayload(
+                    schemaVersion = BackupCodec.CURRENT_SCHEMA_VERSION,
+                    exportedAt = 21_000L,
+                    appVersion = "test",
+                    vehicles = listOf(vehicle),
+                    chargingRecords = emptyList(),
+                    chargingSessions = listOf(pending),
+                )
+            )
+        )
+
+        assertEquals(pending, decoded.chargingSessions.single())
+        assertNull(decoded.chargingSessions.single().pendingMeterEnergyKwh)
+        assertNull(decoded.chargingSessions.single().pendingTotalCost)
     }
 
     @Test

--- a/android/app/src/test/java/com/evchargebook/data/database/ChargingPendingMigration17To18ContractTest.kt
+++ b/android/app/src/test/java/com/evchargebook/data/database/ChargingPendingMigration17To18ContractTest.kt
@@ -1,0 +1,136 @@
+package com.evchargebook.data.database
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.sql.Connection
+import java.sql.DriverManager
+
+class ChargingPendingMigration17To18ContractTest {
+    @Test
+    fun `v17 to v18 preserves existing session facts and adds nullable pending fields`() {
+        Class.forName("org.sqlite.JDBC")
+        DriverManager.getConnection("jdbc:sqlite::memory:").use { db ->
+            createMinimalV17ChargingSessions(db)
+            db.createStatement().use { statement ->
+                statement.execute(
+                    """
+                    INSERT INTO charging_sessions (
+                        id, vehicleId, startedAtEpochMillis, startSoc, targetSoc, chargerType,
+                        unitPricePerKwh, location, status, endedAtEpochMillis, completedRecordId,
+                        updatedAtEpochMillis
+                    ) VALUES (
+                        'legacy-active', 1, 1700000000000, 20, 80, '家充',
+                        0.61, 'Home', 'ACTIVE', NULL, NULL, 1700000000000
+                    )
+                    """.trimIndent()
+                )
+                ChargingPendingMigration17To18.statements.forEach { sql -> statement.execute(sql) }
+            }
+
+            val columns = tableColumns(db, "charging_sessions")
+            listOf(
+                "endSoc",
+                "odometerKm",
+                "pendingMeterEnergyKwh",
+                "pendingTotalCost",
+                "pendingVehicleEnergyKwh",
+            ).forEach { name ->
+                assertTrue(name in columns)
+                assertEquals(false, columns.getValue(name).notNull)
+            }
+
+            db.createStatement().use { statement ->
+                statement.executeQuery(
+                    """
+                    SELECT status, startSoc, targetSoc, chargerType, unitPricePerKwh, location,
+                           endSoc, odometerKm, pendingMeterEnergyKwh, pendingTotalCost,
+                           pendingVehicleEnergyKwh
+                    FROM charging_sessions WHERE id = 'legacy-active'
+                    """.trimIndent()
+                ).use { row ->
+                    assertTrue(row.next())
+                    assertEquals("ACTIVE", row.getString("status"))
+                    assertEquals(20, row.getInt("startSoc"))
+                    assertEquals(80, row.getInt("targetSoc"))
+                    assertEquals("家充", row.getString("chargerType"))
+                    assertEquals(0.61, row.getDouble("unitPricePerKwh"), 0.000001)
+                    assertEquals("Home", row.getString("location"))
+                    assertNull(row.getObject("endSoc"))
+                    assertNull(row.getObject("odometerKm"))
+                    assertNull(row.getObject("pendingMeterEnergyKwh"))
+                    assertNull(row.getObject("pendingTotalCost"))
+                    assertNull(row.getObject("pendingVehicleEnergyKwh"))
+                }
+
+                statement.execute(
+                    """
+                    UPDATE charging_sessions
+                    SET status = 'PENDING_DETAILS', endedAtEpochMillis = 1700003600000,
+                        endSoc = 80, odometerKm = 12345.6
+                    WHERE id = 'legacy-active'
+                    """.trimIndent()
+                )
+                statement.executeQuery(
+                    "SELECT status, endSoc, odometerKm FROM charging_sessions WHERE id = 'legacy-active'"
+                ).use { row ->
+                    assertTrue(row.next())
+                    assertEquals("PENDING_DETAILS", row.getString("status"))
+                    assertEquals(80, row.getInt("endSoc"))
+                    assertEquals(12345.6, row.getDouble("odometerKm"), 0.000001)
+                }
+            }
+        }
+    }
+
+    private fun createMinimalV17ChargingSessions(db: Connection) {
+        db.createStatement().use { statement ->
+            statement.execute(
+                """
+                CREATE TABLE charging_sessions (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    vehicleId INTEGER NOT NULL,
+                    startedAtEpochMillis INTEGER NOT NULL,
+                    startSoc INTEGER,
+                    targetSoc INTEGER,
+                    chargerType TEXT,
+                    unitPricePerKwh REAL,
+                    location TEXT,
+                    remark TEXT,
+                    latitude REAL,
+                    longitude REAL,
+                    locationAccuracyMeters REAL,
+                    status TEXT NOT NULL,
+                    endedAtEpochMillis INTEGER,
+                    completedRecordId INTEGER,
+                    updatedAtEpochMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            statement.execute("CREATE INDEX index_charging_sessions_vehicleId ON charging_sessions(vehicleId)")
+            statement.execute("CREATE INDEX index_charging_sessions_status ON charging_sessions(status)")
+            statement.execute("CREATE INDEX index_charging_sessions_startedAtEpochMillis ON charging_sessions(startedAtEpochMillis)")
+        }
+    }
+
+    private fun tableColumns(db: Connection, table: String): Map<String, ColumnInfo> {
+        val columns = linkedMapOf<String, ColumnInfo>()
+        db.createStatement().use { statement ->
+            statement.executeQuery("PRAGMA table_info($table)").use { rows ->
+                while (rows.next()) {
+                    columns[rows.getString("name")] = ColumnInfo(
+                        type = rows.getString("type"),
+                        notNull = rows.getInt("notnull") == 1,
+                    )
+                }
+            }
+        }
+        return columns
+    }
+
+    private data class ColumnInfo(
+        val type: String,
+        val notNull: Boolean,
+    )
+}


### PR DESCRIPTION
Replacement for closed Draft #293; **same branch, same head, same 9-file diff**. No code was duplicated or rewritten.

Parent: #289 / #253

## Lifecycle contract
`ACTIVE -> PENDING_DETAILS -> COMPLETED`

- pending stores durable end facts while meter/cost may remain unknown (`null`, never fake zero)
- multiple pending sessions per vehicle are allowed; only one ACTIVE
- pending end SOC/odometer can update VehicleState immediately via `CHARGE_PENDING`
- pending sessions do not create `ChargingRecordEntity`, so official cost/energy/count stats remain clean
- later meter backfill finalizes exactly one historical record; retries are idempotent
- pending can be discarded without creating history

## Persistence
- Room v17 -> v18 adds five nullable charging-session columns
- Backup schema v10 preserves pending facts and still reads v2-v9
- production migration SQL is executed by SQLite contract test

## Exact evidence
Base: `main@0ec69086ac75fcda9ba35a454427cc98ea6dbd64`
Head: `e1ce4dfd3b060b2b141d9bc5c5d610f5bf8df601`
- behind 0
- exactly 9 intended data/test files
- Android Build #720 Green
- Room migration workflow #15 Green
- no review threads/comments

Next UI slice will expose `结束并待补录`, pending cards, meter-backfill editor, and restore/archive guards.

Related: #289 #253 #293 #285.