### PR TITLE
refactor(charging): route lifecycle through MainViewModel

### DIFF
--- a/android/app/src/main/java/com/evchargebook/MainActivity.kt
+++ b/android/app/src/main/java/com/evchargebook/MainActivity.kt
@@ -518,6 +518,10 @@ fun MainApp(
                     1 -> RecordsScreen(
                         records = state.chargingRecords,
                         activeSession = state.activeChargingSession,
+                        pendingSessions = state.pendingChargingSessions,
+                        currentSoc = state.currentSoc,
+                        currentSocUpdatedAtEpochMillis = state.currentSocUpdatedAtEpochMillis,
+                        batteryCapacityKwh = state.vehicle?.batteryCapacityKwh,
                         onDelete = viewModel::deleteChargingRecord,
                         onStartCharging = {
                             if (state.vehicle == null) {
@@ -530,6 +534,11 @@ fun MainApp(
                         onEdit = { editingRecord = it },
                         onEditActive = { editActiveCharging = true },
                         onCancelActive = { session -> viewModel.cancelChargingSession(session.id) },
+                        onCompleteCharging = viewModel::completeChargingSession,
+                        onDeferCharging = viewModel::deferChargingCompletion,
+                        onUpdatePendingDetails = viewModel::updatePendingChargingDetails,
+                        onBackfillCharging = viewModel::backfillChargingSession,
+                        onDiscardPending = viewModel::discardPendingChargingSession,
                     )
                     2 -> StatsScreen(state)
                     3 -> {

--- a/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/CompleteChargingScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -42,7 +41,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingSessionEntity
 import com.evchargebook.data.repository.CompleteChargingSessionRequest
 import com.evchargebook.data.repository.DeferChargingCompletionRequest
@@ -59,6 +57,9 @@ import java.util.Locale
 @Composable
 fun CompleteChargingScreen(
     session: ChargingSessionEntity,
+    currentSoc: Int?,
+    currentSocUpdatedAtEpochMillis: Long?,
+    batteryCapacityKwh: Double?,
     onBack: () -> Unit,
     onComplete: suspend (CompleteChargingSessionRequest) -> Long,
     onDefer: suspend (DeferChargingCompletionRequest) -> Unit,
@@ -66,10 +67,6 @@ fun CompleteChargingScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val database = remember(context) { AppDatabase.getInstance(context.applicationContext) }
-    val vehicleState by database.vehicleStateDao().observe(session.vehicleId).collectAsState(initial = null)
-    val vehicles by database.vehicleDao().observeActive().collectAsState(initial = emptyList())
-    val batteryCapacityKwh = vehicles.firstOrNull { it.id == session.vehicleId }?.batteryCapacityKwh
 
     val initialBilling = remember(session.id, session.updatedAtEpochMillis) {
         ChargeBillingEditor.create(
@@ -99,9 +96,9 @@ fun CompleteChargingScreen(
     var submitError by remember(session.id) { mutableStateOf<String?>(null) }
     var submitting by remember(session.id) { mutableStateOf(false) }
 
-    LaunchedEffect(vehicleState?.currentSoc, vehicleState?.updatedAtEpochMillis, session.id) {
-        val knownSoc = vehicleState?.currentSoc
-        val isNewerFact = (vehicleState?.updatedAtEpochMillis ?: 0L) > session.startedAtEpochMillis
+    LaunchedEffect(currentSoc, currentSocUpdatedAtEpochMillis, session.id) {
+        val knownSoc = currentSoc
+        val isNewerFact = (currentSocUpdatedAtEpochMillis ?: 0L) > session.startedAtEpochMillis
         val differsFromStart = knownSoc != null && knownSoc != session.startSoc
         val notBelowStart = knownSoc != null && (session.startSoc == null || knownSoc >= session.startSoc)
         if (!endSocTouched && endSoc.isBlank() && isNewerFact && differsFromStart && notBelowStart) {

--- a/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/RecordsScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -45,14 +44,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.ChargingRecordEntity
 import com.evchargebook.data.entity.ChargingSessionEntity
-import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.data.repository.BackfillChargingSessionRequest
+import com.evchargebook.data.repository.CompleteChargingSessionRequest
+import com.evchargebook.data.repository.DeferChargingCompletionRequest
 import com.evchargebook.ui.components.EmptyState
 import com.evchargebook.ui.components.ResponsiveMetricGrid
 import com.evchargebook.ui.theme.spacing
@@ -68,18 +67,23 @@ import java.util.Locale
 fun RecordsScreen(
     records: List<ChargingRecordEntity>,
     activeSession: ChargingSessionEntity?,
+    pendingSessions: List<ChargingSessionEntity>,
+    currentSoc: Int?,
+    currentSocUpdatedAtEpochMillis: Long?,
+    batteryCapacityKwh: Double?,
     onDelete: (ChargingRecordEntity) -> Unit,
     onStartCharging: () -> Unit,
     onMaintainRecord: () -> Unit,
     onEdit: (ChargingRecordEntity) -> Unit,
     onEditActive: (ChargingSessionEntity) -> Unit,
     onCancelActive: (ChargingSessionEntity) -> Unit,
+    onCompleteCharging: suspend (CompleteChargingSessionRequest) -> Long,
+    onDeferCharging: suspend (DeferChargingCompletionRequest) -> Unit,
+    onUpdatePendingDetails: suspend (DeferChargingCompletionRequest) -> Unit,
+    onBackfillCharging: suspend (BackfillChargingSessionRequest) -> Long,
+    onDiscardPending: suspend (String) -> Unit,
 ) {
-    val context = LocalContext.current.applicationContext
     val scope = rememberCoroutineScope()
-    val database = remember(context) { AppDatabase.getInstance(context) }
-    val chargingRepository = remember(database, context) { ChargingRepository(database, context) }
-    val pendingSessions by chargingRepository.pendingChargingSessions.collectAsState(initial = emptyList())
 
     var pendingDelete by remember { mutableStateOf<ChargingRecordEntity?>(null) }
     var pendingCancel by remember { mutableStateOf<ChargingSessionEntity?>(null) }
@@ -91,9 +95,12 @@ fun RecordsScreen(
     completingSession?.let { session ->
         CompleteChargingScreen(
             session = session,
+            currentSoc = currentSoc,
+            currentSocUpdatedAtEpochMillis = currentSocUpdatedAtEpochMillis,
+            batteryCapacityKwh = batteryCapacityKwh,
             onBack = { completingSession = null },
-            onComplete = chargingRepository::completeChargingSession,
-            onDefer = chargingRepository::deferChargingCompletion,
+            onComplete = onCompleteCharging,
+            onDefer = onDeferCharging,
             onCompleted = { completingSession = null },
         )
         return
@@ -103,7 +110,7 @@ fun RecordsScreen(
         ChargingMeterBackfillScreen(
             session = session,
             onBack = { backfillingSession = null },
-            onBackfill = chargingRepository::backfillChargingSession,
+            onBackfill = onBackfillCharging,
             onCompleted = { backfillingSession = null },
         )
         return
@@ -113,7 +120,7 @@ fun RecordsScreen(
         PendingChargingDetailsScreen(
             session = session,
             onBack = { editingPendingSession = null },
-            onSave = chargingRepository::deferChargingCompletion,
+            onSave = onUpdatePendingDetails,
             onSaved = { editingPendingSession = null },
         )
         return
@@ -256,8 +263,8 @@ fun RecordsScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        scope.launch { chargingRepository.discardPendingChargingSession(session.id) }
                         pendingDiscard = null
+                        scope.launch { runCatching { onDiscardPending(session.id) } }
                     }
                 ) {
                     Text("删除", color = MaterialTheme.colorScheme.error)

--- a/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/evchargebook/viewmodel/MainViewModel.kt
@@ -11,7 +11,10 @@ import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleCatalogEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.data.repository.BackfillChargingSessionRequest
 import com.evchargebook.data.repository.ChargingRepository
+import com.evchargebook.data.repository.CompleteChargingSessionRequest
+import com.evchargebook.data.repository.DeferChargingCompletionRequest
 import com.evchargebook.data.repository.StartChargingSessionRequest
 import com.evchargebook.domain.ChargerCategorySummary
 import com.evchargebook.domain.ChargerTypeAnalytics
@@ -34,6 +37,8 @@ import java.time.ZoneId
 data class MainUiState(
     val vehicle: VehicleEntity? = null,
     val currentSoc: Int? = null,
+    val currentSocUpdatedAtEpochMillis: Long? = null,
+    val currentSocUpdateSource: String? = null,
     val currentMileageKm: Double? = null,
     val vehicles: List<VehicleEntity> = emptyList(),
     val catalogVehicles: List<VehicleCatalogEntity> = emptyList(),
@@ -41,6 +46,7 @@ data class MainUiState(
     val pairedBluetoothDevices: List<PairedBluetoothDevice> = emptyList(),
     val chargingRecords: List<ChargingRecordEntity> = emptyList(),
     val activeChargingSession: ChargingSessionEntity? = null,
+    val pendingChargingSessions: List<ChargingSessionEntity> = emptyList(),
     val trips: List<TripSessionEntity> = emptyList(),
     val activeTrip: TripSessionEntity? = null,
     val selectedTripId: Long? = null,
@@ -80,10 +86,13 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
         viewModelScope.launch { repository.bluetoothSettings.collect { settings -> _uiState.value = _uiState.value.copy(bluetoothSettings = settings) } }
         viewModelScope.launch { repository.activeTrip.collect { trip -> _uiState.value = _uiState.value.copy(activeTrip = trip) } }
         viewModelScope.launch { repository.activeChargingSession.collect { session -> _uiState.value = _uiState.value.copy(activeChargingSession = session) } }
+        viewModelScope.launch { repository.pendingChargingSessions.collect { sessions -> _uiState.value = _uiState.value.copy(pendingChargingSessions = sessions) } }
         viewModelScope.launch {
             repository.vehicleState.collect { vehicleState ->
                 _uiState.value = _uiState.value.copy(
                     currentSoc = vehicleState?.currentSoc,
+                    currentSocUpdatedAtEpochMillis = vehicleState?.updatedAtEpochMillis,
+                    currentSocUpdateSource = vehicleState?.updateSource,
                     currentMileageKm = vehicleState?.currentMileage
                 )
             }
@@ -159,8 +168,12 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
     }
 
     fun restoreBackup(content: String) {
-        if (_uiState.value.activeTrip != null || _uiState.value.activeChargingSession != null) {
-            _uiState.value = _uiState.value.copy(errorMessage = "有进行中的行程或充电，请结束后再恢复备份")
+        if (
+            _uiState.value.activeTrip != null ||
+            _uiState.value.activeChargingSession != null ||
+            _uiState.value.pendingChargingSessions.isNotEmpty()
+        ) {
+            _uiState.value = _uiState.value.copy(errorMessage = "有进行中或待补录的行程/充电，请处理后再恢复备份")
             return
         }
         viewModelScope.launch {
@@ -191,6 +204,57 @@ class MainViewModel(private val repository: ChargingRepository) : ViewModel() {
             runCatching { repository.cancelChargingSession(sessionId) }
                 .onSuccess { _uiState.value = _uiState.value.copy(successMessage = "已取消本次充电记录") }
                 .onFailure { _uiState.value = _uiState.value.copy(errorMessage = it.message ?: "无法取消充电") }
+        }
+    }
+
+    suspend fun completeChargingSession(request: CompleteChargingSessionRequest): Long =
+        runChargingCommand(
+            successMessage = "充电已完成并写入账本",
+            fallbackError = "无法结束充电",
+        ) { repository.completeChargingSession(request) }
+
+    suspend fun deferChargingCompletion(request: DeferChargingCompletionRequest) {
+        runChargingCommand(
+            successMessage = "充电已结束，等待补充电表数据",
+            fallbackError = "无法结束充电",
+        ) { repository.deferChargingCompletion(request) }
+    }
+
+    suspend fun updatePendingChargingDetails(request: DeferChargingCompletionRequest) {
+        runChargingCommand(
+            successMessage = "结束信息已更新",
+            fallbackError = "无法更新结束信息",
+        ) { repository.deferChargingCompletion(request) }
+    }
+
+    suspend fun backfillChargingSession(request: BackfillChargingSessionRequest): Long =
+        runChargingCommand(
+            successMessage = "电表数据已补录，充电账本已完成",
+            fallbackError = "无法补充电表数据",
+        ) { repository.backfillChargingSession(request) }
+
+    suspend fun discardPendingChargingSession(sessionId: String) {
+        runChargingCommand(
+            successMessage = "已删除待补录充电",
+            fallbackError = "无法删除待补录充电",
+        ) { repository.discardPendingChargingSession(sessionId) }
+    }
+
+    private suspend fun <T> runChargingCommand(
+        successMessage: String,
+        fallbackError: String,
+        block: suspend () -> T,
+    ): T {
+        return try {
+            val result = block()
+            _uiState.value = _uiState.value.copy(successMessage = successMessage, errorMessage = null)
+            result
+        } catch (error: Throwable) {
+            _uiState.value = _uiState.value.copy(
+                successMessage = null,
+                errorMessage = error.message ?: fallbackError,
+            )
+            throw error
         }
     }
 


### PR DESCRIPTION
Architecture implementation is complete on exact head `3bc50df11f58449ac192f856f2980470c925ce50`.

Final gate:
- base `main@0348d4ba53b077795ba2476b8d8d6feda587bc2a`
- behind 0
- exactly 4 intended files
- Android Build #764 Green including Build/Test + Debug APK
- no review threads/comments/reviews

The connected Draft -> Ready action could not be completed by the connector. This Draft PR is closed only for metadata normalization. A non-Draft replacement will reuse the exact same branch/head/base/diff; no implementation is duplicated or rewritten.

Scope remains #285 only: route pending state and complete/defer/update-pending/backfill/discard commands through MainViewModel, and remove Room/Repository access from Records/Completion UI.

Physical acceptance remains #253 / #289.