### PR TITLE
docs(charging): sync v0.7 authority to current main

### DIFF
--- a/docs/CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/docs/CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1,83 +1,159 @@
 # EV Charge Book Charging v0.7 Design and Implementation Plan
 
 Status: Authority for #251
-Updated: 2026-08-31
+Updated: 2026-09-02
+Current implementation baseline: `main@86f5e69152480546e69ed2b90cb9e62afcc63dd3`
 
 ## 1. Purpose
 
-Charging v0.7 evolves the current completed-record ledger into a broader Local First charging workflow **without removing manual charging record maintenance**.
+Charging v0.7 evolves the completed-record ledger into a broader Local First charging workflow **without removing manual charging record maintenance**.
 
 The approved product model has two parallel creation paths:
 
-1. `开始充电` — optional lifecycle recording / preset flow.
-2. `充电记录维护` — manual add, backfill and edit of completed charging facts.
+1. `开始充电` — optional local lifecycle bookkeeping.
+2. `充电记录维护` — independent manual add / backfill / edit of completed charging facts.
 
-A user must never be forced to start a live/local charging session just to maintain a historical record.
+A user must never be forced to start a charging session just to maintain a historical record.
 
-This document extends the v0.6 Records baseline. It does not rewrite the existing v0.6 visual closeout owned by #159/#164.
+This document extends the v0.6 Records baseline. It does not rewrite the v0.6 visual closeout owned by #159/#164.
 
 ## 2. Locked UX principles
 
 ### 2.1 Records overview
 
-Keep Dark First visual language, compact density and restrained spacing. Preserve useful range tabs. Add a truthful `充电中` state only when an active local charging session exists. Keep the ledger summary and dense historical charging list.
+Keep the compact Dark First visual language and restrained spacing. Preserve the ledger summary and dense historical list.
 
 Expose two sibling primary entries:
 
 - `开始充电`
 - `充电记录维护`
 
-`开始充电` is not a replacement for manual maintenance.
+When a local active session exists, Records may show one compact `充电中` card. When physical charging has ended but final meter/billing data is not yet available, Records shows a separate `待补录` section. Pending sessions are not completed charging records and do not enter completed count, kWh, cost, average-price or interval statistics.
 
 ### 2.2 Completed charging detail
 
-A completed charging record gets a dedicated detail surface.
+A dedicated completed charging detail surface remains a product option under #251; do not infer that it is shipped merely because Add/Edit maintenance exists.
 
-Primary facts may include location / charger type, total cost, billed or meter energy, effective unit price, start time, end time when present, start/end SOC when explicitly entered, odometer/mileage facts and notes.
+If/when rendered, primary facts may include location / charger type, total cost, billed or meter energy, effective unit price, start/end time, explicitly known start/end SOC, odometer and notes.
 
-Derived facts may include duration, average charging power and charging-loss estimate. Derived facts are shown only when inputs are sufficient and semantically compatible.
+Derived facts may include duration, average charging power and charging-loss estimate. They must use the centralized calculation contract and appear only when inputs are sufficient and semantically compatible.
 
 ### 2.3 Manual maintenance
 
-Manual record maintenance remains fully supported: add historical record, edit existing record, backfill missing completion facts, edit start SOC/time, edit end time/address, and edit billed energy/cost/unit price through the coupled-field rules.
+Manual record maintenance remains first-class and independent of active-session lifecycle. Add/Edit uses the shared billing editor and must preserve raw typing/cursor stability.
 
-The production UI must not expose internal/debug labels such as `手动输入`, `自动计算`, `自动带入` beside every field. Show `估算` only when it is a user-relevant semantic distinction.
+Production UI must not expose internal/debug labels such as `手动输入`, `自动计算`, or `自动带入` beside every field. Show `估算` only when it is a user-relevant truth distinction.
 
 ## 3. Data-truth boundary
 
-The app currently does not have an authoritative live SOC feed. Do not display a fake current SOC as if read from the car. Start/end SOC are manual/external facts unless a future authoritative source exists. Target SOC is user intent, not measurement.
+The app does not have an authoritative live SOC/BMS feed. Do not display a fake current SOC as if read from the car. Start/end SOC are manual/external facts unless a future authoritative source exists. Target SOC is intent, not measurement.
 
