### PR TITLE
fix(charging): keep reused prices location-safe

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
@@ -22,6 +22,9 @@ interface ChargingSessionDao {
     @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC")
     suspend fun getPendingForVehicle(vehicleId: Long): List<ChargingSessionEntity>
 
+    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status IN ('COMPLETED', 'PENDING_DETAILS') AND unitPricePerKwh IS NOT NULL AND unitPricePerKwh >= 0 ORDER BY COALESCE(endedAtEpochMillis, startedAtEpochMillis) DESC, updatedAtEpochMillis DESC")
+    fun observePricedForVehicle(vehicleId: Long): Flow<List<ChargingSessionEntity>>
+
     @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' AND endSoc IS NOT NULL ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC LIMIT 1")
     suspend fun getLatestPendingWithEndSocForVehicle(vehicleId: Long): ChargingSessionEntity?
 

--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicy.kt
@@ -1,0 +1,87 @@
+package com.evchargebook.ui.records
+
+import java.util.Locale
+
+internal data class ChargingPriceMemory(
+    val pricePerKwh: Double,
+    val chargerType: String?,
+    val location: String?,
+    val timestampEpochMillis: Long,
+    /** True only for a price explicitly stored on a charging session, not cost / energy. */
+    val isStoredTariff: Boolean,
+)
+
+internal object ChargingPriceSuggestionPolicy {
+    fun autoFillPrice(
+        chargerType: String,
+        location: String,
+        memories: List<ChargingPriceMemory>,
+    ): Double? {
+        val typeKey = normalizeType(chargerType) ?: return null
+        val locationKey = normalizeLocation(location) ?: return null
+        return memories
+            .asSequence()
+            .filter { it.isStoredTariff && it.pricePerKwh >= 0.0 }
+            .filter { normalizeType(it.chargerType) == typeKey }
+            .filter { normalizeLocation(it.location) == locationKey }
+            .sortedByDescending { it.timestampEpochMillis }
+            .map { it.pricePerKwh }
+            .firstOrNull()
+    }
+
+    fun suggestionPrices(
+        chargerType: String,
+        location: String,
+        memories: List<ChargingPriceMemory>,
+        limit: Int = 4,
+    ): List<Double> {
+        if (limit <= 0) return emptyList()
+        val typeKey = normalizeType(chargerType)
+        val locationKey = normalizeLocation(location)
+        val valid = memories
+            .asSequence()
+            .filter { it.pricePerKwh >= 0.0 }
+            .sortedByDescending { it.timestampEpochMillis }
+            .toList()
+
+        val tiers = listOf(
+            valid.filter {
+                it.isStoredTariff &&
+                    typeKey != null && normalizeType(it.chargerType) == typeKey &&
+                    locationKey != null && normalizeLocation(it.location) == locationKey
+            },
+            valid.filter {
+                it.isStoredTariff && typeKey != null && normalizeType(it.chargerType) == typeKey
+            },
+            valid.filter { it.isStoredTariff },
+            valid.filter {
+                !it.isStoredTariff && typeKey != null && normalizeType(it.chargerType) == typeKey
+            },
+            valid.filter { !it.isStoredTariff },
+        )
+
+        val result = mutableListOf<Double>()
+        val seen = mutableSetOf<Long>()
+        for (tier in tiers) {
+            for (memory in tier) {
+                val key = (memory.pricePerKwh * 1000.0).toLong()
+                if (seen.add(key)) {
+                    result += memory.pricePerKwh
+                    if (result.size == limit) return result
+                }
+            }
+        }
+        return result
+    }
+
+    internal fun normalizeLocation(value: String?): String? = value
+        ?.trim()
+        ?.replace(Regex("\\s+"), " ")
+        ?.lowercase(Locale.ROOT)
+        ?.takeIf { it.isNotEmpty() }
+
+    private fun normalizeType(value: String?): String? = value
+        ?.trim()
+        ?.lowercase(Locale.ROOT)
+        ?.takeIf { it.isNotEmpty() }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/records/StartChargingScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/StartChargingScreen.kt
@@ -87,6 +87,7 @@ fun StartChargingScreen(
     val scope = rememberCoroutineScope()
     val database = remember(context) { AppDatabase.getInstance(context.applicationContext) }
     val recentRecords by database.chargingRecordDao().observeForVehicle(vehicle.id).collectAsState(initial = emptyList())
+    val pricedSessions by database.chargingSessionDao().observePricedForVehicle(vehicle.id).collectAsState(initial = emptyList())
     val locationProvider = remember(context) { AndroidLocationProvider(context.applicationContext) }
     val addressResolver = remember(context) { AndroidGeocoderAddressResolver(context.applicationContext) }
 
@@ -114,24 +115,53 @@ fun StartChargingScreen(
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
     val isEditing = existingSession != null
-    val recentPriceChoices = remember(recentRecords, chargerType) {
-        recentRecords
-            .asSequence()
-            .filter { it.energyKwh > 0.0 && it.cost >= 0.0 }
-            .filter { chargerType.isBlank() || it.chargerType == chargerType }
-            .map { it.pricePerKwh }
-            .filter { it >= 0.0 }
-            .distinctBy { (it * 1000).toLong() }
-            .take(4)
-            .toList()
+    val priceMemories = remember(pricedSessions, recentRecords) {
+        buildList {
+            pricedSessions.forEach { session ->
+                val price = session.unitPricePerKwh ?: return@forEach
+                add(
+                    ChargingPriceMemory(
+                        pricePerKwh = price,
+                        chargerType = session.chargerType,
+                        location = session.location,
+                        timestampEpochMillis = session.endedAtEpochMillis ?: session.startedAtEpochMillis,
+                        isStoredTariff = true,
+                    )
+                )
+            }
+            recentRecords.forEach { record ->
+                if (record.energyKwh > 0.0 && record.cost >= 0.0) {
+                    add(
+                        ChargingPriceMemory(
+                            pricePerKwh = record.pricePerKwh,
+                            chargerType = record.chargerType,
+                            location = record.location,
+                            timestampEpochMillis = record.endedAtEpochMillis ?: record.chargeTimeEpochMillis,
+                            isStoredTariff = false,
+                        )
+                    )
+                }
+            }
+        }
+    }
+    val recentPriceChoices = remember(priceMemories, chargerType, location) {
+        ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = chargerType,
+            location = location,
+            memories = priceMemories,
+        )
+    }
+    val autoFillPrice = remember(priceMemories, chargerType, location) {
+        ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = chargerType,
+            location = location,
+            memories = priceMemories,
+        )
     }
 
-    LaunchedEffect(chargerType, recentRecords, priceTouched, isEditing) {
-        if (!isEditing && !priceTouched && chargerType.isNotBlank()) {
-            val remembered = recentRecords.firstOrNull {
-                it.chargerType == chargerType && it.energyKwh > 0.0 && it.cost >= 0.0
-            }?.pricePerKwh
-            if (remembered != null) unitPrice = remembered.toEditableChargingNumber()
+    LaunchedEffect(autoFillPrice, priceTouched, isEditing) {
+        if (!isEditing && !priceTouched) {
+            unitPrice = autoFillPrice?.toEditableChargingNumber().orEmpty()
         }
     }
 
@@ -306,10 +336,7 @@ fun StartChargingScreen(
                 ActiveChargingTypes.forEach { type ->
                     FilterChip(
                         selected = chargerType == type,
-                        onClick = {
-                            chargerType = type
-                            priceTouched = false
-                        },
+                        onClick = { chargerType = type },
                         label = { Text(type) },
                     )
                 }
@@ -474,7 +501,7 @@ fun StartChargingScreen(
 @Composable
 private fun CompactFieldLabel(text: String) {
     Text(
-        text,
+        text = text,
         style = MaterialTheme.typography.labelMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         fontWeight = FontWeight.Medium,

--- a/android/app/src/test/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicyTest.kt
@@ -1,0 +1,124 @@
+package com.evchargebook.ui.records
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChargingPriceSuggestionPolicyTest {
+    @Test
+    fun `same normalized location and type may auto fill stored session tariff`() {
+        val memories = listOf(
+            memory(1.20, "家充", " 上海  奉贤 ", 100, storedTariff = true),
+            memory(1.35, "家充", "上海 奉贤", 200, storedTariff = true),
+        )
+
+        val result = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = " 家充 ",
+            location = "上海   奉贤",
+            memories = memories,
+        )
+
+        assertEquals(1.35, result!!, 0.000001)
+    }
+
+    @Test
+    fun `same type at another location is suggestion only`() {
+        val memories = listOf(
+            memory(0.72, "家充", "公司地库", 200, storedTariff = true),
+        )
+
+        val auto = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+        )
+        val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+        )
+
+        assertNull(auto)
+        assertEquals(listOf(0.72), suggestions)
+    }
+
+    @Test
+    fun `effective record price is never an automatic tariff`() {
+        val memories = listOf(
+            memory(1.18, "公共快充", "站点 A", 300, storedTariff = false),
+        )
+
+        val auto = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = "公共快充",
+            location = "站点 A",
+            memories = memories,
+        )
+        val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = "公共快充",
+            location = "站点 A",
+            memories = memories,
+        )
+
+        assertNull(auto)
+        assertEquals(listOf(1.18), suggestions)
+    }
+
+    @Test
+    fun `suggestions prioritize exact stored tariff then type tariff then effective prices`() {
+        val memories = listOf(
+            memory(1.40, "家充", "家", 100, storedTariff = true),
+            memory(1.10, "家充", "公司", 400, storedTariff = true),
+            memory(0.95, "公共快充", "其他", 500, storedTariff = true),
+            memory(1.30, "家充", "家", 600, storedTariff = false),
+        )
+
+        val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+        )
+
+        assertEquals(listOf(1.40, 1.10, 0.95, 1.30), suggestions)
+    }
+
+    @Test
+    fun `suggestions deduplicate prices across source tiers`() {
+        val memories = listOf(
+            memory(1.20, "家充", "家", 300, storedTariff = true),
+            memory(1.20, "家充", "公司", 200, storedTariff = true),
+            memory(1.20, "家充", "家", 100, storedTariff = false),
+        )
+
+        val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+        )
+
+        assertEquals(listOf(1.20), suggestions)
+    }
+
+    @Test
+    fun `location normalization trims collapses whitespace and ignores case`() {
+        assertEquals(
+            ChargingPriceSuggestionPolicy.normalizeLocation("  Garage   A  "),
+            ChargingPriceSuggestionPolicy.normalizeLocation("garage a"),
+        )
+        assertTrue(ChargingPriceSuggestionPolicy.normalizeLocation("   ") == null)
+    }
+
+    private fun memory(
+        price: Double,
+        type: String?,
+        location: String?,
+        timestamp: Long,
+        storedTariff: Boolean,
+    ) = ChargingPriceMemory(
+        pricePerKwh = price,
+        chargerType = type,
+        location = location,
+        timestampEpochMillis = timestamp,
+        isStoredTariff = storedTariff,
+    )
+}


### PR DESCRIPTION
Implementation is complete on exact head `e22fe20e9e51e4a53c1727cc101ed9e4193eccdd`.

Final gate before metadata normalization:
- base `main@7700c14b3c81e7590617269104eef0924a1add64`
- ahead 1 / behind 0
- exactly 4 intended files
- GitHub mergeable=true
- Android Build #775 Green including Build/Test + Debug APK
- no review threads, submitted reviews, or PR comments

The connected Draft -> Ready mutation failed again on the known GitHub wrapper error: `Repository.fullDatabaseId` does not exist. This Draft PR is closed **only for metadata normalization**.

A non-Draft replacement will reuse this exact branch/head/base/diff. No code will be duplicated or rewritten.

Scope remains #289 price-reuse truth only; physical editing acceptance remains #289/#253.