### PR TITLE
refactor(android): add vehicle presence boundary

### DIFF
--- a/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/autotrip/AutoTripPolicy.kt
@@ -1,9 +1,11 @@
 package com.evchargebook.autotrip
 
 /**
- * User-selected behavior for vehicle Bluetooth automation.
+ * Evidence-policy behavior for vehicle Bluetooth automation.
  *
- * This model is intentionally pure Kotlin and is not wired into production receivers yet.
+ * This pure Kotlin policy is intentionally distinct from the production per-vehicle
+ * `autoStartOnConnect` setting. That setting is a user-defined direct automation shortcut; it must
+ * not be described as VERIFIED_AUTO_START or as proof that the app detected real driving.
  */
 enum class AutoTripMode {
     OFF,

--- a/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionReceiver.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionReceiver.kt
@@ -8,7 +8,10 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import com.evchargebook.autotrip.AutoTripPromptCoordinator
+import com.evchargebook.vehicle.presence.VehiclePresenceDispatcher
+import com.evchargebook.vehicle.presence.VehiclePresenceEvent
+import com.evchargebook.vehicle.presence.VehiclePresenceSource
+import com.evchargebook.vehicle.presence.VehiclePresenceState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -23,17 +26,21 @@ class BluetoothConnectionReceiver : BroadcastReceiver() {
         ) return
 
         val device = intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE) ?: return
+        val state = when (intent.action) {
+            BluetoothDevice.ACTION_ACL_CONNECTED -> VehiclePresenceState.CONNECTED
+            BluetoothDevice.ACTION_ACL_DISCONNECTED -> VehiclePresenceState.DISCONNECTED
+            else -> return
+        }
+        val event = VehiclePresenceEvent(
+            state = state,
+            source = VehiclePresenceSource.CLASSIC_ACL,
+            deviceAddress = device.address,
+            deviceName = device.name,
+        )
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val coordinator = AutoTripPromptCoordinator(context.applicationContext)
-                when (intent.action) {
-                    BluetoothDevice.ACTION_ACL_CONNECTED ->
-                        coordinator.onBluetoothConnected(device.address, device.name)
-
-                    BluetoothDevice.ACTION_ACL_DISCONNECTED ->
-                        coordinator.onBluetoothDisconnected(device.address)
-                }
+                VehiclePresenceDispatcher.forAutoTrip(context).dispatch(event)
             } finally {
                 pending.finish()
             }