-Use the currently selected vehicle automatically when entering charging flows, while still allowing explicit switching where appropriate.
+Current app VehicleState may be used as an editable candidate only. Finish prefill must not substitute target SOC for actual end SOC.
 
-Start time defaults to now and remains editable. End time on completion defaults to now and remains editable. Duration is derived from start/end time.
+Start time defaults to now and remains editable. End time defaults to now and remains editable. Duration is derived from start/end time.
 
-Location defaults to the current real coordinate fix when permission/provider is available. Persist latitude, longitude, accuracy and a readable address when reverse geocoding succeeds. Address text remains editable. If reverse geocoding fails, retain coordinates and allow manual address maintenance. Interactive map-point selection remains under #254.
+Location defaults to a real coordinate fix when permission/provider is available. Persist latitude, longitude, accuracy and a readable address when reverse geocoding succeeds. If the user edits address text manually, stale coordinate evidence must be cleared. Interactive map-point selection remains under #254.
 
-## 4. Optional start-charge lifecycle
+Unknown meter energy / cost must remain missing. Never encode unknown as `0`.
 
-`开始充电` is bookkeeping only. It does not remotely control a charger or vehicle.
+SOC-delta × known battery capacity may be displayed as a vehicle-energy **estimate**. It is not measured/BMS vehicle-side energy and must not be persisted or relabeled as such without an authoritative source.
 
-Default inputs may include the current selected vehicle, start time = now, current real location and remembered charger/price defaults. Editable inputs may include manual start SOC, optional target SOC, charger type, price rule/unit price, address and notes.
+## 4. Current merged lifecycle
 
-`保存为预设` stores reusable environment inputs only. It must not pre-commit future actual meter energy, end time, final cost or end SOC as facts.
+### 4.1 Calculation and manual editor
 
-If an active local charging session exists, Records may show one compact `充电中` card containing only known or derivable local facts. Do not show fake live SOC, fake live power or fake BMS energy.
+Merged authority:
 
-Completion opens the same mature record editor with known start facts prefilled and completion facts pending.
+- #268 — centralized `ChargeCalculationEngine` and focused tests.
+- #261 — shared `ChargeBillingEditor` adopted by Add/Edit.
 
-## 5. Coupled-field calculation rules
-
-Authority issue: #252.
-
-Product priority:
+Billing priority:
 
 ```text
 total cost > unit price > billed/meter energy
 ```
 
-When the user edits total cost, keep a valid unit price stable and recompute billed energy. When the user edits unit price, keep total cost stable and recompute billed energy. When the user edits billed energy, do not silently overwrite higher-priority user facts; update lower-priority derived outputs and surface an explicit inconsistency when the trio no longer agrees.
+Authoritative user facts and calculated dependants remain distinct. Repeated edits must not accumulate display-rounding drift. Conflicting authoritative facts stay visible as a conflict instead of oscillating.
 
