### PR TITLE
feat(android): define vehicle telemetry provider contract

### DIFF
--- a/android/app/src/main/java/com/evchargebook/vehicle/telemetry/VehicleTelemetry.kt
+++ b/android/app/src/main/java/com/evchargebook/vehicle/telemetry/VehicleTelemetry.kt
@@ -1,0 +1,218 @@
+package com.evchargebook.vehicle.telemetry
+
+import com.evchargebook.data.entity.VehicleEntity
+
+/**
+ * Read-only vehicle facts supplied by an explicitly configured provider.
+ *
+ * This contract does not grant permission to update VehicleState, Trip history or Charging history.
+ * A later resolver owns any business-state integration after real source validation.
+ */
+interface VehicleTelemetryProvider {
+    val providerId: String
+
+    suspend fun capabilities(vehicle: VehicleEntity): VehicleTelemetryCapabilities
+
+    suspend fun readSnapshot(vehicle: VehicleEntity): VehicleTelemetryReadResult
+}
+
+enum class VehicleTelemetryField {
+    SOC_PERCENT,
+    ODOMETER_KM,
+    ESTIMATED_RANGE_KM,
+    CHARGING_STATE,
+    CHARGING_POWER_KW,
+    PLUG_STATE,
+    LOCK_STATE,
+}
+
+data class VehicleTelemetryCapabilities(
+    val supportedFields: Set<VehicleTelemetryField>,
+    val supportsSnapshotCaptureTime: Boolean = false,
+    val supportsFieldCaptureTime: Boolean = false,
+    val requiresNetwork: Boolean = false,
+    val requiresExternalHardware: Boolean = false,
+    val minimumRefreshIntervalMillis: Long? = null,
+) {
+    init {
+        require(minimumRefreshIntervalMillis == null || minimumRefreshIntervalMillis >= 0L) {
+            "minimumRefreshIntervalMillis must be non-negative"
+        }
+    }
+}
+
+enum class TelemetryValueSemantic {
+    /** Direct/local measurement such as a decoded read-only OBD value. */
+    DIRECT_MEASUREMENT,
+
+    /** A factual state/value reported by an authorized provider. */
+    PROVIDER_REPORTED,
+
+    /** A provider/manufacturer estimate; never use as a measured energy/SOC substitute. */
+    OEM_ESTIMATE,
+}
+
+/**
+ * Field-level value metadata prevents one freshly updated field from making older fields look fresh.
+ * `resolution` is the smallest known meaningful step in the field's native unit when known.
+ */
+data class TelemetryValue<T>(
+    val value: T,
+    val capturedAtEpochMillis: Long? = null,
+    val resolution: Double? = null,
+    val semantic: TelemetryValueSemantic = TelemetryValueSemantic.PROVIDER_REPORTED,
+) {
+    init {
+        require(resolution == null || (resolution.isFinite() && resolution > 0.0)) {
+            "resolution must be finite and positive"
+        }
+    }
+}
+
+enum class VehicleChargingState {
+    NOT_CHARGING,
+    CHARGING,
+    COMPLETE,
+    UNKNOWN,
+}
+
+enum class VehiclePlugState {
+    DISCONNECTED,
+    CONNECTED,
+    UNKNOWN,
+}
+
+enum class VehicleLockState {
+    UNLOCKED,
+    LOCKED,
+    UNKNOWN,
+}
+
+/**
+ * One provider read. Provider/account/device identity must be opaque metadata, never an auth token,
+ * client certificate or secret copied into persistence/logging.
+ */
+data class VehicleTelemetrySnapshot(
+    val vehicleId: Long,
+    val providerId: String,
+    val providerVehicleIdentity: String? = null,
+    val snapshotCapturedAtEpochMillis: Long? = null,
+    val receivedAtEpochMillis: Long,
+    val socPercent: TelemetryValue<Double>? = null,
+    val odometerKm: TelemetryValue<Double>? = null,
+    val estimatedRangeKm: TelemetryValue<Double>? = null,
+    val chargingState: TelemetryValue<VehicleChargingState>? = null,
+    val chargingPowerKw: TelemetryValue<Double>? = null,
+    val plugState: TelemetryValue<VehiclePlugState>? = null,
+    val lockState: TelemetryValue<VehicleLockState>? = null,
+) {
+    init {
+        require(vehicleId > 0L) { "vehicleId must be positive" }
+        require(providerId.isNotBlank()) { "providerId must not be blank" }
+        require(receivedAtEpochMillis > 0L) { "receivedAtEpochMillis must be positive" }
+        require(socPercent == null || (socPercent.value.isFinite() && socPercent.value in 0.0..100.0)) {
+            "SOC must be finite and within 0..100"
+        }
+        require(odometerKm == null || (odometerKm.value.isFinite() && odometerKm.value >= 0.0)) {
+            "odometer must be finite and non-negative"
+        }
+        require(
+            estimatedRangeKm == null ||
+                (estimatedRangeKm.value.isFinite() && estimatedRangeKm.value >= 0.0)
+        ) {
+            "estimated range must be finite and non-negative"
+        }
+        require(
+            estimatedRangeKm == null ||
+                estimatedRangeKm.semantic == TelemetryValueSemantic.OEM_ESTIMATE
+        ) {
+            "estimated range must remain estimate semantics"
+        }
+        require(
+            chargingPowerKw == null ||
+                (chargingPowerKw.value.isFinite() && chargingPowerKw.value >= 0.0)
+        ) {
+            "charging power must be finite and non-negative"
+        }
+    }
+
+    fun availableFields(): Set<VehicleTelemetryField> = buildSet {
+        if (socPercent != null) add(VehicleTelemetryField.SOC_PERCENT)
+        if (odometerKm != null) add(VehicleTelemetryField.ODOMETER_KM)
+        if (estimatedRangeKm != null) add(VehicleTelemetryField.ESTIMATED_RANGE_KM)
+        if (chargingState != null) add(VehicleTelemetryField.CHARGING_STATE)
+        if (chargingPowerKw != null) add(VehicleTelemetryField.CHARGING_POWER_KW)
+        if (plugState != null) add(VehicleTelemetryField.PLUG_STATE)
+        if (lockState != null) add(VehicleTelemetryField.LOCK_STATE)
+    }
+}
+
+enum class VehicleTelemetryUnavailableReason {
+    NOT_SUPPORTED,
+    NOT_CONFIGURED,
+    AUTHORIZATION_REQUIRED,
+    OFFLINE,
+    VEHICLE_ASLEEP,
+    EXTERNAL_HARDWARE_MISSING,
+}
+
+sealed interface VehicleTelemetryReadResult {
+    data class Success(val snapshot: VehicleTelemetrySnapshot) : VehicleTelemetryReadResult
+
+    data class Unavailable(
+        val reason: VehicleTelemetryUnavailableReason,
+        val detail: String? = null,
+    ) : VehicleTelemetryReadResult
+
+    data class Failure(
+        val detail: String? = null,
+        val retryable: Boolean = true,
+    ) : VehicleTelemetryReadResult
+}
+
+enum class TelemetryTimeAuthority {
+    FIELD_CAPTURE_TIME,
+    SNAPSHOT_CAPTURE_TIME,
+    RECEIVE_TIME_ONLY,
+}
+
+data class TelemetryFreshness(
+    val observedAtEpochMillis: Long,
+    val ageMillis: Long,
+    val authority: TelemetryTimeAuthority,
+)
+
+/**
+ * Freshness is explicit about whether it is based on vehicle/provider capture time or only receipt.
+ */
+object VehicleTelemetryFreshness {
+    fun <T> evaluate(
+        snapshot: VehicleTelemetrySnapshot,
+        value: TelemetryValue<T>,
+        nowEpochMillis: Long,
+    ): TelemetryFreshness {
+        val fieldCapturedAt = value.capturedAtEpochMillis
+        val snapshotCapturedAt = snapshot.snapshotCapturedAtEpochMillis
+        val observedAt: Long
+        val authority: TelemetryTimeAuthority
+        when {
+            fieldCapturedAt != null -> {
+                observedAt = fieldCapturedAt
+                authority = TelemetryTimeAuthority.FIELD_CAPTURE_TIME
+            }
+            snapshotCapturedAt != null -> {
+                observedAt = snapshotCapturedAt
+                authority = TelemetryTimeAuthority.SNAPSHOT_CAPTURE_TIME
+            }
+            else -> {
+                observedAt = snapshot.receivedAtEpochMillis
+                authority = TelemetryTimeAuthority.RECEIVE_TIME_ONLY
+            }
+        }
+        return TelemetryFreshness(
+            observedAtEpochMillis = observedAt,
+            ageMillis = (nowEpochMillis - observedAt).coerceAtLeast(0L),
+            authority = authority,
+        )
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/vehicle/telemetry/VehicleTelemetryTest.kt
+++ b/android/app/src/test/java/com/evchargebook/vehicle/telemetry/VehicleTelemetryTest.kt
@@ -1,0 +1,125 @@
+package com.evchargebook.vehicle.telemetry
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VehicleTelemetryTest {
+    @Test
+    fun `fractional SOC is preserved and available fields are explicit`() {
+        val snapshot = VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            receivedAtEpochMillis = 2_000L,
+            socPercent = TelemetryValue(
+                value = 74.6,
+                capturedAtEpochMillis = 1_900L,
+                resolution = 0.1,
+            ),
+            odometerKm = TelemetryValue(value = 12_841.2, resolution = 0.1),
+        )
+
+        assertEquals(74.6, snapshot.socPercent?.value ?: 0.0, 0.0001)
+        assertEquals(
+            setOf(VehicleTelemetryField.SOC_PERCENT, VehicleTelemetryField.ODOMETER_KM),
+            snapshot.availableFields(),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `SOC outside physical percent bounds is rejected`() {
+        VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            receivedAtEpochMillis = 2_000L,
+            socPercent = TelemetryValue(100.1),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `remaining range cannot masquerade as measured truth`() {
+        VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            receivedAtEpochMillis = 2_000L,
+            estimatedRangeKm = TelemetryValue(
+                value = 394.0,
+                semantic = TelemetryValueSemantic.PROVIDER_REPORTED,
+            ),
+        )
+    }
+
+    @Test
+    fun `field capture time wins over snapshot and receive time`() {
+        val value = TelemetryValue(value = 74.6, capturedAtEpochMillis = 1_700L)
+        val snapshot = VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            snapshotCapturedAtEpochMillis = 1_800L,
+            receivedAtEpochMillis = 1_900L,
+            socPercent = value,
+        )
+
+        val freshness = VehicleTelemetryFreshness.evaluate(snapshot, value, nowEpochMillis = 2_000L)
+
+        assertEquals(TelemetryTimeAuthority.FIELD_CAPTURE_TIME, freshness.authority)
+        assertEquals(1_700L, freshness.observedAtEpochMillis)
+        assertEquals(300L, freshness.ageMillis)
+    }
+
+    @Test
+    fun `snapshot capture time is used when field timestamp is absent`() {
+        val value = TelemetryValue(value = 12_841.2)
+        val snapshot = VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            snapshotCapturedAtEpochMillis = 1_800L,
+            receivedAtEpochMillis = 1_900L,
+            odometerKm = value,
+        )
+
+        val freshness = VehicleTelemetryFreshness.evaluate(snapshot, value, nowEpochMillis = 2_000L)
+
+        assertEquals(TelemetryTimeAuthority.SNAPSHOT_CAPTURE_TIME, freshness.authority)
+        assertEquals(200L, freshness.ageMillis)
+    }
+
+    @Test
+    fun `receive time fallback is explicitly marked when capture time is unknown`() {
+        val value = TelemetryValue(value = VehiclePlugState.CONNECTED)
+        val snapshot = VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "obd",
+            receivedAtEpochMillis = 1_900L,
+            plugState = value,
+        )
+
+        val freshness = VehicleTelemetryFreshness.evaluate(snapshot, value, nowEpochMillis = 2_000L)
+
+        assertEquals(TelemetryTimeAuthority.RECEIVE_TIME_ONLY, freshness.authority)
+        assertEquals(100L, freshness.ageMillis)
+    }
+
+    @Test
+    fun `OEM estimated range remains displayable as estimate`() {
+        val snapshot = VehicleTelemetrySnapshot(
+            vehicleId = 1L,
+            providerId = "test-oem",
+            receivedAtEpochMillis = 2_000L,
+            estimatedRangeKm = TelemetryValue(
+                value = 394.0,
+                semantic = TelemetryValueSemantic.OEM_ESTIMATE,
+            ),
+        )
+
+        assertTrue(snapshot.availableFields().contains(VehicleTelemetryField.ESTIMATED_RANGE_KM))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `negative provider refresh interval is rejected`() {
+        VehicleTelemetryCapabilities(
+            supportedFields = emptySet(),
+            minimumRefreshIntervalMillis = -1L,
+        )
+    }
+}


### PR DESCRIPTION
Refs #300
Parent research: #138

## Summary

Pure domain/JVM foundation for future supported OEM or user-owned OBD telemetry. This PR deliberately adds **no provider implementation, credentials, network calls, Room table or VehicleState write path**.

- add `VehicleTelemetryProvider` capability/read contract;
- preserve fractional SOC as `Double` rather than rounding into current integer VehicleState;
- model field-level `TelemetryValue` metadata with capture time, resolution and truth semantic;
- keep OEM remaining range explicitly `OEM_ESTIMATE` so it cannot masquerade as measured energy/SOC truth;
- model odometer, charging state/power, plug and lock as optional fields only;
- distinguish field capture time -> snapshot capture time -> receive-time-only freshness authority;
- add explicit unavailable/failure outcomes for fail-closed adapters;
- add JVM tests for fractional SOC, invalid bounds, range estimate semantics, field freshness precedence and receive-time fallback.

## Truth / security boundary

- no unofficial Leapmotor client certificate/token/secret;
- no OPPO/private-app scraping;
- no digital-key reverse engineering;
- no remote command provider;
- no history mutation;
- no network dependency for normal Trip/Charging bookkeeping.

## Current base / diff

Normalized on `main@4ca6b2dd5be57cd63ecbae958069624df6897532`.

- head `1a9539aa0bf6f14b51c7485106dadb289260484a`
- ahead 1 / behind 0
- effective diff = exactly 2 new files
- mergeable = true
- no review threads / blocking reviews

## Validation

- [x] JVM tests via Android Build #770 / run `33620302348`
- [x] `:app:assembleDebug` via same current-head run
- [x] Debug APK upload succeeded
- [x] Android CI Green on current synchronized head

A real OEM/OBD adapter remains a later evidence-gated #300 slice. This contract alone does not authorize a production source.