### PR TITLE
feat(android): add truthful local vehicle widget

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,16 @@
             </intent-filter>
         </receiver>
         <receiver android:name=".autotrip.AutoTripActionReceiver" android:exported="false" />
+        <receiver
+            android:name=".widget.VehicleHomeWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/vehicle_widget_info" />
+        </receiver>
         <service
             android:name=".trip.TripTrackingService"
             android:exported="false"

--- a/android/app/src/main/java/com/evchargebook/EvChargeBookApplication.kt
+++ b/android/app/src/main/java/com/evchargebook/EvChargeBookApplication.kt
@@ -1,8 +1,10 @@
 package com.evchargebook
 
 import android.app.Application
+import androidx.room.InvalidationTracker
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.repository.VehicleCatalogSync
+import com.evchargebook.widget.VehicleHomeWidgetUpdater
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -10,14 +12,36 @@ import kotlinx.coroutines.launch
 
 class EvChargeBookApplication : Application() {
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val widgetObserver = object : InvalidationTracker.Observer(
+        "vehicles",
+        "vehicle_state",
+        "trip_sessions",
+        "charging_sessions",
+    ) {
+        override fun onInvalidated(tables: Set<String>) {
+            applicationScope.launch {
+                runCatching {
+                    VehicleHomeWidgetUpdater.updateAll(this@EvChargeBookApplication)
+                }
+            }
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
+        val database = AppDatabase.getInstance(this)
+        database.invalidationTracker.addObserver(widgetObserver)
+
         applicationScope.launch {
+            // Widget state is Local First and should be useful even when catalog networking fails.
+            runCatching {
+                VehicleHomeWidgetUpdater.updateAll(this@EvChargeBookApplication)
+            }
+
             // Catalog networking is best-effort metadata refresh only. A timeout, malformed response,
             // DNS failure or server outage must never block or fail normal local app startup.
             runCatching {
-                VehicleCatalogSync(AppDatabase.getInstance(this@EvChargeBookApplication))
+                VehicleCatalogSync(database)
                     .refresh(BuildConfig.VEHICLE_CATALOG_URL)
             }
         }

--- a/android/app/src/main/java/com/evchargebook/widget/VehicleHomeWidget.kt
+++ b/android/app/src/main/java/com/evchargebook/widget/VehicleHomeWidget.kt
@@ -1,0 +1,148 @@
+package com.evchargebook.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import com.evchargebook.MainActivity
+import com.evchargebook.R
+import com.evchargebook.data.database.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+data class VehicleWidgetSnapshot(
+    val vehicleId: Long? = null,
+    val displayName: String = "EV Charge Book",
+    val currentSoc: Int? = null,
+    val currentMileageKm: Double? = null,
+    val stateUpdatedAtEpochMillis: Long? = null,
+    val activeTrip: Boolean = false,
+    val activeCharging: Boolean = false,
+)
+
+/**
+ * Reads only local app facts. Rated range/battery capacity are deliberately not used as live state.
+ */
+class VehicleWidgetSnapshotReader(context: Context) {
+    private val database = AppDatabase.getInstance(context.applicationContext)
+
+    suspend fun read(): VehicleWidgetSnapshot {
+        val vehicle = database.vehicleDao().observeActive().first().firstOrNull()
+            ?: return VehicleWidgetSnapshot()
+        val state = database.vehicleStateDao().get(vehicle.id)
+        val activeTrip = database.tripDao().getActive()?.vehicleId == vehicle.id
+        val activeCharging = database.chargingSessionDao().getActiveForVehicle(vehicle.id) != null
+
+        return VehicleWidgetSnapshot(
+            vehicleId = vehicle.id,
+            displayName = vehicle.displayName,
+            currentSoc = state?.currentSoc,
+            currentMileageKm = state?.currentMileage,
+            stateUpdatedAtEpochMillis = state?.updatedAtEpochMillis,
+            activeTrip = activeTrip,
+            activeCharging = activeCharging,
+        )
+    }
+}
+
+class VehicleHomeWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
+                VehicleHomeWidgetUpdater.update(
+                    context = context.applicationContext,
+                    appWidgetManager = appWidgetManager,
+                    appWidgetIds = appWidgetIds,
+                )
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}
+
+object VehicleHomeWidgetUpdater {
+    suspend fun updateAll(context: Context) {
+        val appContext = context.applicationContext
+        val manager = AppWidgetManager.getInstance(appContext)
+        val ids = manager.getAppWidgetIds(
+            ComponentName(appContext, VehicleHomeWidgetProvider::class.java)
+        )
+        if (ids.isNotEmpty()) {
+            update(appContext, manager, ids)
+        }
+    }
+
+    suspend fun update(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        val snapshot = VehicleWidgetSnapshotReader(context).read()
+        appWidgetIds.forEach { appWidgetId ->
+            appWidgetManager.updateAppWidget(
+                appWidgetId,
+                render(context, snapshot),
+            )
+        }
+    }
+
+    internal fun render(context: Context, snapshot: VehicleWidgetSnapshot): RemoteViews =
+        RemoteViews(context.packageName, R.layout.widget_vehicle_home).apply {
+            setTextViewText(R.id.widget_vehicle_name, snapshot.displayName)
+            setTextViewText(R.id.widget_soc, VehicleWidgetTruthText.soc(snapshot))
+            setTextViewText(
+                R.id.widget_mileage,
+                snapshot.currentMileageKm?.let(::formatMileage) ?: "-- km",
+            )
+            setTextViewText(
+                R.id.widget_state_label,
+                VehicleWidgetTruthText.stateLabel(snapshot) { timestamp ->
+                    DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
+                        .format(Date(timestamp))
+                },
+            )
+            setTextViewText(R.id.widget_trip_action, VehicleWidgetTruthText.tripAction(snapshot))
+            setTextViewText(R.id.widget_app_action, VehicleWidgetTruthText.appAction(snapshot))
+
+            val openApp = PendingIntent.getActivity(
+                context,
+                REQUEST_OPEN_APP,
+                Intent(context, MainActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            val openTrip = PendingIntent.getActivity(
+                context,
+                REQUEST_OPEN_TRIP,
+                Intent(context, MainActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    .putExtra(MainActivity.EXTRA_OPEN_ACTIVE_TRIP, true),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+            setOnClickPendingIntent(R.id.widget_root, openApp)
+            setOnClickPendingIntent(R.id.widget_trip_action, openTrip)
+            setOnClickPendingIntent(R.id.widget_app_action, openApp)
+        }
+
+    private fun formatMileage(value: Double): String =
+        String.format(Locale.getDefault(), "%,.0f km", value)
+
+    private const val REQUEST_OPEN_APP = 30_100
+    private const val REQUEST_OPEN_TRIP = 30_101
+}

--- a/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetTruthText.kt
+++ b/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetTruthText.kt
@@ -1,0 +1,25 @@
+package com.evchargebook.widget
+
+/** Pure presentation rules that keep the Stage 1 widget honest about local vs live vehicle state. */
+object VehicleWidgetTruthText {
+    fun soc(snapshot: VehicleWidgetSnapshot): String =
+        snapshot.currentSoc?.let { "$it%" } ?: "--"
+
+    fun stateLabel(
+        snapshot: VehicleWidgetSnapshot,
+        formatTime: (Long) -> String,
+    ): String = when {
+        snapshot.activeTrip -> "行程记录中 · 本地状态"
+        snapshot.activeCharging -> "充电记录中 · 本地状态"
+        snapshot.stateUpdatedAtEpochMillis != null ->
+            "上次记录 · ${formatTime(snapshot.stateUpdatedAtEpochMillis)}"
+        snapshot.vehicleId != null -> "尚无车辆状态记录"
+        else -> "打开 App 添加车辆"
+    }
+
+    fun tripAction(snapshot: VehicleWidgetSnapshot): String =
+        if (snapshot.activeTrip) "打开行程" else "行程"
+
+    fun appAction(snapshot: VehicleWidgetSnapshot): String =
+        if (snapshot.activeCharging) "充电记录中" else "打开 App"
+}

--- a/android/app/src/main/res/drawable/widget_action_background.xml
+++ b/android/app/src/main/res/drawable/widget_action_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#232729" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_vehicle_background.xml
+++ b/android/app/src/main/res/drawable/widget_vehicle_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#151718" />
+    <corners android:radius="24dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#2B2F31" />
+</shape>

--- a/android/app/src/main/res/layout/widget_vehicle_home.xml
+++ b/android/app/src/main/res/layout/widget_vehicle_home.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_vehicle_background"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/widget_vehicle_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-medium"
+        android:maxLines="1"
+        android:text="EV Charge Book"
+        android:textColor="#F4F6F6"
+        android:textSize="15sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="6dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/widget_soc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="sans-serif-medium"
+            android:text="--"
+            android:textColor="#F4F6F6"
+            android:textSize="34sp" />
+
+        <TextView
+            android:id="@+id/widget_mileage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="end"
+            android:maxLines="1"
+            android:text="-- km"
+            android:textColor="#B7C0C1"
+            android:textSize="14sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_state_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="尚无车辆状态记录"
+        android:textColor="#8D989A"
+        android:textSize="12sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginTop="10dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/widget_trip_action"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/widget_action_background"
+            android:gravity="center"
+            android:text="行程"
+            android:textColor="#32F080"
+            android:textSize="13sp" />
+
+        <TextView
+            android:id="@+id/widget_app_action"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/widget_action_background"
+            android:gravity="center"
+            android:text="打开 App"
+            android:textColor="#DCE1E2"
+            android:textSize="13sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/xml/vehicle_widget_info.xml
+++ b/android/app/src/main/res/xml/vehicle_widget_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_vehicle_home"
+    android:minWidth="250dp"
+    android:minHeight="140dp"
+    android:minResizeWidth="180dp"
+    android:minResizeHeight="110dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/android/app/src/test/java/com/evchargebook/widget/VehicleWidgetTruthTextTest.kt
+++ b/android/app/src/test/java/com/evchargebook/widget/VehicleWidgetTruthTextTest.kt
@@ -1,0 +1,55 @@
+package com.evchargebook.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class VehicleWidgetTruthTextTest {
+    @Test
+    fun `unknown local state stays unavailable instead of inventing vehicle facts`() {
+        val snapshot = VehicleWidgetSnapshot(
+            vehicleId = 7L,
+            displayName = "C16",
+        )
+
+        assertEquals("--", VehicleWidgetTruthText.soc(snapshot))
+        assertEquals(
+            "尚无车辆状态记录",
+            VehicleWidgetTruthText.stateLabel(snapshot) { "should-not-be-used" },
+        )
+    }
+
+    @Test
+    fun `known state is explicitly labeled as last local record`() {
+        val snapshot = VehicleWidgetSnapshot(
+            vehicleId = 7L,
+            displayName = "C16",
+            currentSoc = 74,
+            stateUpdatedAtEpochMillis = 1234L,
+        )
+
+        assertEquals("74%", VehicleWidgetTruthText.soc(snapshot))
+        val label = VehicleWidgetTruthText.stateLabel(snapshot) { "16:06" }
+        assertEquals("上次记录 · 16:06", label)
+        assertFalse(label.contains("实时"))
+        assertFalse(label.contains("车辆同步"))
+    }
+
+    @Test
+    fun `active trip and charging labels describe app bookkeeping only`() {
+        val trip = VehicleWidgetSnapshot(vehicleId = 7L, activeTrip = true)
+        val charging = VehicleWidgetSnapshot(vehicleId = 7L, activeCharging = true)
+
+        assertEquals("行程记录中 · 本地状态", VehicleWidgetTruthText.stateLabel(trip) { "16:06" })
+        assertEquals("打开行程", VehicleWidgetTruthText.tripAction(trip))
+        assertEquals("充电记录中 · 本地状态", VehicleWidgetTruthText.stateLabel(charging) { "16:06" })
+        assertEquals("充电记录中", VehicleWidgetTruthText.appAction(charging))
+    }
+
+    @Test
+    fun `empty app state asks user to add vehicle`() {
+        val snapshot = VehicleWidgetSnapshot()
+
+        assertEquals("打开 App 添加车辆", VehicleWidgetTruthText.stateLabel(snapshot) { "16:06" })
+    }
+}


### PR DESCRIPTION
Refs #301

## Summary

Stage 1 Local First home-screen widget. This deliberately does **not** wait for OEM/OBD telemetry and does not label app bookkeeping as live vehicle state.

- register a standard Android home-screen `AppWidgetProvider` with no OPPO/ColorOS private dependency;
- read only the selected local vehicle + `VehicleState` + active Trip/Charging session facts from Room;
- show nickname/model, known SOC, known mileage, and an explicit `上次记录` / `本地状态` label;
- keep unknown SOC/mileage unavailable (`--`) instead of deriving from rated range or battery capacity;
- refresh widget instances from Room invalidations for vehicle/state/Trip/Charging changes and once on app process startup;
- Trip action reuses the existing `MainActivity.EXTRA_OPEN_ACTIVE_TRIP` entry and never creates a Trip from the widget;
- root/secondary action opens the existing app. A dedicated direct `开始充电` navigation entry is intentionally deferred rather than duplicating Charging transaction/navigation logic in the widget;
- add pure JVM tests locking truthful wording (`上次记录`, no `实时`/`车辆同步` claims).

## Scope / truth boundary

- no Room/schema migration;
- no background polling/service/WorkManager;
- no network dependency;
- no Glance dependency required for this first platform-widget slice;
- no OEM range/SOC/BMS claims;
- no remote lock/HVAC/vehicle commands;
- no reading another app/widget.

## Current base / diff

Normalized after #308 onto `main@09b8608a95e0c6b6abf8909e40b5c3bf791b0d5d`.

- head `94a808f712fc9a91711b67b621f6d8188798fad7`
- ahead 1 / behind 0
- effective diff = exactly 9 widget/local-state files
- no Room migration / new permission / background polling

## Validation

- [x] JVM tests via Android Build #772 / run `33620675958`
- [x] `:app:assembleDebug` via same current-head run
- [x] Android CI Green on current synchronized head
- [x] Debug APK upload succeeded
- [ ] physical launcher add/remove + ColorOS/non-OPPO acceptance remains under #301

## Follow-up

After this foundation, the smallest follow-up can add an explicit Charging navigation entry behind the existing `MainViewModel`/Charging authority. Telemetry-aware values remain owned by #300 and must replace/augment the widget only with source + freshness semantics.