-The editor must avoid bidirectional recomposition loops and rounding drift. Formulas belong in one pure domain/state component, not duplicated across Composables.
+### 4.2 Persistence and exactly-once transaction
+
+Merged #271 provides durable charging-session persistence and the transaction authority for completion.
+
+The lifecycle now includes:
+
+```text
+ACTIVE -> COMPLETED
+ACTIVE -> PENDING_DETAILS -> COMPLETED
+ACTIVE -> CANCELLED
+PENDING_DETAILS -> CANCELLED   (explicit discard, no historical row)
+```
+
+Key rules:
+
+- reject a second ACTIVE session for the same vehicle;
+- persist edits to known ACTIVE facts;
+- completion creates exactly one `ChargingRecordEntity` and links it to the session;
+- repeated completion/backfill returns the already-created result rather than inserting a duplicate;
+- cancel/discard creates no completed historical record;
+- pending end SOC/odometer may participate in VehicleState reconstruction while pending billing remains excluded from completed statistics.
+
+### 4.3 Start / active UI
+
+Merged #276 provides:
+
+- separate `开始充电` and `充电记录维护` entries;
+- editable start time;
+- editable start SOC / optional target SOC;
+- charger type / price inputs;
+- current-location capture with editable address fallback;
+- persisted compact `充电中` card;
+- edit active session;
+- explicit cancel.
+
+No fake live SOC/power/BMS telemetry is shown.
+
+### 4.4 Completion UI
+
+Merged #277 provides the active-session finish flow:
+
+- editable end time;
+- actual end SOC confirmation;
+- target SOC remains reference-only;
+- shared billing editor for cost / price / meter energy;
+- exactly-once repository transaction remains completion authority;
+- editing location clears stale coordinate evidence.
+
+### 4.5 Delayed home-meter backfill
+
+Merged #297 adds the truthful next-day-meter path:
+
+- physical charging can end even when meter/grid usage is not yet available;
+- known end facts persist as `PENDING_DETAILS`;
+- unknown meter/cost stays null;
+- a meter value derived only from other billing fields is not accepted as a physical meter reading;
+- only user-confirmed meter/charger kWh may finalize the completed record;
+- pending releases the ACTIVE slot so a later charge can start;
+- backfill finalizes exactly once;
+- explicit pending delete produces no historical row.
+
+Merged #302 adds `修改结束信息` for pending sessions:
+
+- edit end time;
+- edit end SOC;
+- edit location;
+- edit ending odometer;
+- preserve pending billing facts;
+- rebuild VehicleState after correction.
+
+### 4.6 UI command boundary
+
+Merged #305 routes selected-vehicle pending state and complete/defer/update-pending/backfill/discard commands through `MainViewModel`.
+
+`RecordsScreen` and `CompleteChargingScreen` no longer construct `AppDatabase`, `ChargingRepository`, or Room DAO access. Existing repository/session transactions remain the only persistence authority.
+
+## 5. Derived calculation contract
+
+Authority issue: #252.
 
 Derived duration:
 
