### PR TITLE
feat(charging): add pending meter backfill UI

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingRepository.kt
@@ -78,6 +78,9 @@ class ChargingRepository(private val database: AppDatabase, private val context:
     val activeChargingSession: Flow<ChargingSessionEntity?> = vehicle.flatMapLatest { selected ->
         selected?.let { chargingSessionDao.observeActiveForVehicle(it.id) } ?: flowOf(null)
     }
+    val pendingChargingSessions: Flow<List<ChargingSessionEntity>> = vehicle.flatMapLatest { selected ->
+        selected?.let { chargingSessionDao.observePendingForVehicle(it.id) } ?: flowOf(emptyList())
+    }
     val trips: Flow<List<TripSessionEntity>> = vehicle.flatMapLatest { selected ->
         selected?.let { tripDao.observeForVehicle(it.id) } ?: flowOf(emptyList())
     }
@@ -89,8 +92,6 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         seedVehicleCatalog()
         val activeVehicles = vehicles.first()
         if (activeVehicles.isEmpty()) {
-            // An empty garage is a valid first-run state. The app must never decide which
-            // managed model the user owns; the user selects one from the cached catalog.
             context.vehicleSelectionDataStore.edit { it.remove(selectedVehicleIdKey) }
             return
         }
@@ -126,7 +127,9 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         val payload = BackupCodec.decode(content)
         database.withTransaction {
             require(tripDao.getActive() == null) { "请先结束当前行程，再恢复备份" }
-            require(chargingSessionDao.getAnyActive() == null) { "请先结束或取消当前充电，再恢复备份" }
+            require(chargingSessionDao.getAnyUnfinished() == null) {
+                "请先处理进行中或待补录的充电，再恢复备份"
+            }
             chargingSessionDao.deleteAll()
             tripDao.deleteAllSessions()
             chargingRecordDao.deleteAll()
@@ -159,6 +162,15 @@ class ChargingRepository(private val database: AppDatabase, private val context:
 
     suspend fun completeChargingSession(request: CompleteChargingSessionRequest): Long =
         chargingSessionRepository.complete(request)
+
+    suspend fun deferChargingCompletion(request: DeferChargingCompletionRequest) =
+        chargingSessionRepository.deferCompletion(request)
+
+    suspend fun backfillChargingSession(request: BackfillChargingSessionRequest): Long =
+        chargingSessionRepository.backfill(request)
+
+    suspend fun discardPendingChargingSession(sessionId: String) =
+        chargingSessionRepository.discardPending(sessionId)
 
     suspend fun startTrip(
         vehicleId: Long,
@@ -361,6 +373,9 @@ class ChargingRepository(private val database: AppDatabase, private val context:
             val activeTrip = tripDao.getActive()
             require(activeTrip?.vehicleId != vehicleId) { "请先结束这辆车的当前行程" }
             require(chargingSessionDao.getActiveForVehicle(vehicleId) == null) { "请先结束或取消这辆车的当前充电" }
+            require(chargingSessionDao.getPendingForVehicle(vehicleId).isEmpty()) {
+                "请先补录或删除这辆车的待补录充电"
+            }
             val activeVehicles = vehicleDao.observeActive().first()
             require(activeVehicles.size > 1) { "请至少保留一辆车辆" }
             val vehicle = activeVehicles.firstOrNull { it.id == vehicleId } ?: error("车辆不可用")
@@ -388,6 +403,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         val manualState = existing?.takeIf { it.updateSource == VehicleStateUpdateSource.MANUAL_UPDATE.name }
 
         val latestCharge = chargingRecordDao.getLatestForVehicle(vehicleId)
+        val latestPendingSoc = chargingSessionDao.getLatestPendingWithEndSocForVehicle(vehicleId)
         val latestTripSoc = tripDao.getLatestCompletedWithSocForVehicle(vehicleId)
         val socFact = latestFact(
             latestCharge?.let {
@@ -395,6 +411,13 @@ class ChargingRepository(private val database: AppDatabase, private val context:
                     it.endSoc,
                     it.endedAtEpochMillis ?: it.chargeTimeEpochMillis,
                     VehicleStateUpdateSource.CHARGE_RECORD,
+                )
+            },
+            latestPendingSoc?.endSoc?.let {
+                VehicleStateFact(
+                    it,
+                    latestPendingSoc.endedAtEpochMillis ?: latestPendingSoc.updatedAtEpochMillis,
+                    VehicleStateUpdateSource.CHARGE_PENDING,
                 )
             },
             latestTripSoc?.let {
@@ -406,6 +429,7 @@ class ChargingRepository(private val database: AppDatabase, private val context:
         )
 
         val latestChargeMileage = chargingRecordDao.getLatestWithOdometerForVehicle(vehicleId)
+        val latestPendingMileage = chargingSessionDao.getLatestPendingWithOdometerForVehicle(vehicleId)
         val latestTripMileage = tripDao.getLatestCompletedWithMileageForVehicle(vehicleId)
         val mileageFact = latestFact(
             latestChargeMileage?.odometerKm?.let {
@@ -413,6 +437,13 @@ class ChargingRepository(private val database: AppDatabase, private val context:
                     it,
                     latestChargeMileage.endedAtEpochMillis ?: latestChargeMileage.chargeTimeEpochMillis,
                     VehicleStateUpdateSource.CHARGE_RECORD,
+                )
+            },
+            latestPendingMileage?.odometerKm?.let {
+                VehicleStateFact(
+                    it,
+                    latestPendingMileage.endedAtEpochMillis ?: latestPendingMileage.updatedAtEpochMillis,
+                    VehicleStateUpdateSource.CHARGE_PENDING,
                 )
             },
             latestTripMileage?.endMileageKm?.let {

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
@@ -15,7 +15,7 @@ data class ChargeBillingEditorState(
     val issues: Set<ChargeCalculationIssue> = emptySet()
 ) {
     val totalCost: Double? get() = calculationInput.totalCost
-    val unitPrice: Double? get() = calculationInput.unitPrice
+    val unitPrice: Double? = calculationInput.unitPrice
     val meterEnergyKwh: Double? get() = calculationInput.meterEnergyKwh
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargeBillingEditorState.kt
@@ -15,7 +15,7 @@ data class ChargeBillingEditorState(
     val issues: Set<ChargeCalculationIssue> = emptySet()
 ) {
     val totalCost: Double? get() = calculationInput.totalCost
-    val unitPrice: Double? = calculationInput.unitPrice
+    val unitPrice: Double? get() = calculationInput.unitPrice
     val meterEnergyKwh: Double? get() = calculationInput.meterEnergyKwh
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargingMeterBackfillScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargingMeterBackfillScreen.kt
@@ -78,10 +78,11 @@ fun ChargingMeterBackfillScreen(
 
     val meterEnergy = billing.meterEnergyKwh
     val totalCost = billing.totalCost
+    val unitPrice = billing.unitPrice
     val meterIsConfirmed = ChargeBillingField.METER_ENERGY in billing.calculationInput.authoritativeBillingFields
     val invalidMeterText = billing.meterEnergyText.isNotBlank() && (meterEnergy == null || meterEnergy <= 0.0)
     val invalidCostText = billing.totalCostText.isNotBlank() && (totalCost == null || totalCost < 0.0)
-    val invalidPriceText = billing.unitPriceText.isNotBlank() && (billing.unitPrice == null || billing.unitPrice < 0.0)
+    val invalidPriceText = billing.unitPriceText.isNotBlank() && (unitPrice == null || unitPrice < 0.0)
     val blockingBillingIssue = billing.issues.any {
         it == ChargeCalculationIssue.NEGATIVE_VALUE || it == ChargeCalculationIssue.BILLING_CONFLICT
     }

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargingMeterBackfillScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargingMeterBackfillScreen.kt
@@ -1,0 +1,255 @@
+package com.evchargebook.ui.records
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.ChargingSessionEntity
+import com.evchargebook.data.repository.BackfillChargingSessionRequest
+import com.evchargebook.domain.charge.ChargeBillingField
+import com.evchargebook.domain.charge.ChargeCalculationIssue
+import com.evchargebook.ui.theme.spacing
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChargingMeterBackfillScreen(
+    session: ChargingSessionEntity,
+    onBack: () -> Unit,
+    onBackfill: suspend (BackfillChargingSessionRequest) -> Long,
+    onCompleted: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val initialPrice = session.unitPricePerKwh?.toBackfillNumber().orEmpty()
+    val initialEnergy = session.pendingMeterEnergyKwh?.toBackfillNumber().orEmpty()
+    val initialCost = session.pendingTotalCost?.toBackfillNumber().orEmpty()
+    var billing by remember(session.id, session.updatedAtEpochMillis) {
+        mutableStateOf(
+            ChargeBillingEditor.create(
+                totalCostText = initialCost,
+                unitPriceText = initialPrice,
+                meterEnergyText = initialEnergy,
+                authoritativeBillingFields = buildSet {
+                    if (session.pendingTotalCost != null) add(ChargeBillingField.TOTAL_COST)
+                    if (session.unitPricePerKwh != null) add(ChargeBillingField.UNIT_PRICE)
+                    if (session.pendingMeterEnergyKwh != null) add(ChargeBillingField.METER_ENERGY)
+                },
+            )
+        )
+    }
+    var submitError by remember(session.id) { mutableStateOf<String?>(null) }
+    var submitting by remember(session.id) { mutableStateOf(false) }
+
+    BackHandler(onBack = onBack)
+
+    val meterEnergy = billing.meterEnergyKwh
+    val totalCost = billing.totalCost
+    val meterIsConfirmed = ChargeBillingField.METER_ENERGY in billing.calculationInput.authoritativeBillingFields
+    val invalidMeterText = billing.meterEnergyText.isNotBlank() && (meterEnergy == null || meterEnergy <= 0.0)
+    val invalidCostText = billing.totalCostText.isNotBlank() && (totalCost == null || totalCost < 0.0)
+    val invalidPriceText = billing.unitPriceText.isNotBlank() && (billing.unitPrice == null || billing.unitPrice < 0.0)
+    val blockingBillingIssue = billing.issues.any {
+        it == ChargeCalculationIssue.NEGATIVE_VALUE || it == ChargeCalculationIssue.BILLING_CONFLICT
+    }
+    val canSubmit = !submitting && meterIsConfirmed &&
+        meterEnergy != null && meterEnergy > 0.0 &&
+        totalCost != null && totalCost >= 0.0 &&
+        !invalidMeterText && !invalidCostText && !invalidPriceText && !blockingBillingIssue
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = { Text("补充电表数据", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold) },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+        ) {
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium,
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+            ) {
+                Column(
+                    modifier = Modifier.padding(MaterialTheme.spacing.sm),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        listOfNotNull(session.chargerType, session.location).filter { it.isNotBlank() }.joinToString(" · ").ifBlank { "待补录充电" },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        "${formatBackfillTime(session.startedAtEpochMillis)} → ${session.endedAtEpochMillis?.let(::formatBackfillTime) ?: "已结束"}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (session.startSoc != null && session.endSoc != null) {
+                        Text(
+                            "SOC ${session.startSoc}% → ${session.endSoc}%",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Text(
+                "家充电表可以第二天再补。只有确认真实电表电量后，这笔充电才会进入费用、电量和次数统计。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            OutlinedTextField(
+                value = billing.meterEnergyText,
+                onValueChange = {
+                    billing = ChargeBillingEditor.edit(billing, ChargeBillingField.METER_ENERGY, it)
+                    submitError = null
+                },
+                label = { Text("电表 / 桩端实际电量") },
+                suffix = { Text("kWh") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                OutlinedTextField(
+                    value = billing.unitPriceText,
+                    onValueChange = {
+                        billing = ChargeBillingEditor.edit(billing, ChargeBillingField.UNIT_PRICE, it)
+                        submitError = null
+                    },
+                    label = { Text("电价") },
+                    suffix = { Text("元/kWh") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedTextField(
+                    value = billing.totalCostText,
+                    onValueChange = {
+                        billing = ChargeBillingEditor.edit(billing, ChargeBillingField.TOTAL_COST, it)
+                        submitError = null
+                    },
+                    label = { Text("总费用") },
+                    suffix = { Text("元") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            when {
+                blockingBillingIssue -> Text(
+                    "费用、单价和电量不一致，请确认输入。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                invalidMeterText || invalidCostText || invalidPriceText -> Text(
+                    "请输入有效数字。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                meterEnergy != null && !meterIsConfirmed -> Text(
+                    "当前电量是联动计算结果。请以电表/充电桩显示值为准，最后确认一次实际电量。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            submitError?.let {
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        it,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(MaterialTheme.spacing.sm),
+                    )
+                }
+            }
+
+            Button(
+                enabled = canSubmit,
+                onClick = {
+                    val request = BackfillChargingSessionRequest(
+                        sessionId = session.id,
+                        meterEnergyKwh = meterEnergy!!,
+                        totalCost = totalCost!!,
+                        vehicleEnergyKwh = session.pendingVehicleEnergyKwh,
+                    )
+                    submitting = true
+                    submitError = null
+                    scope.launch {
+                        runCatching { onBackfill(request) }
+                            .onSuccess { onCompleted() }
+                            .onFailure { submitError = it.message ?: "无法补充电表数据" }
+                        submitting = false
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+            ) {
+                Text(if (submitting) "正在入账…" else "补齐并写入充电账本", fontWeight = FontWeight.SemiBold)
+            }
+
+            Spacer(Modifier.height(MaterialTheme.spacing.sm))
+        }
+    }
+}
+
+private fun formatBackfillTime(value: Long): String =
+    SimpleDateFormat("M月d日 HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(value))
+
+private fun Double.toBackfillNumber(): String {
+    val text = String.format(Locale.US, "%.4f", this)
+    return text.trimEnd('0').trimEnd('.')
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
@@ -116,6 +116,8 @@ fun CompleteChargingScreen(
     val meterEnergy = billing.meterEnergyKwh
     val totalCost = billing.totalCost
     val unitPrice = billing.unitPrice
+    val meterIsConfirmed =
+        ChargeBillingField.METER_ENERGY in billing.calculationInput.authoritativeBillingFields
     val odometerValue = odometer.takeIf { it.isNotBlank() }?.toDoubleOrNull()
 
     val invalidMeterText = billing.meterEnergyText.isNotBlank() && (meterEnergy == null || meterEnergy <= 0.0)
@@ -136,7 +138,10 @@ fun CompleteChargingScreen(
     }
 
     val hasFinalBilling =
-        meterEnergy != null && meterEnergy > 0.0 && totalCost != null && totalCost >= 0.0 && !blockingBillingIssue
+        meterIsConfirmed &&
+        meterEnergy != null && meterEnergy > 0.0 &&
+        totalCost != null && totalCost >= 0.0 &&
+        !blockingBillingIssue
 
     val canEnd = !submitting &&
         startSocValue != null && startSocValue in 0..100 &&
@@ -328,6 +333,11 @@ fun CompleteChargingScreen(
                     "已填写的电表/费用信息需要是有效数字；暂时不知道可以直接留空。",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
+                )
+                meterEnergy != null && !meterIsConfirmed -> Text(
+                    "当前电量是联动计算结果，不会当作实测电表值入账；本次会先保存为待补录。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 !hasFinalBilling -> Text(
                     "电表数据还没出来也可以结束充电；本次会保存为待补录，不进入费用和电量统计。",

--- a/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingSessionEntity
 import com.evchargebook.data.repository.CompleteChargingSessionRequest
+import com.evchargebook.data.repository.DeferChargingCompletionRequest
 import com.evchargebook.domain.charge.ChargeBillingField
 import com.evchargebook.domain.charge.ChargeCalculationIssue
 import com.evchargebook.ui.theme.spacing
@@ -60,6 +61,7 @@ fun CompleteChargingScreen(
     session: ChargingSessionEntity,
     onBack: () -> Unit,
     onComplete: suspend (CompleteChargingSessionRequest) -> Long,
+    onDefer: suspend (DeferChargingCompletionRequest) -> Unit,
     onCompleted: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -69,26 +71,27 @@ fun CompleteChargingScreen(
     val vehicles by database.vehicleDao().observeActive().collectAsState(initial = emptyList())
     val batteryCapacityKwh = vehicles.firstOrNull { it.id == session.vehicleId }?.batteryCapacityKwh
 
-    val initialUnitPrice = session.unitPricePerKwh?.toEditableCompletionNumber().orEmpty()
     val initialBilling = remember(session.id, session.updatedAtEpochMillis) {
         ChargeBillingEditor.create(
-            totalCostText = "",
-            unitPriceText = initialUnitPrice,
-            meterEnergyText = "",
-            authoritativeBillingFields = if (session.unitPricePerKwh != null) {
-                setOf(ChargeBillingField.UNIT_PRICE)
-            } else {
-                emptySet()
+            totalCostText = session.pendingTotalCost?.toEditableCompletionNumber().orEmpty(),
+            unitPriceText = session.unitPricePerKwh?.toEditableCompletionNumber().orEmpty(),
+            meterEnergyText = session.pendingMeterEnergyKwh?.toEditableCompletionNumber().orEmpty(),
+            authoritativeBillingFields = buildSet {
+                if (session.pendingTotalCost != null) add(ChargeBillingField.TOTAL_COST)
+                if (session.unitPricePerKwh != null) add(ChargeBillingField.UNIT_PRICE)
+                if (session.pendingMeterEnergyKwh != null) add(ChargeBillingField.METER_ENERGY)
             },
         )
     }
 
     var startSoc by remember(session.id) { mutableStateOf(session.startSoc?.toString().orEmpty()) }
-    var endSoc by remember(session.id) { mutableStateOf("") }
-    var endSocTouched by remember(session.id) { mutableStateOf(false) }
+    var endSoc by remember(session.id) { mutableStateOf(session.endSoc?.toString().orEmpty()) }
+    var endSocTouched by remember(session.id) { mutableStateOf(session.endSoc != null) }
     var billing by remember(session.id, session.updatedAtEpochMillis) { mutableStateOf(initialBilling) }
-    var odometer by remember(session.id) { mutableStateOf("") }
-    var endedAt by remember(session.id) { mutableLongStateOf(System.currentTimeMillis()) }
+    var odometer by remember(session.id) { mutableStateOf(session.odometerKm?.toEditableCompletionNumber().orEmpty()) }
+    var endedAt by remember(session.id) {
+        mutableLongStateOf(session.endedAtEpochMillis ?: System.currentTimeMillis())
+    }
     var location by remember(session.id) { mutableStateOf(session.location.orEmpty()) }
     var latitude by remember(session.id) { mutableStateOf(session.latitude) }
     var longitude by remember(session.id) { mutableStateOf(session.longitude) }
@@ -113,10 +116,15 @@ fun CompleteChargingScreen(
     val meterEnergy = billing.meterEnergyKwh
     val totalCost = billing.totalCost
     val odometerValue = odometer.takeIf { it.isNotBlank() }?.toDoubleOrNull()
-    val invalidOdometer = odometer.isNotBlank() && odometerValue == null
+
+    val invalidMeterText = billing.meterEnergyText.isNotBlank() && (meterEnergy == null || meterEnergy <= 0.0)
+    val invalidCostText = billing.totalCostText.isNotBlank() && (totalCost == null || totalCost < 0.0)
+    val invalidPriceText = billing.unitPriceText.isNotBlank() && (billing.unitPrice == null || billing.unitPrice < 0.0)
+    val invalidOdometer = odometer.isNotBlank() && (odometerValue == null || odometerValue < 0.0)
     val blockingBillingIssue = billing.issues.any {
         it == ChargeCalculationIssue.NEGATIVE_VALUE || it == ChargeCalculationIssue.BILLING_CONFLICT
     }
+
     val estimatedVehicleEnergy = if (
         batteryCapacityKwh != null && batteryCapacityKwh > 0.0 &&
         startSocValue != null && endSocValue != null && endSocValue >= startSocValue
@@ -125,14 +133,16 @@ fun CompleteChargingScreen(
     } else {
         null
     }
-    val canSubmit = !submitting &&
+
+    val hasFinalBilling =
+        meterEnergy != null && meterEnergy > 0.0 && totalCost != null && totalCost >= 0.0 && !blockingBillingIssue
+
+    val canEnd = !submitting &&
         startSocValue != null && startSocValue in 0..100 &&
         endSocValue != null && endSocValue in 0..100 && endSocValue >= startSocValue &&
-        meterEnergy != null && meterEnergy > 0.0 &&
-        totalCost != null && totalCost >= 0.0 &&
         endedAt > session.startedAtEpochMillis &&
-        !invalidOdometer && !blockingBillingIssue &&
-        (odometerValue == null || odometerValue >= 0.0)
+        !invalidMeterText && !invalidCostText && !invalidPriceText && !invalidOdometer &&
+        !blockingBillingIssue
 
     val dateText = remember(endedAt) {
         SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(Date(endedAt))
@@ -189,12 +199,8 @@ fun CompleteChargingScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
-                title = {
-                    Text("结束充电", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "返回") }
-                },
+                title = { Text("结束充电", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold) },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, "返回") } },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
             )
         },
@@ -268,7 +274,7 @@ fun CompleteChargingScreen(
 
             estimatedVehicleEnergy?.let {
                 Text(
-                    "按 SOC 与电池容量估算，本次车辆约充入 ${"%.1f".format(Locale.US, it)} kWh",
+                    "按 SOC 与电池容量估算，车辆约充入 ${"%.1f".format(Locale.US, it)} kWh",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -280,7 +286,7 @@ fun CompleteChargingScreen(
                     billing = ChargeBillingEditor.edit(billing, ChargeBillingField.METER_ENERGY, it)
                     submitError = null
                 },
-                label = "电表 / 桩端电量",
+                label = "电表 / 桩端电量（可稍后补）",
                 suffix = "kWh",
                 modifier = Modifier.fillMaxWidth(),
                 keyboardType = KeyboardType.Decimal,
@@ -310,8 +316,23 @@ fun CompleteChargingScreen(
                     keyboardType = KeyboardType.Decimal,
                 )
             }
-            if (blockingBillingIssue) {
-                Text("费用、单价和电量不一致，请确认输入。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+
+            when {
+                blockingBillingIssue -> Text(
+                    "费用、单价和电量不一致，请确认输入。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                invalidMeterText || invalidCostText || invalidPriceText -> Text(
+                    "已填写的电表/费用信息需要是有效数字；暂时不知道可以直接留空。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                !hasFinalBilling -> Text(
+                    "电表数据还没出来也可以结束充电；本次会保存为待补录，不进入费用和电量统计。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
             OutlinedTextField(
@@ -355,36 +376,69 @@ fun CompleteChargingScreen(
             }
 
             Button(
-                enabled = canSubmit,
+                enabled = canEnd,
                 onClick = {
-                    val request = CompleteChargingSessionRequest(
-                        sessionId = session.id,
-                        startSoc = startSocValue!!,
-                        endSoc = endSocValue!!,
-                        meterEnergyKwh = meterEnergy!!,
-                        vehicleEnergyKwh = null,
-                        totalCost = totalCost!!,
-                        endedAtEpochMillis = endedAt,
-                        odometerKm = odometerValue,
-                        chargerType = session.chargerType,
-                        location = location.trim().takeIf { it.isNotEmpty() },
-                        remark = session.remark,
-                        latitude = latitude,
-                        longitude = longitude,
-                        locationAccuracyMeters = locationAccuracyMeters,
-                    )
                     submitting = true
                     submitError = null
                     scope.launch {
-                        runCatching { onComplete(request) }
+                        val result = if (hasFinalBilling) {
+                            runCatching {
+                                onComplete(
+                                    CompleteChargingSessionRequest(
+                                        sessionId = session.id,
+                                        startSoc = startSocValue!!,
+                                        endSoc = endSocValue!!,
+                                        meterEnergyKwh = meterEnergy!!,
+                                        vehicleEnergyKwh = null,
+                                        totalCost = totalCost!!,
+                                        endedAtEpochMillis = endedAt,
+                                        odometerKm = odometerValue,
+                                        chargerType = session.chargerType,
+                                        location = location.trim().takeIf { it.isNotEmpty() },
+                                        remark = session.remark,
+                                        latitude = latitude,
+                                        longitude = longitude,
+                                        locationAccuracyMeters = locationAccuracyMeters,
+                                    )
+                                )
+                            }
+                        } else {
+                            runCatching {
+                                onDefer(
+                                    DeferChargingCompletionRequest(
+                                        sessionId = session.id,
+                                        startSoc = startSocValue!!,
+                                        endSoc = endSocValue!!,
+                                        endedAtEpochMillis = endedAt,
+                                        odometerKm = odometerValue,
+                                        meterEnergyKwh = meterEnergy?.takeIf { it > 0.0 },
+                                        totalCost = totalCost?.takeIf { it >= 0.0 },
+                                        vehicleEnergyKwh = null,
+                                        location = location.trim().takeIf { it.isNotEmpty() },
+                                        remark = session.remark,
+                                        latitude = latitude,
+                                        longitude = longitude,
+                                        locationAccuracyMeters = locationAccuracyMeters,
+                                    )
+                                )
+                            }
+                        }
+                        result
                             .onSuccess { onCompleted() }
-                            .onFailure { submitError = it.message ?: "无法完成充电记录" }
+                            .onFailure { submitError = it.message ?: "无法结束充电" }
                         submitting = false
                     }
                 },
                 modifier = Modifier.fillMaxWidth().height(50.dp),
             ) {
-                Text(if (submitting) "正在保存…" else "完成并写入充电账本", fontWeight = FontWeight.SemiBold)
+                Text(
+                    when {
+                        submitting -> "正在保存…"
+                        hasFinalBilling -> "完成并写入充电账本"
+                        else -> "结束充电 · 稍后补电表"
+                    },
+                    fontWeight = FontWeight.SemiBold,
+                )
             }
 
             Spacer(Modifier.height(MaterialTheme.spacing.sm))
@@ -422,5 +476,7 @@ private fun formatCompletionDuration(milliseconds: Long): String {
     return if (hours > 0L) "${hours}小时${minutes}分" else "${minutes}分钟"
 }
 
-private fun Double.toEditableCompletionNumber(): String =
-    if (this % 1.0 == 0.0) toLong().toString() else toString()
+private fun Double.toEditableCompletionNumber(): String {
+    val text = String.format(Locale.US, "%.4f", this)
+    return text.trimEnd('0').trimEnd('.')
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
@@ -115,11 +115,12 @@ fun CompleteChargingScreen(
     val endSocValue = endSoc.toIntOrNull()
     val meterEnergy = billing.meterEnergyKwh
     val totalCost = billing.totalCost
+    val unitPrice = billing.unitPrice
     val odometerValue = odometer.takeIf { it.isNotBlank() }?.toDoubleOrNull()
 
     val invalidMeterText = billing.meterEnergyText.isNotBlank() && (meterEnergy == null || meterEnergy <= 0.0)
     val invalidCostText = billing.totalCostText.isNotBlank() && (totalCost == null || totalCost < 0.0)
-    val invalidPriceText = billing.unitPriceText.isNotBlank() && (billing.unitPrice == null || billing.unitPrice < 0.0)
+    val invalidPriceText = billing.unitPriceText.isNotBlank() && (unitPrice == null || unitPrice < 0.0)
     val invalidOdometer = odometer.isNotBlank() && (odometerValue == null || odometerValue < 0.0)
     val blockingBillingIssue = billing.issues.any {
         it == ChargeCalculationIssue.NEGATIVE_VALUE || it == ChargeCalculationIssue.BILLING_CONFLICT

--- a/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
@@ -422,7 +422,7 @@ fun CompleteChargingScreen(
                                         endSoc = endSocValue!!,
                                         endedAtEpochMillis = endedAt,
                                         odometerKm = odometerValue,
-                                        meterEnergyKwh = meterEnergy?.takeIf { it > 0.0 },
+                                        meterEnergyKwh = meterEnergy?.takeIf { meterIsConfirmed && it > 0.0 },
                                         totalCost = totalCost?.takeIf { it >= 0.0 },
                                         vehicleEnergyKwh = null,
                                         location = location.trim().takeIf { it.isNotEmpty() },

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -36,10 +36,12 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,11 +52,12 @@ import androidx.compose.ui.unit.dp
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.ChargingSessionEntity
-import com.evchargebook.data.repository.ChargingSessionRepository
+import com.evchargebook.data.repository.ChargingRepository
 import com.evchargebook.ui.components.EmptyState
 import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -72,20 +75,35 @@ fun RecordsScreen(
     onEditActive: (ChargingSessionEntity) -> Unit,
     onCancelActive: (ChargingSessionEntity) -> Unit,
 ) {
+    val context = LocalContext.current.applicationContext
+    val scope = rememberCoroutineScope()
+    val database = remember(context) { AppDatabase.getInstance(context) }
+    val chargingRepository = remember(database, context) { ChargingRepository(database, context) }
+    val pendingSessions by chargingRepository.pendingChargingSessions.collectAsState(initial = emptyList())
+
     var pendingDelete by remember { mutableStateOf<ChargingRecordEntity?>(null) }
     var pendingCancel by remember { mutableStateOf<ChargingSessionEntity?>(null) }
+    var pendingDiscard by remember { mutableStateOf<ChargingSessionEntity?>(null) }
     var completingSession by remember { mutableStateOf<ChargingSessionEntity?>(null) }
+    var backfillingSession by remember { mutableStateOf<ChargingSessionEntity?>(null) }
 
     completingSession?.let { session ->
-        val context = LocalContext.current.applicationContext
-        val completionRepository = remember(context) {
-            ChargingSessionRepository(AppDatabase.getInstance(context))
-        }
         CompleteChargingScreen(
             session = session,
             onBack = { completingSession = null },
-            onComplete = completionRepository::complete,
+            onComplete = chargingRepository::completeChargingSession,
+            onDefer = chargingRepository::deferChargingCompletion,
             onCompleted = { completingSession = null },
+        )
+        return
+    }
+
+    backfillingSession?.let { session ->
+        ChargingMeterBackfillScreen(
+            session = session,
+            onBack = { backfillingSession = null },
+            onBackfill = chargingRepository::backfillChargingSession,
+            onCompleted = { backfillingSession = null },
         )
         return
     }
@@ -94,9 +112,7 @@ fun RecordsScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
-                title = {
-                    Text("充电记录", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                },
+                title = { Text("充电记录", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold) },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
             )
         },
@@ -125,12 +141,40 @@ fun RecordsScreen(
                 }
             }
 
+            if (pendingSessions.isNotEmpty()) {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = MaterialTheme.spacing.xs),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text("待补录", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        Spacer(Modifier.weight(1f))
+                        Text(
+                            "${pendingSessions.size} 笔",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                items(pendingSessions, key = { "pending-${it.id}" }) { session ->
+                    PendingChargingCard(
+                        session = session,
+                        onBackfill = { backfillingSession = session },
+                        onDiscard = { pendingDiscard = session },
+                    )
+                }
+            }
+
             if (records.isEmpty()) {
                 item {
-                    Box(Modifier.fillMaxWidth().height(260.dp)) {
+                    Box(Modifier.fillMaxWidth().height(if (pendingSessions.isEmpty()) 260.dp else 180.dp)) {
                         EmptyState(
                             "还没有已完成的充电记录",
-                            if (activeSession != null) "当前充电仍在进行；完成后会进入历史账本。" else "可以开始记录充电，也可以补录已有账单。",
+                            when {
+                                activeSession != null -> "当前充电仍在进行；结束后会进入账本或待补录。"
+                                pendingSessions.isNotEmpty() -> "上方充电等待补充电表数据，补齐后才进入正式统计。"
+                                else -> "可以开始记录充电，也可以补录已有账单。"
+                            },
                             "补录历史充电",
                             onMaintainRecord,
                         )
@@ -191,6 +235,25 @@ fun RecordsScreen(
             dismissButton = { TextButton(onClick = { pendingCancel = null }) { Text("继续记录") } },
         )
     }
+
+    pendingDiscard?.let { session ->
+        AlertDialog(
+            onDismissRequest = { pendingDiscard = null },
+            title = { Text("删除这次待补录充电？") },
+            text = { Text("这次物理充电已经结束。删除后不会生成历史账本记录，也无法恢复这次待补录信息。") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch { chargingRepository.discardPendingChargingSession(session.id) }
+                        pendingDiscard = null
+                    }
+                ) {
+                    Text("删除", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = { TextButton(onClick = { pendingDiscard = null }) { Text("保留") } },
+        )
+    }
 }
 
 @Composable
@@ -210,10 +273,7 @@ private fun ChargingEntryActions(
         ) {
             Text(if (hasActiveSession) "充电进行中" else "开始充电")
         }
-        OutlinedButton(
-            onClick = onMaintainRecord,
-            modifier = Modifier.weight(1f),
-        ) {
+        OutlinedButton(onClick = onMaintainRecord, modifier = Modifier.weight(1f)) {
             Text("充电记录维护")
         }
     }
@@ -255,11 +315,7 @@ private fun ActiveChargingCard(
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
                 Text("充电中", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                 Spacer(Modifier.weight(1f))
-                Text(
-                    formatElapsed(elapsed),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                Text(formatElapsed(elapsed), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
             }
             Text(
                 session.location?.takeIf { it.isNotBlank() } ?: "未记录充电地点",
@@ -282,15 +338,6 @@ private fun ActiveChargingCard(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            session.remark?.takeIf { it.isNotBlank() }?.let {
-                Text(
-                    it,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
@@ -299,6 +346,70 @@ private fun ActiveChargingCard(
                 TextButton(onClick = onCancel) { Text("取消") }
                 TextButton(onClick = onEdit) { Text("编辑") }
                 Button(onClick = onComplete) { Text("结束充电") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PendingChargingCard(
+    session: ChargingSessionEntity,
+    onBackfill: () -> Unit,
+    onDiscard: () -> Unit,
+) {
+    val facts = listOfNotNull(
+        session.startSoc?.let { start -> session.endSoc?.let { end -> "SOC $start% → $end%" } },
+        session.pendingMeterEnergyKwh?.let { "${one(it)} kWh" },
+        session.pendingTotalCost?.let { "¥${two(it)}" },
+        session.chargerType?.takeIf { it.isNotBlank() },
+    )
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(Modifier.size(8.dp).background(MaterialTheme.colorScheme.secondary, CircleShape))
+                Spacer(Modifier.width(MaterialTheme.spacing.xs))
+                Text("待补电表数据", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.weight(1f))
+                Text(
+                    session.endedAtEpochMillis?.let(::format) ?: format(session.startedAtEpochMillis),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                session.location?.takeIf { it.isNotBlank() } ?: "未记录充电地点",
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (facts.isNotEmpty()) {
+                Text(
+                    facts.joinToString(" · "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                "补齐前不计入累计费用、电量和充电次数。",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDiscard) { Text("删除") }
+                Button(onClick = onBackfill) { Text("补充电表数据") }
             }
         }
     }
@@ -327,17 +438,11 @@ private fun LedgerSummaryV06(records: List<ChargingRecordEntity>) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(Modifier.size(7.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
                 Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                Text(
-                    "累计账本",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                Text("累计账本", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Row(verticalAlignment = Alignment.Bottom) {
-                Column {
-                    Text("累计支出", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    Text("¥ ${two(totalCost)}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-                }
+            Column {
+                Text("累计支出", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("¥ ${two(totalCost)}", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
             }
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .24f))
             ResponsiveMetricGrid(metrics.size) { index, modifier ->
@@ -363,18 +468,12 @@ private fun RecordTimelineItemV06(
     onDelete: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onEdit)
-            .padding(vertical = MaterialTheme.spacing.xs),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onEdit).padding(vertical = MaterialTheme.spacing.xs),
         verticalAlignment = Alignment.Top,
     ) {
         ChargingRailV06()
         Spacer(Modifier.width(MaterialTheme.spacing.sm))
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(5.dp),
-        ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(5.dp)) {
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
                 Column(Modifier.weight(1f)) {
                     Text(
@@ -384,29 +483,18 @@ private fun RecordTimelineItemV06(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    Text(
-                        format(record.chargeTimeEpochMillis),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Text(format(record.chargeTimeEpochMillis), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
                 Spacer(Modifier.width(MaterialTheme.spacing.sm))
                 Column(horizontalAlignment = Alignment.End) {
                     Text("¥ ${two(record.cost)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        "+${one(record.energyKwh)} kWh",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                    Text("+${one(record.energyKwh)} kWh", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
                 }
             }
 
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        "SOC ${record.startSoc}% → ${record.endSoc}% · ¥ ${two(record.pricePerKwh)}/kWh",
-                        style = MaterialTheme.typography.bodySmall,
-                    )
+                    Text("SOC ${record.startSoc}% → ${record.endSoc}% · ¥ ${two(record.pricePerKwh)}/kWh", style = MaterialTheme.typography.bodySmall)
                     val extras = listOfNotNull(
                         record.chargerType?.takeIf { it.isNotBlank() },
                         record.odometerKm?.let { "里程 ${formatKm(it)} km" },
@@ -444,20 +532,10 @@ private fun ChargingRailV06() {
             color = MaterialTheme.colorScheme.primary.copy(alpha = .10f),
         ) {
             Box(contentAlignment = Alignment.Center) {
-                Icon(
-                    Icons.Default.Bolt,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(15.dp),
-                )
+                Icon(Icons.Default.Bolt, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(15.dp))
             }
         }
-        Box(
-            Modifier
-                .width(1.dp)
-                .height(66.dp)
-                .background(MaterialTheme.colorScheme.outline.copy(alpha = .32f)),
-        )
+        Box(Modifier.width(1.dp).height(66.dp).background(MaterialTheme.colorScheme.outline.copy(alpha = .32f)))
     }
 }
 


### PR DESCRIPTION
Parent: #289 / #253
Persistence: #294 merged to main
Architecture follow-up: #285 remains open

Implementation is complete on exact head `9727d291a8e03b8fc0f9f1ef46a9cc9b03fda205`.

Final gate:
- base `main@5b0279e50ce8ed4fa0dffbdd94c95ba3e92967a2`
- behind 0
- exactly 4 intended files
- Android Build #757 Green, including Build/Test and Debug APK upload
- no review threads/comments/reviews
- direct finalization requires user-confirmed meter energy
- derived kWh is neither finalized nor persisted as a pending measured meter fact

This Draft PR is closed only because the connected Draft -> Ready GraphQL mutation still fails on nonexistent `Repository.fullDatabaseId`. A non-Draft replacement will reuse the exact same branch/head/diff; no implementation is duplicated or rewritten.

Still separate under #289: `修改结束信息` for PENDING_DETAILS.
Related: #289 #253 #285 #294.