### PR TITLE
feat(charging): edit pending completion facts

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
@@ -189,7 +189,7 @@ class ChargingSessionRepository(private val database: AppDatabase) {
     }
 
     /**
-     * End physical charging without inventing missing meter facts.
+     * End physical charging or revise an already-pending session without inventing meter facts.
      *
      * The pending session immediately becomes a vehicle-state fact, but it does not create a
      * `ChargingRecordEntity` and therefore cannot enter charging cost / energy statistics.
@@ -198,7 +198,7 @@ class ChargingSessionRepository(private val database: AppDatabase) {
         database.withTransaction {
             val session = chargingSessionDao.get(request.sessionId) ?: error("充电会话不存在")
             when (session.status) {
-                ChargingSessionStatus.PENDING_DETAILS -> return@withTransaction
+                ChargingSessionStatus.PENDING_DETAILS -> Unit
                 ChargingSessionStatus.COMPLETED -> error("本次充电已经完成")
                 ChargingSessionStatus.CANCELLED -> error("已取消的充电不能结束")
                 ChargingSessionStatus.ACTIVE -> Unit

--- a/android/app/src/main/java/com/evchargebook/ui/records/PendingChargingDetailsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/PendingChargingDetailsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -56,6 +57,7 @@ fun PendingChargingDetailsScreen(
     onSave: suspend (DeferChargingCompletionRequest) -> Unit,
     onSaved: () -> Unit,
 ) {
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val startSoc = session.startSoc
 
@@ -95,19 +97,10 @@ fun PendingChargingDetailsScreen(
         SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(endedAt))
     }
 
-    fun chooseDate() {
-        val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
-        DatePickerDialog(
-            calendarContext = null,
-        )
-    }
-
-    val contextHolder = androidx.compose.ui.platform.LocalContext.current
-
     fun openDatePicker() {
         val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
         DatePickerDialog(
-            contextHolder,
+            context,
             { _, year, month, day ->
                 val next = Calendar.getInstance().apply {
                     timeInMillis = endedAt
@@ -127,7 +120,7 @@ fun PendingChargingDetailsScreen(
     fun openTimePicker() {
         val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
         TimePickerDialog(
-            contextHolder,
+            context,
             { _, hour, minute ->
                 val next = Calendar.getInstance().apply {
                     timeInMillis = endedAt

--- a/android/app/src/main/java/com/evchargebook/ui/records/PendingChargingDetailsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/PendingChargingDetailsScreen.kt
@@ -1,0 +1,362 @@
+package com.evchargebook.ui.records
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.ChargingSessionEntity
+import com.evchargebook.data.repository.DeferChargingCompletionRequest
+import com.evchargebook.ui.theme.spacing
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PendingChargingDetailsScreen(
+    session: ChargingSessionEntity,
+    onBack: () -> Unit,
+    onSave: suspend (DeferChargingCompletionRequest) -> Unit,
+    onSaved: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val startSoc = session.startSoc
+
+    var endSoc by remember(session.id, session.updatedAtEpochMillis) {
+        mutableStateOf(session.endSoc?.toString().orEmpty())
+    }
+    var endedAt by remember(session.id, session.updatedAtEpochMillis) {
+        mutableLongStateOf(session.endedAtEpochMillis ?: System.currentTimeMillis())
+    }
+    var location by remember(session.id, session.updatedAtEpochMillis) {
+        mutableStateOf(session.location.orEmpty())
+    }
+    var latitude by remember(session.id, session.updatedAtEpochMillis) { mutableStateOf(session.latitude) }
+    var longitude by remember(session.id, session.updatedAtEpochMillis) { mutableStateOf(session.longitude) }
+    var locationAccuracyMeters by remember(session.id, session.updatedAtEpochMillis) {
+        mutableStateOf(session.locationAccuracyMeters)
+    }
+    var odometer by remember(session.id, session.updatedAtEpochMillis) {
+        mutableStateOf(session.odometerKm?.toPendingDetailsNumber().orEmpty())
+    }
+    var submitError by remember(session.id) { mutableStateOf<String?>(null) }
+    var submitting by remember(session.id) { mutableStateOf(false) }
+
+    BackHandler(onBack = onBack)
+
+    val endSocValue = endSoc.toIntOrNull()
+    val odometerValue = odometer.takeIf { it.isNotBlank() }?.toDoubleOrNull()
+    val invalidOdometer = odometer.isNotBlank() && (odometerValue == null || odometerValue < 0.0)
+    val validEndSoc = startSoc != null && endSocValue != null && endSocValue in startSoc..100
+    val validEndTime = endedAt > session.startedAtEpochMillis
+    val canSave = !submitting && validEndSoc && validEndTime && !invalidOdometer
+
+    val dateText = remember(endedAt) {
+        SimpleDateFormat("M月d日", Locale.SIMPLIFIED_CHINESE).format(Date(endedAt))
+    }
+    val timeText = remember(endedAt) {
+        SimpleDateFormat("HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(endedAt))
+    }
+
+    fun chooseDate() {
+        val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
+        DatePickerDialog(
+            calendarContext = null,
+        )
+    }
+
+    val contextHolder = androidx.compose.ui.platform.LocalContext.current
+
+    fun openDatePicker() {
+        val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
+        DatePickerDialog(
+            contextHolder,
+            { _, year, month, day ->
+                val next = Calendar.getInstance().apply {
+                    timeInMillis = endedAt
+                    set(Calendar.YEAR, year)
+                    set(Calendar.MONTH, month)
+                    set(Calendar.DAY_OF_MONTH, day)
+                }
+                endedAt = next.timeInMillis
+                submitError = null
+            },
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH),
+            calendar.get(Calendar.DAY_OF_MONTH),
+        ).show()
+    }
+
+    fun openTimePicker() {
+        val calendar = Calendar.getInstance().apply { timeInMillis = endedAt }
+        TimePickerDialog(
+            contextHolder,
+            { _, hour, minute ->
+                val next = Calendar.getInstance().apply {
+                    timeInMillis = endedAt
+                    set(Calendar.HOUR_OF_DAY, hour)
+                    set(Calendar.MINUTE, minute)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }
+                endedAt = next.timeInMillis
+                submitError = null
+            },
+            calendar.get(Calendar.HOUR_OF_DAY),
+            calendar.get(Calendar.MINUTE),
+            true,
+        ).show()
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "修改结束信息",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+        ) {
+            Spacer(Modifier.height(MaterialTheme.spacing.xs))
+
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium,
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+            ) {
+                Column(
+                    modifier = Modifier.padding(MaterialTheme.spacing.sm),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        listOfNotNull(
+                            session.chargerType?.takeIf { it.isNotBlank() },
+                            session.location?.takeIf { it.isNotBlank() },
+                        ).joinToString(" · ").ifBlank { "待补录充电" },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        buildString {
+                            append("开始 ${formatPendingDetailsTime(session.startedAtEpochMillis)}")
+                            startSoc?.let { append(" · SOC $it%") }
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Text(
+                "这里只修正已经结束的充电事实，不会修改待补录的电表电量、费用或电价。",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                OutlinedButton(
+                    onClick = ::openDatePicker,
+                    modifier = Modifier.weight(1f),
+                ) { Text(dateText) }
+                OutlinedButton(
+                    onClick = ::openTimePicker,
+                    modifier = Modifier.weight(1f),
+                ) { Text(timeText) }
+            }
+            if (!validEndTime) {
+                Text(
+                    "结束时间必须晚于开始时间",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+
+            OutlinedTextField(
+                value = endSoc,
+                onValueChange = {
+                    endSoc = it.filter(Char::isDigit)
+                    submitError = null
+                },
+                label = { Text("结束 SOC") },
+                suffix = { Text("%") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                isError = endSoc.isNotBlank() && !validEndSoc,
+                supportingText = if (startSoc != null && endSoc.isNotBlank() && !validEndSoc) {
+                    { Text("结束 SOC 需在 $startSoc%–100% 之间") }
+                } else {
+                    null
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = location,
+                onValueChange = { value ->
+                    if (value != location) {
+                        latitude = null
+                        longitude = null
+                        locationAccuracyMeters = null
+                    }
+                    location = value
+                    submitError = null
+                },
+                label = { Text("充电地点") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = odometer,
+                onValueChange = {
+                    odometer = it
+                    submitError = null
+                },
+                label = { Text("结束里程（可选）") },
+                suffix = { Text("km") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                isError = invalidOdometer,
+                supportingText = if (invalidOdometer) {
+                    { Text("请输入不小于 0 的里程") }
+                } else {
+                    null
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (startSoc == null) {
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        "这条待补录记录缺少开始 SOC，无法安全修改结束信息。",
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(MaterialTheme.spacing.sm),
+                    )
+                }
+            }
+
+            submitError?.let {
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        it,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(MaterialTheme.spacing.sm),
+                    )
+                }
+            }
+
+            Button(
+                enabled = canSave,
+                onClick = {
+                    val request = DeferChargingCompletionRequest(
+                        sessionId = session.id,
+                        startSoc = startSoc!!,
+                        endSoc = endSocValue!!,
+                        endedAtEpochMillis = endedAt,
+                        odometerKm = odometerValue,
+                        meterEnergyKwh = session.pendingMeterEnergyKwh,
+                        totalCost = session.pendingTotalCost,
+                        vehicleEnergyKwh = session.pendingVehicleEnergyKwh,
+                        location = location.trim().takeIf { it.isNotEmpty() },
+                        remark = session.remark,
+                        latitude = latitude,
+                        longitude = longitude,
+                        locationAccuracyMeters = locationAccuracyMeters,
+                    )
+                    submitting = true
+                    submitError = null
+                    scope.launch {
+                        runCatching { onSave(request) }
+                            .onSuccess { onSaved() }
+                            .onFailure { submitError = it.message ?: "无法保存结束信息" }
+                        submitting = false
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+            ) {
+                Text(
+                    if (submitting) "正在保存…" else "保存结束信息",
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
+            Spacer(Modifier.height(MaterialTheme.spacing.sm))
+        }
+    }
+}
+
+private fun formatPendingDetailsTime(value: Long): String =
+    SimpleDateFormat("M月d日 HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(value))
+
+private fun Double.toPendingDetailsNumber(): String {
+    val text = String.format(Locale.US, "%.1f", this)
+    return text.trimEnd('0').trimEnd('.')
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -86,6 +86,7 @@ fun RecordsScreen(
     var pendingDiscard by remember { mutableStateOf<ChargingSessionEntity?>(null) }
     var completingSession by remember { mutableStateOf<ChargingSessionEntity?>(null) }
     var backfillingSession by remember { mutableStateOf<ChargingSessionEntity?>(null) }
+    var editingPendingSession by remember { mutableStateOf<ChargingSessionEntity?>(null) }
 
     completingSession?.let { session ->
         CompleteChargingScreen(
@@ -104,6 +105,16 @@ fun RecordsScreen(
             onBack = { backfillingSession = null },
             onBackfill = chargingRepository::backfillChargingSession,
             onCompleted = { backfillingSession = null },
+        )
+        return
+    }
+
+    editingPendingSession?.let { session ->
+        PendingChargingDetailsScreen(
+            session = session,
+            onBack = { editingPendingSession = null },
+            onSave = chargingRepository::deferChargingCompletion,
+            onSaved = { editingPendingSession = null },
         )
         return
     }
@@ -159,6 +170,7 @@ fun RecordsScreen(
                 items(pendingSessions, key = { "pending-${it.id}" }) { session ->
                     PendingChargingCard(
                         session = session,
+                        onEditDetails = { editingPendingSession = session },
                         onBackfill = { backfillingSession = session },
                         onDiscard = { pendingDiscard = session },
                     )
@@ -354,6 +366,7 @@ private fun ActiveChargingCard(
 @Composable
 private fun PendingChargingCard(
     session: ChargingSessionEntity,
+    onEditDetails: () -> Unit,
     onBackfill: () -> Unit,
     onDiscard: () -> Unit,
 ) {
@@ -409,6 +422,7 @@ private fun PendingChargingCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = onDiscard) { Text("删除") }
+                TextButton(onClick = onEditDetails) { Text("修改结束信息") }
                 Button(onClick = onBackfill) { Text("补充电表数据") }
             }
         }


### PR DESCRIPTION
Replacement for closed Draft #298; same branch, same head `6df2c4cb70ffc9b4b9ed9c0e99a3ae2b159b92fa`, same 3-file diff. No code is duplicated or rewritten.

Parent: #289
Lifecycle owner: #253
Architecture follow-up: #285 remains separate

Delivered:
- pending card action `修改结束信息`
- edit end time / end SOC / location / ending odometer only
- preserve existing pending meter/cost/vehicle-energy facts unchanged
- manual location edit clears stale coordinates
- reuse centralized `deferCompletion()` transaction for PENDING_DETAILS revision
- rebuild VehicleState after correcting completion facts
- create no historical record and change no official charging statistics

Final evidence:
- base `main@6486f0808e8b7f586349f02dea145833a7f53e27`
- head `6df2c4cb70ffc9b4b9ed9c0e99a3ae2b159b92fa`
- behind 0
- exactly 3 intended files
- Android Build #760 Green including Build/Test + Debug APK
- no review threads/comments/reviews

Related: #289 #253 #285 #297 #298.