@@ -85,7 +161,7 @@ Derived duration:
 duration = endTime - startTime
 ```
 
-If endTime <= startTime, duration is unavailable/invalid.
+If `endTime <= startTime`, duration is unavailable/invalid.
 
 Derived average power:
 
@@ -95,46 +171,94 @@ averagePowerKw = billedEnergyKwh / durationHours
 
 This is an energy/time average, not charger telemetry or peak power.
 
-Charging-loss estimate, only when compatible meter and vehicle-side energy exist:
+Charging loss, only when compatible meter and vehicle-side energy exist:
 
 ```text
 lossRate = (meterEnergy - vehicleEnergy) / meterEnergy * 100%
 ```
 
-Guardrails: meter energy <= 0 -> unavailable; vehicle energy < 0 -> unavailable; vehicle energy > meter energy -> inconsistent; SOC-derived vehicle energy remains estimated and must not be relabeled as BMS measurement.
+Guardrails:
 
-## 6. Current implementation baseline
+- meter energy <= 0 -> unavailable;
+- vehicle energy < 0 -> unavailable;
+- vehicle energy > meter energy -> inconsistent;
+- SOC-derived vehicle energy remains estimate semantics and cannot become measured vehicle-side energy.
 
-The current completed-record model stores vehicle identity, one charge timestamp, energy, cost, start/end SOC, charger type, location, remark, odometer and optional coordinates/accuracy. It does not yet represent active-session lifecycle, explicit end time, explicit vehicle-side energy or presets.
+Any future completed-record detail/analysis display must consume this shared contract rather than introduce a second formula path.
 
-The existing Add Record flow already provides useful foundations: now-time default, current-location request/reverse geocoding, manual location fallback, recent defaults, partial energy/price/cost coupling and dirty-form protection. Reuse these foundations.
+## 6. Preset boundary
 
-As of 2026-08-31, Draft PR #258 establishes the first pure calculation-engine code slice for #252. It is not yet runtime authority until merged, and it does not by itself complete #252 because Add/Edit UI/state adoption remains required.
+Preset persistence/UX is **not currently shipped** and remains a decision under #253/#251.
+
+If retained in v0.7, a preset may store reusable environment inputs such as charger context, price defaults and location labels. It must never pre-commit future actual meter energy, end time, end SOC or final cost.
+
+Do not block truthful active/pending lifecycle code on a speculative preset implementation. Resolve preset scope explicitly before #253/#251 close.
 
 ## 7. Implementation ownership
 
-- #251 — parent product/implementation owner
-- #252 — centralized coupled calculation engine + derived metrics
-- #253 — optional active charging / preset lifecycle and persistence
-- #254 — current-location behavior + future map-point picker
-- #14 — existing Location / Geocoder physical acceptance foundation
-- #42 — accessibility / dirty forms / state safety
-- #159 / #164 — v0.6 Records visual closeout only
+- #251 — parent product / end-to-end acceptance owner.
+- #252 — centralized coupled calculation + truthful derived metrics.
+- #253 — active / pending / completion lifecycle and physical acceptance.
+- #260 — Add/Edit editor physical acceptance.
+- #289 — compact Start/Finish + delayed-meter physical feedback acceptance.
+- #254 — current-location behavior + future map-point picker.
+- #14 — Location / Geocoder physical acceptance foundation.
+- #42 — accessibility / dirty forms / state safety.
+- #159 / #164 — v0.6 Records visual closeout only.
+- #6 — documentation/status authority maintenance.
 
-Implementation order should preserve small slices: authority/model design -> calculation engine -> persistence/session migration -> Records overview/detail/manual maintenance -> optional start-charge/preset UI -> location/map follow-up -> migration/backup + physical acceptance.
+Merged implementation evidence:
+
+- #268 — calculation engine.
+- #261 — Add/Edit billing editor.
+- #271 — charging persistence / exactly-once foundation.
+- #276 — Start / Active UI.
+- #277 — completion UI.
+- #297 — delayed-meter pending lifecycle.
+- #302 — pending end-fact revision.
+- #305 — MainViewModel lifecycle boundary.
 
 ## 8. Migration and backup requirements
 
-Before persistence changes land, define the schema migration path, historical-field semantics and backup compatibility. Do not synthesize fake historical end times. Restore must not duplicate active/completed charging sessions.
+Historical fields must remain truthful; migrations must not synthesize fake end time, vehicle-side energy, meter energy or cost.
 
-## 9. Acceptance
+Backup must include charging sessions and extended completed-record facts. Restore must not duplicate active/pending/completed sessions and must remain blocked while local unfinished lifecycle state would make overwrite unsafe.
 
-Data truth: no fake live SOC/BMS/power values; missing facts remain missing; derived metrics follow sufficient inputs only.
+Automated migration/backup tests are evidence, but real historical-install/database-open behavior remains a physical acceptance gate under #253.
 
-Editing maturity: cost/price/energy precedence is deterministic; time changes refresh duration/power; dependent loss/power refresh without value flicker; repeated edits do not accumulate rounding drift.
+## 9. Remaining acceptance
 
-Workflow: manual completed-record maintenance remains independent; optional start-charge remains independent; active session survives process recreation; completion produces one completed record; current vehicle/time/location defaults behave as specified.
+Implementation is no longer blocked on the old Draft PR stack. Remaining v0.7 closeout is mainly physical acceptance and explicit product-scope decisions.
 
-UI: compact Dark First hierarchy; no internal calculation/debug badges; 320–360dp and large-font usability; Light mode readable where supported.
+### Lifecycle/device
 
-Engineering: Android CI Green, migration tests Green, backup/restore tests Green, and no unrelated Trip/Hero/catalog rewrite.
+- ACTIVE survives force-stop/process-kill/relaunch;
+- active edits survive relaunch;
+- complete produces exactly one historical row;
+- repeated completion does not duplicate;
+- PENDING_DETAILS survives relaunch;
+- next-day backfill produces exactly one historical row;
+- pending end-fact revision persists truthfully;
+- cancel/discard produces no historical row;
+- backup/restore guards behave truthfully;
+- historical/current database opens on a real Android device.
+
+### UI/editor
+
+- Dark / Light readability;
+- 320–360dp width;
+- large font;
+- keyboard does not make primary actions unreachable;
+- raw decimal edits (`1.`, clear, retype) remain stable;
+- no P0 cursor jump, recomposition loop or value flicker;
+- back navigation / unsaved-edit behavior passes.
+
+### Product decisions
+
+- decide whether preset storage/UX is v0.7 or explicitly deferred;
+- decide whether a dedicated completed charging detail surface is still required for v0.7;
+- if duration / average power / loss are rendered, use the centralized derived contract and truthful labels.
+
+## 10. Status rule
+
+Current `main` is runtime authority. Merged PRs and current-head CI are implementation evidence. Open Issues own remaining acceptance/future work. CI Green does **not** substitute for physical-device acceptance.

--- a/docs/CURRENT_STATUS_AUTHORITY.md
+++ b/docs/CURRENT_STATUS_AUTHORITY.md
@@ -1,8 +1,8 @@
 # EV Charge Book Current Status Authority
 
-Updated: 2026-08-31
+Updated: 2026-09-02
 Status: Operational status authority
-Baseline: `main@e5149a6474a17c7a5ce0a987f04fc3ab38a143b0`
+Baseline: `main@86f5e69152480546e69ed2b90cb9e62afcc63dd3`
 
 ## Purpose
 
@@ -56,46 +56,52 @@ Current product/data authority:
 
 - #251 parent workflow and truth rules;
 - `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`;
-- #252 coupled calculation / derived metrics;
-- #260 Add/Edit linked billing adoption;
-- #253 optional active charging session / preset lifecycle;
+- #252 coupled calculation / truthful derived metrics;
+- #260 Add/Edit billing editor physical acceptance;
+- #253 active / pending / completion lifecycle physical acceptance;
+- #289 compact Start/Finish + delayed-meter physical feedback acceptance;
 - #254 current-location behavior / future map-point picker.
 
-#### PR #258 — pure calculation contract
+Current `main` implementation is no longer the old #258/#261/#267 Draft stack. Merged authority now includes:
 
-Current parent state at this snapshot:
+- #268 — centralized calculation/provenance engine;
+- #261 — shared Add/Edit `ChargeBillingEditor` adoption;
+- #271 — durable charging-session persistence + exactly-once completion foundation;
+- #276 — separate `开始充电` / `充电记录维护`, Start screen and persisted active card;
+- #277 — completion UI;
+- #297 — truthful `PENDING_DETAILS` delayed-meter lifecycle, backfill and explicit pending delete;
+- #302 — `修改结束信息` for pending end time/SOC/location/odometer;
+- #305 — pending state and complete/defer/update-pending/backfill/discard commands routed through `MainViewModel`; Records/Completion UI no longer constructs database/repository/Room access.
 
-- Draft;
-- current head `b506b749a6cea7041b4825b80b83ed9455b4196e`;
-- comparison to baseline `main@e5149a6` is **ahead 10 / behind 0**;
-- effective diff remains only `ChargeCalculationEngine.kt` + focused test;
-- prior head Android Build #626 was Green;
-- synchronized-head Android Build #637 is running at the time of this snapshot.
+Key current truth rules:
 
-Durable merge gate: the current synchronized head needs successful current-head Android CI and unchanged intended diff before Ready/Merge. Historical #626 Green does not authorize the new head.
+- no fake live SOC/BMS/charger-power telemetry;
+- target SOC is intent, not actual end SOC;
+- unknown meter/cost remains null, never fake zero;
+- only user-confirmed meter/charger kWh may finalize a completed record;
+- a kWh value derived only from cost/price linkage is not a physical meter fact;
+- pending physical charge-end facts may update VehicleState but pending does not enter completed charging statistics;
+- completion/backfill remains exactly-once under repository/session transaction authority;
+- manual completed-record maintenance remains independent of active-session lifecycle;
+- SOC-delta × battery capacity is display-only vehicle-energy estimate, not measured/BMS truth.
 
-#### PR #261 — stacked Add/Edit billing adoption
+Architecture follow-up #285 is completed/closed after #305. Do not reopen it to duplicate transaction logic.
 
-Current child state:
+Remaining Charging v0.7 gates are primarily physical acceptance / explicit scope decisions:
 
-- Draft;
-- child head `c805ba3150576b57dc2cd74631edc09e0a8b8c44`;
-- base branch name is still the #258 calculation branch;
-- the child was built against the older #258 parent head;
-- Android Build #630 was Green for that older stack relationship;
-- after #258 synchronized to current `main`, comparison to the **new parent branch** is now diverged/behind;
-- intended child diff remains editor state/tests plus `AddRecordScreen.kt` and `RecordEditScreen.kt` adoption.
+- real historical/current Android database-open migration pass;
+- ACTIVE process-kill/relaunch and active-edit persistence;
+- complete exactly once / retry no duplicate;
+- PENDING_DETAILS process-kill/relaunch + next-day backfill exactly once;
+- pending end-fact revision + VehicleState truth;
+- cancel/delete produce no historical record;
+- active/pending backup and restore guards;
+- current vehicle/time/location defaults;
+- Dark/Light, 320–360dp, large font, keyboard/decimal/back-navigation acceptance;
+- preset decision: implement reusable environment-only presets or explicitly defer them from v0.7;
+- completed-detail / derived-metric presentation decision if still required by final v0.7 UX.
 
-Required order:
-
-1. finish current-head validation/review for #258;
-2. resolve/merge #258 first;
-3. normalize #261 onto the surviving `main` base using the normal code-maintenance workflow;
-4. re-read #261 effective diff;
-5. obtain current-head Android CI for the normalized child;
-6. only then decide Ready/Merge for #261.
-
-Do not delete the #258 branch while #261 still depends on it.
+#253/#289 remain Open because CI Green is not physical lifecycle acceptance. #252/#260 remain Open for their editor/derived-metric physical gates.
 
 ### Vehicle maturity / catalog / resource onboarding — #244 and #20
 
@@ -225,10 +231,17 @@ Completed in the 2026-08-31 audit:
 - README/LICENSE/templates/branch-stack rules merged by #263;
 - #75 rewritten to exact current branch-protection/CI target;
 - #265 created for stale-branch cleanup/merge-time deletion;
-- #258/#261/#260/#251 descriptions synchronized to actual stacked behavior;
 - PR #264 resource workbench / Hero theme-variant baseline incorporated into current authority.
 
-Remaining documentation debt after this authority-sync PR:
+Charging authority normalized 2026-09-02:
+
+- #268/#261/#271/#276/#277/#297/#302/#305 recorded as merged runtime authority;
+- #285 closed as completed architecture cleanup;
+- #251/#253/#289 normalized through status comments to distinguish merged implementation from physical acceptance;
+- old #258/#261 stacked-candidate prose removed from this fast-status file;
+- `CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md` updated to current lifecycle truth.
+
+Remaining documentation debt:
 
 - reconcile older Trip/UI acceptance Issues that still call historical SHAs “latest main”;
 - narrow old #70 local-Hero/model-whitelist wording to physical visual closeout;


### PR DESCRIPTION
Docs/status governance under #6. No runtime code changes.

## Why
Charging v0.7 authority had drifted behind current `main`: the design plan still described Draft #258 as the first calculation slice and said active-session lifecycle/end-time/vehicle-energy were not represented; `CURRENT_STATUS_AUTHORITY.md` still described #258/#261 as the active Draft stack.

## Normalize to current main
Baseline: `main@86f5e69152480546e69ed2b90cb9e62afcc63dd3`

Merged Charging authority now recorded:
- #268 calculation engine
- #261 Add/Edit billing editor
- #271 persistence / exactly-once foundation
- #276 Start / Active UI
- #277 completion UI
- #297 delayed-meter `PENDING_DETAILS` lifecycle
- #302 pending `修改结束信息`
- #305 MainViewModel lifecycle boundary

Remaining work is stated as physical acceptance / explicit product decisions rather than missing implementation:
- migration/device-open
- ACTIVE/PENDING process recreation
- exactly-once completion/backfill physical pass
- cancel/delete/backup/restore truth
- narrow/large-font/Dark-Light/keyboard editing acceptance
- preset scope decision
- completed-detail/derived-metric presentation decision if still required

## Effective diff
Exactly 2 Markdown files:
- `docs/CHARGING_V0.7_DESIGN_AND_IMPLEMENTATION_PLAN.md`
- `docs/CURRENT_STATUS_AUTHORITY.md`

No schema, Kotlin, workflow, or product-runtime change.

Related: #6 #251 #252 #253 #260 #289 #285 #305.