--- a/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionStateChecker.kt
+++ b/android/app/src/main/java/com/evchargebook/bluetooth/BluetoothConnectionStateChecker.kt
@@ -8,7 +8,11 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 import com.evchargebook.autotrip.AutoTripCandidateResult
-import com.evchargebook.autotrip.AutoTripPromptCoordinator
+import com.evchargebook.vehicle.presence.VehiclePresenceDispatchResult
+import com.evchargebook.vehicle.presence.VehiclePresenceDispatcher
+import com.evchargebook.vehicle.presence.VehiclePresenceEvent
+import com.evchargebook.vehicle.presence.VehiclePresenceSource
+import com.evchargebook.vehicle.presence.VehiclePresenceState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -65,11 +69,18 @@ object BluetoothConnectionStateChecker {
         onResult: (Boolean) -> Unit,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
-            val result = runCatching {
-                AutoTripPromptCoordinator(context.applicationContext)
-                    .onBluetoothConnected(deviceAddress, deviceName = null)
+            val dispatchResult = runCatching {
+                VehiclePresenceDispatcher.forAutoTrip(context).dispatch(
+                    VehiclePresenceEvent(
+                        state = VehiclePresenceState.CONNECTED,
+                        source = VehiclePresenceSource.FOREGROUND_CONNECTION_CHECK,
+                        deviceAddress = deviceAddress,
+                    )
+                )
             }.getOrNull()
-            val shouldShowForegroundPrompt = result is AutoTripCandidateResult.Created && result.notificationVisible
+            val candidate = (dispatchResult as? VehiclePresenceDispatchResult.Candidate)?.result
+            val shouldShowForegroundPrompt =
+                candidate is AutoTripCandidateResult.Created && candidate.notificationVisible
             ContextCompat.getMainExecutor(context).execute {
                 onResult(shouldShowForegroundPrompt)
             }

--- a/android/app/src/main/java/com/evchargebook/vehicle/presence/VehiclePresence.kt
+++ b/android/app/src/main/java/com/evchargebook/vehicle/presence/VehiclePresence.kt
@@ -1,0 +1,113 @@
+package com.evchargebook.vehicle.presence
+
+import android.content.Context
+import com.evchargebook.autotrip.AutoTripCandidateResult
+import com.evchargebook.autotrip.AutoTripPromptCoordinator
+
+/**
+ * A bounded observation that a configured vehicle-facing device is present or connected.
+ *
+ * Presence is intentionally not telemetry and not proof of driving. The existing per-vehicle
+ * Bluetooth binding remains the authority that resolves a device address to a vehicle before any
+ * Trip candidate can be created.
+ */
+data class VehiclePresenceEvent(
+    val state: VehiclePresenceState,
+    val source: VehiclePresenceSource,
+    val deviceAddress: String,
+    val deviceName: String? = null,
+    val observedAtEpochMillis: Long = System.currentTimeMillis(),
+) {
+    init {
+        require(deviceAddress.isNotBlank()) { "deviceAddress must not be blank" }
+    }
+}
+
+enum class VehiclePresenceState {
+    /** Device is nearby/observable, but a transport connection has not been established. */
+    PRESENT,
+
+    /** A transport connection that can feed the existing auto-Trip candidate flow is active. */
+    CONNECTED,
+
+    /** The previously connected transport is no longer connected. */
+    DISCONNECTED,
+}
+
+enum class VehiclePresenceSource {
+    /** Android Bluetooth ACL connect/disconnect broadcast. */
+    CLASSIC_ACL,
+
+    /** Future Android Companion Device presence/connection callback. */
+    COMPANION_DEVICE,
+
+    /** Foreground reconciliation against already-connected A2DP/HEADSET profiles. */
+    FOREGROUND_CONNECTION_CHECK,
+}
+
+sealed interface VehiclePresenceDispatchResult {
+    /** Presence-only observations are recorded as observations, not Trip candidates. */
+    data object ObservedOnly : VehiclePresenceDispatchResult
+
+    /** A connected observation was handed to the existing auto-Trip candidate authority. */
+    data class Candidate(val result: AutoTripCandidateResult) : VehiclePresenceDispatchResult
+
+    /** A disconnect was handed to the existing session close/cancel path. */
+    data object Disconnected : VehiclePresenceDispatchResult
+}
+
+/**
+ * Small boundary between platform-specific presence sources and the existing #235 auto-Trip flow.
+ *
+ * Providers must not create Trips themselves. CONNECTED observations are delegated to the existing
+ * AutoTripPromptCoordinator, which still owns per-vehicle binding, session dedupe and the route to
+ * TripStartCoordinator. PRESENT is deliberately non-authoritative in this first slice.
+ */
+class VehiclePresenceDispatcher(
+    private val sink: VehiclePresenceCandidateSink,
+) {
+    suspend fun dispatch(event: VehiclePresenceEvent): VehiclePresenceDispatchResult =
+        when (event.state) {
+            VehiclePresenceState.PRESENT -> VehiclePresenceDispatchResult.ObservedOnly
+            VehiclePresenceState.CONNECTED -> VehiclePresenceDispatchResult.Candidate(
+                sink.onConnected(event)
+            )
+            VehiclePresenceState.DISCONNECTED -> {
+                sink.onDisconnected(event)
+                VehiclePresenceDispatchResult.Disconnected
+            }
+        }
+
+    companion object {
+        fun forAutoTrip(context: Context): VehiclePresenceDispatcher =
+            VehiclePresenceDispatcher(
+                AutoTripVehiclePresenceSink(
+                    AutoTripPromptCoordinator(context.applicationContext)
+                )
+            )
+    }
+}
+
+/** Injectable seam so the presence contract can be tested without Android framework state. */
+interface VehiclePresenceCandidateSink {
+    suspend fun onConnected(event: VehiclePresenceEvent): AutoTripCandidateResult
+    suspend fun onDisconnected(event: VehiclePresenceEvent)
+}
+
+private class AutoTripVehiclePresenceSink(
+    private val coordinator: AutoTripPromptCoordinator,
+) : VehiclePresenceCandidateSink {
+    override suspend fun onConnected(event: VehiclePresenceEvent): AutoTripCandidateResult =
+        coordinator.onBluetoothConnected(
+            deviceAddress = event.deviceAddress,
+            deviceName = event.deviceName,
+            now = event.observedAtEpochMillis,
+        )
+
+    override suspend fun onDisconnected(event: VehiclePresenceEvent) {
+        coordinator.onBluetoothDisconnected(
+            deviceAddress = event.deviceAddress,
+            now = event.observedAtEpochMillis,
+        )
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/vehicle/presence/VehiclePresenceDispatcherTest.kt
+++ b/android/app/src/test/java/com/evchargebook/vehicle/presence/VehiclePresenceDispatcherTest.kt
@@ -1,0 +1,104 @@
+package com.evchargebook.vehicle.presence
+
+import com.evchargebook.autotrip.AutoTripCandidateResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VehiclePresenceDispatcherTest {
+    @Test
+    fun `connected observation is delegated with source and timestamp intact`() = runBlocking {
+        val sink = FakeSink()
+        val dispatcher = VehiclePresenceDispatcher(sink)
+        val event = VehiclePresenceEvent(
+            state = VehiclePresenceState.CONNECTED,
+            source = VehiclePresenceSource.CLASSIC_ACL,
+            deviceAddress = "AA:BB:CC:DD:EE:FF",
+            deviceName = "Car",
+            observedAtEpochMillis = 1234L,
+        )
+
+        val result = dispatcher.dispatch(event)
+
+        assertTrue(result is VehiclePresenceDispatchResult.Candidate)
+        assertEquals(event, sink.connected.single())
+        assertTrue(sink.disconnected.isEmpty())
+    }
+
+    @Test
+    fun `foreground reconciliation remains a distinct presence source`() = runBlocking {
+        val sink = FakeSink()
+        val dispatcher = VehiclePresenceDispatcher(sink)
+        val event = VehiclePresenceEvent(
+            state = VehiclePresenceState.CONNECTED,
+            source = VehiclePresenceSource.FOREGROUND_CONNECTION_CHECK,
+            deviceAddress = "AA:BB:CC:DD:EE:FF",
+            observedAtEpochMillis = 5678L,
+        )
+
+        dispatcher.dispatch(event)
+
+        assertEquals(VehiclePresenceSource.FOREGROUND_CONNECTION_CHECK, sink.connected.single().source)
+        assertEquals(5678L, sink.connected.single().observedAtEpochMillis)
+    }
+
+    @Test
+    fun `present only observation never becomes a Trip candidate`() = runBlocking {
+        val sink = FakeSink()
+        val dispatcher = VehiclePresenceDispatcher(sink)
+
+        val result = dispatcher.dispatch(
+            VehiclePresenceEvent(
+                state = VehiclePresenceState.PRESENT,
+                source = VehiclePresenceSource.COMPANION_DEVICE,
+                deviceAddress = "AA:BB:CC:DD:EE:FF",
+            )
+        )
+
+        assertEquals(VehiclePresenceDispatchResult.ObservedOnly, result)
+        assertTrue(sink.connected.isEmpty())
+        assertTrue(sink.disconnected.isEmpty())
+    }
+
+    @Test
+    fun `disconnect only delegates session close path`() = runBlocking {
+        val sink = FakeSink()
+        val dispatcher = VehiclePresenceDispatcher(sink)
+        val event = VehiclePresenceEvent(
+            state = VehiclePresenceState.DISCONNECTED,
+            source = VehiclePresenceSource.CLASSIC_ACL,
+            deviceAddress = "AA:BB:CC:DD:EE:FF",
+            observedAtEpochMillis = 9012L,
+        )
+
+        val result = dispatcher.dispatch(event)
+
+        assertEquals(VehiclePresenceDispatchResult.Disconnected, result)
+        assertEquals(event, sink.disconnected.single())
+        assertTrue(sink.connected.isEmpty())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `blank device identity is rejected`() {
+        VehiclePresenceEvent(
+            state = VehiclePresenceState.CONNECTED,
+            source = VehiclePresenceSource.CLASSIC_ACL,
+            deviceAddress = "   ",
+        )
+    }
+
+    private class FakeSink : VehiclePresenceCandidateSink {
+        val connected = mutableListOf<VehiclePresenceEvent>()
+        val disconnected = mutableListOf<VehiclePresenceEvent>()
+
+        override suspend fun onConnected(event: VehiclePresenceEvent): AutoTripCandidateResult {
+            connected += event
+            return AutoTripCandidateResult.NotConfigured
+        }
+
+        override suspend fun onDisconnected(event: VehiclePresenceEvent) {
+            disconnected += event
+        }
+    }
+}


### PR DESCRIPTION
Refs #299

## Summary

First focused slice of the Vehicle Presence work. This does **not** add Companion Device yet and does not change Trip/Room semantics.

- add `VehiclePresenceEvent` / state / source contract and a small dispatcher;
- route existing ACL connect/disconnect broadcasts through the presence boundary;
- route foreground A2DP/HEADSET reconciliation through the same boundary;
- keep existing `AutoTripPromptCoordinator` as binding/session/dedupe authority and `TripStartCoordinator` as the only Trip-start authority;
- keep `PRESENT` non-authoritative so nearby-only observations cannot create a Trip candidate;
- document that per-binding `autoStartOnConnect` is explicit user automation and is **not** `VERIFIED_AUTO_START` driving proof;
- add JVM coverage for connected, foreground-source, present-only, disconnect and invalid identity routing.

## Behavior preserved

- configured ACL connection still reaches the existing prompt/direct-auto-start path;
- non-configured devices remain filtered by the existing binding authority;
- existing detection-session dedupe is unchanged;
- disconnect still closes/cancels only the detection session path and never silently ends a Trip;
- no SOC/range/odometer/BMS telemetry is introduced.

## Current base / diff

Re-normalized after #308 and #306 onto `main@7700c14b3c81e7590617269104eef0924a1add64`.

- head `28dc3fb0f4f15bb8ca283693f23adb8d63ea439a`
- ahead 1 / behind 0
- effective diff = exactly 5 presence/ACL files
- no Room/schema migration
- no new service / WorkManager
- no new Android permission
- no Companion Device API in this slice

## Validation

- [x] `testDebugUnitTest` via Android Build #774 / run `33620996713`
- [x] `:app:assembleDebug` via same current-head run
- [x] Android CI Green on current synchronized head
- [x] Debug APK upload succeeded

## Draft metadata

Implementation/evidence is ready for review, but the connected Draft -> Ready mutation has previously failed on GitHub GraphQL schema compatibility (`Repository.fullDatabaseId`). Do not create a duplicate PR solely to clear metadata. A maintainer may clear the Draft badge in GitHub UI if the connector still fails.

After this slice lands, #299 can evaluate the optional Companion Device adapter against the same boundary without creating a second auto-Trip architecture.