### PR TITLE
feat(android): add Companion Device presence PoC

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-feature
+        android:name="android.software.companion_device_setup"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
@@ -10,6 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.REQUEST_OBSERVE_COMPANION_DEVICE_PRESENCE" />
+
     <application
         android:name=".EvChargeBookApplication"
         android:allowBackup="true"
@@ -40,6 +46,14 @@
             android:exported="false"
             android:foregroundServiceType="location"
             android:stopWithTask="false" />
+        <service
+            android:name=".vehicle.presence.CompanionVehiclePresenceService"
+            android:exported="true"
+            android:permission="android.permission.BIND_COMPANION_DEVICE_SERVICE">
+            <intent-filter>
+                <action android:name="android.companion.CompanionDeviceService" />
+            </intent-filter>
+        </service>
         <activity
             android:name=".autotrip.AutoTripConfirmationActivity"
             android:exported="false"

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/BluetoothPromptScreen.kt
@@ -83,6 +83,12 @@ fun BluetoothPromptScreen(
                 )
             }
             item {
+                CompanionPresencePocSection(
+                    deviceAddress = settings.deviceAddress,
+                    deviceName = settings.deviceName,
+                )
+            }
+            item {
                 Column {
                     Text("已配对设备", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
                     Text(

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/CompanionPresencePocSection.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/CompanionPresencePocSection.kt
@@ -1,7 +1,6 @@
 package com.evchargebook.ui.vehicle
 
 import android.app.Activity
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -10,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.evchargebook.ui.theme.spacing
@@ -47,11 +48,7 @@ fun CompanionPresencePocSection(
         val address = deviceAddress
         if (!address.isNullOrBlank()) {
             if (result.resultCode == Activity.RESULT_OK) {
-                val observationResult = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                    controller.ensureObservation(address)
-                } else {
-                    Result.success(Unit)
-                }
+                val observationResult = controller.ensureObservation(address)
                 status = controller.status(address)
                 resultText = observationResult.fold(
                     onSuccess = { "系统关联完成；等待真实连接/断开事件进行验收。" },
@@ -66,7 +63,9 @@ fun CompanionPresencePocSection(
 
     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(MaterialTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
         ) {
             Column(
@@ -98,7 +97,10 @@ fun CompanionPresencePocSection(
             }
 
             if (status.support == CompanionPresenceSupport.SUPPORTED) {
-                Row(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     if (status.associated && !deviceAddress.isNullOrBlank()) {
                         OutlinedButton(
                             onClick = {

--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/CompanionPresencePocSection.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/CompanionPresencePocSection.kt
@@ -1,0 +1,161 @@
+package com.evchargebook.ui.vehicle
+
+import android.app.Activity
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.evchargebook.ui.theme.spacing
+import com.evchargebook.vehicle.presence.CompanionDevicePresenceController
+import com.evchargebook.vehicle.presence.CompanionPresenceSupport
+
+@Composable
+fun CompanionPresencePocSection(
+    deviceAddress: String?,
+    deviceName: String?,
+) {
+    val context = LocalContext.current
+    val controller = remember(context) {
+        CompanionDevicePresenceController(context.applicationContext)
+    }
+    var status by remember(deviceAddress) {
+        mutableStateOf(controller.status(deviceAddress))
+    }
+    var resultText by remember(deviceAddress) { mutableStateOf<String?>(null) }
+
+    val approvalLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+        val address = deviceAddress
+        if (!address.isNullOrBlank()) {
+            if (result.resultCode == Activity.RESULT_OK) {
+                val observationResult = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    controller.ensureObservation(address)
+                } else {
+                    Result.success(Unit)
+                }
+                status = controller.status(address)
+                resultText = observationResult.fold(
+                    onSuccess = { "系统关联完成；等待真实连接/断开事件进行验收。" },
+                    onFailure = { it.message ?: "系统关联完成，但连接观察启用失败。" },
+                )
+            } else {
+                status = controller.status(address)
+                resultText = "系统关联已取消，原 ACL 蓝牙路径继续生效。"
+            }
+        }
+    }
+
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+            ) {
+                Text(
+                    "系统级连接观察 · 实验",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    "Companion Device 只增强 Android 对已绑定经典蓝牙连接事件的系统投递；不读取 SOC、续航、里程，也不代表已识别正在驾驶。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    when (status.support) {
+                        CompanionPresenceSupport.ANDROID_TOO_OLD -> "需要 Android 12 或更高版本；当前继续使用 ACL 检测。"
+                        CompanionPresenceSupport.FEATURE_MISSING -> "此设备没有 Companion Device Setup 能力；当前继续使用 ACL 检测。"
+                        CompanionPresenceSupport.SUPPORTED -> when {
+                            deviceAddress.isNullOrBlank() -> "先在上方选择一个已配对的车辆蓝牙。"
+                            status.associated -> "${deviceName ?: "当前车辆蓝牙"} 已完成系统关联。"
+                            else -> "可为 ${deviceName ?: "当前车辆蓝牙"} 建立系统关联，用于 #315 真机可靠性测试。"
+                        }
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (status.support == CompanionPresenceSupport.SUPPORTED) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    if (status.associated && !deviceAddress.isNullOrBlank()) {
+                        OutlinedButton(
+                            onClick = {
+                                controller.removeAssociation(deviceAddress)
+                                    .onSuccess {
+                                        status = controller.status(deviceAddress)
+                                        resultText = "系统关联已撤销；ACL 蓝牙路径仍保留。"
+                                    }
+                                    .onFailure {
+                                        resultText = it.message ?: "撤销系统关联失败。"
+                                    }
+                            },
+                        ) {
+                            Text("撤销系统关联")
+                        }
+                    } else {
+                        Button(
+                            enabled = !deviceAddress.isNullOrBlank(),
+                            onClick = {
+                                val address = deviceAddress ?: return@Button
+                                controller.requestAssociation(
+                                    deviceAddress = address,
+                                    onPendingUserApproval = { intentSender ->
+                                        approvalLauncher.launch(
+                                            IntentSenderRequest.Builder(intentSender).build()
+                                        )
+                                    },
+                                    onAssociated = {
+                                        status = controller.status(address)
+                                        resultText = "系统关联与连接观察已启用。"
+                                    },
+                                    onFailure = { message ->
+                                        status = controller.status(address)
+                                        resultText = message
+                                    },
+                                )
+                            },
+                        ) {
+                            Text("启用系统观察")
+                        }
+                    }
+                    Spacer(Modifier.width(MaterialTheme.spacing.sm))
+                    Text(
+                        "ACL 保底始终保留",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            resultText?.let { message ->
+                Text(
+                    message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/vehicle/presence/CompanionDevicePresence.kt
+++ b/android/app/src/main/java/com/evchargebook/vehicle/presence/CompanionDevicePresence.kt
@@ -1,0 +1,294 @@
+package com.evchargebook.vehicle.presence
+
+import android.companion.AssociationInfo
+import android.companion.AssociationRequest
+import android.companion.BluetoothDeviceFilter
+import android.companion.CompanionDeviceManager
+import android.companion.CompanionDeviceService
+import android.companion.DevicePresenceEvent
+import android.companion.ObservingDevicePresenceRequest
+import android.content.Context
+import android.content.IntentSender
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.core.content.ContextCompat
+import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+enum class CompanionPresenceSupport {
+    ANDROID_TOO_OLD,
+    FEATURE_MISSING,
+    SUPPORTED,
+}
+
+data class CompanionPresenceStatus(
+    val support: CompanionPresenceSupport,
+    val associated: Boolean,
+)
+
+object CompanionPresencePolicy {
+    fun support(sdkInt: Int, hasCompanionSetupFeature: Boolean): CompanionPresenceSupport =
+        when {
+            sdkInt < Build.VERSION_CODES.S -> CompanionPresenceSupport.ANDROID_TOO_OLD
+            !hasCompanionSetupFeature -> CompanionPresenceSupport.FEATURE_MISSING
+            else -> CompanionPresenceSupport.SUPPORTED
+        }
+
+    fun classicCallbackState(appeared: Boolean): VehiclePresenceState =
+        if (appeared) VehiclePresenceState.CONNECTED else VehiclePresenceState.DISCONNECTED
+}
+
+/**
+ * Optional #299 A2 adapter for Android Companion Device presence.
+ *
+ * The request is deliberately scoped to the already-selected classic-Bluetooth MAC. For classic
+ * Bluetooth Android reports connection/disconnection presence, not vehicle telemetry. ACL remains
+ * registered as the fallback path and both sources converge on VehiclePresenceDispatcher.
+ */
+class CompanionDevicePresenceController(
+    private val context: Context,
+) {
+    private val manager: CompanionDeviceManager?
+        get() = context.getSystemService(CompanionDeviceManager::class.java)
+
+    fun status(deviceAddress: String?): CompanionPresenceStatus {
+        val support = support()
+        if (support != CompanionPresenceSupport.SUPPORTED || deviceAddress.isNullOrBlank()) {
+            return CompanionPresenceStatus(support = support, associated = false)
+        }
+        return CompanionPresenceStatus(
+            support = support,
+            associated = isAssociated(deviceAddress),
+        )
+    }
+
+    fun requestAssociation(
+        deviceAddress: String,
+        onPendingUserApproval: (IntentSender) -> Unit,
+        onAssociated: () -> Unit,
+        onFailure: (String) -> Unit,
+    ) {
+        if (support() != CompanionPresenceSupport.SUPPORTED) {
+            onFailure("当前 Android 设备不支持 Companion Device presence")
+            return
+        }
+        val companionManager = manager ?: run {
+            onFailure("系统 CompanionDeviceManager 不可用")
+            return
+        }
+        val normalizedAddress = normalize(deviceAddress)
+        if (isAssociated(normalizedAddress)) {
+            ensureObservation(normalizedAddress)
+                .onSuccess { onAssociated() }
+                .onFailure { onFailure(it.message ?: "无法启用系统连接观察") }
+            return
+        }
+
+        val request = AssociationRequest.Builder()
+            .addDeviceFilter(
+                BluetoothDeviceFilter.Builder()
+                    .setAddress(normalizedAddress)
+                    .build()
+            )
+            .setSingleDevice(true)
+            .build()
+
+        val callback = object : CompanionDeviceManager.Callback() {
+            override fun onFailure(error: CharSequence?) {
+                onFailure(error?.toString().orEmpty().ifBlank { "系统关联未完成" })
+            }
+
+            @Suppress("DEPRECATION")
+            override fun onDeviceFound(chooserLauncher: IntentSender) {
+                onPendingUserApproval(chooserLauncher)
+            }
+
+            override fun onAssociationPending(intentSender: IntentSender) {
+                onPendingUserApproval(intentSender)
+            }
+
+            override fun onAssociationCreated(associationInfo: AssociationInfo) {
+                val createdAddress = associationInfo.deviceMacAddress?.toString()
+                    ?: normalizedAddress
+                ensureObservation(createdAddress)
+                    .onSuccess { onAssociated() }
+                    .onFailure { onFailure(it.message ?: "系统关联已创建，但连接观察启用失败") }
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            companionManager.associate(request, ContextCompat.getMainExecutor(context), callback)
+        } else {
+            @Suppress("DEPRECATION")
+            companionManager.associate(request, callback, Handler(Looper.getMainLooper()))
+        }
+    }
+
+    fun ensureObservation(deviceAddress: String): Result<Unit> {
+        if (support() != CompanionPresenceSupport.SUPPORTED) {
+            return Result.failure(IllegalStateException("Companion Device presence unsupported"))
+        }
+        val companionManager = manager
+            ?: return Result.failure(IllegalStateException("CompanionDeviceManager unavailable"))
+        val normalizedAddress = normalize(deviceAddress)
+        if (!isAssociated(normalizedAddress)) {
+            return Result.failure(IllegalStateException("Device is not associated"))
+        }
+
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+                val association = findAssociation(normalizedAddress)
+                    ?: error("Associated device record unavailable")
+                val request = ObservingDevicePresenceRequest.Builder()
+                    .setAssociationId(association.id)
+                    .build()
+                companionManager.startObservingDevicePresence(request)
+            } else {
+                @Suppress("DEPRECATION")
+                companionManager.startObservingDevicePresence(normalizedAddress)
+            }
+        }
+    }
+
+    fun removeAssociation(deviceAddress: String): Result<Unit> {
+        if (support() != CompanionPresenceSupport.SUPPORTED) {
+            return Result.failure(IllegalStateException("Companion Device presence unsupported"))
+        }
+        val companionManager = manager
+            ?: return Result.failure(IllegalStateException("CompanionDeviceManager unavailable"))
+        val normalizedAddress = normalize(deviceAddress)
+
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val association = findAssociation(normalizedAddress) ?: return@runCatching
+                runCatching {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+                        val request = ObservingDevicePresenceRequest.Builder()
+                            .setAssociationId(association.id)
+                            .build()
+                        companionManager.stopObservingDevicePresence(request)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        companionManager.stopObservingDevicePresence(normalizedAddress)
+                    }
+                }
+                companionManager.disassociate(association.id)
+            } else {
+                runCatching {
+                    @Suppress("DEPRECATION")
+                    companionManager.stopObservingDevicePresence(normalizedAddress)
+                }
+                @Suppress("DEPRECATION")
+                companionManager.disassociate(normalizedAddress)
+            }
+        }
+    }
+
+    private fun support(): CompanionPresenceSupport =
+        CompanionPresencePolicy.support(
+            sdkInt = Build.VERSION.SDK_INT,
+            hasCompanionSetupFeature = context.packageManager.hasSystemFeature(
+                PackageManager.FEATURE_COMPANION_DEVICE_SETUP
+            ),
+        )
+
+    private fun isAssociated(deviceAddress: String): Boolean {
+        val normalizedAddress = normalize(deviceAddress)
+        val companionManager = manager ?: return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            companionManager.myAssociations.any { association ->
+                association.deviceMacAddress?.toString()
+                    ?.equals(normalizedAddress, ignoreCase = true) == true
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            companionManager.associations.any { address ->
+                address.equals(normalizedAddress, ignoreCase = true)
+            }
+        }
+    }
+
+    private fun findAssociation(deviceAddress: String): AssociationInfo? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
+        val normalizedAddress = normalize(deviceAddress)
+        return manager?.myAssociations?.firstOrNull { association ->
+            association.deviceMacAddress?.toString()
+                ?.equals(normalizedAddress, ignoreCase = true) == true
+        }
+    }
+
+    private fun normalize(address: String): String =
+        VehicleBluetoothBindingPreferences.normalizeAddress(address)
+}
+
+/**
+ * System-bound presence callback. It never creates or ends Trips directly.
+ */
+class CompanionVehiclePresenceService : CompanionDeviceService() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Suppress("DEPRECATION")
+    override fun onDeviceAppeared(address: String) {
+        dispatch(address, CompanionPresencePolicy.classicCallbackState(appeared = true))
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onDeviceDisappeared(address: String) {
+        dispatch(address, CompanionPresencePolicy.classicCallbackState(appeared = false))
+    }
+
+    override fun onDeviceAppeared(associationInfo: AssociationInfo) {
+        dispatch(
+            associationInfo.deviceMacAddress?.toString(),
+            CompanionPresencePolicy.classicCallbackState(appeared = true),
+        )
+    }
+
+    override fun onDeviceDisappeared(associationInfo: AssociationInfo) {
+        dispatch(
+            associationInfo.deviceMacAddress?.toString(),
+            CompanionPresencePolicy.classicCallbackState(appeared = false),
+        )
+    }
+
+    override fun onDevicePresenceEvent(event: DevicePresenceEvent) {
+        val state = when (event.event) {
+            DevicePresenceEvent.EVENT_BT_CONNECTED -> VehiclePresenceState.CONNECTED
+            DevicePresenceEvent.EVENT_BT_DISCONNECTED -> VehiclePresenceState.DISCONNECTED
+            DevicePresenceEvent.EVENT_BLE_APPEARED -> VehiclePresenceState.PRESENT
+            else -> return
+        }
+        val associationId = event.associationId
+        if (associationId == DevicePresenceEvent.NO_ASSOCIATION) return
+        val address = getSystemService(CompanionDeviceManager::class.java)
+            ?.myAssociations
+            ?.firstOrNull { it.id == associationId }
+            ?.deviceMacAddress
+            ?.toString()
+        dispatch(address, state)
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    private fun dispatch(address: String?, state: VehiclePresenceState) {
+        if (address.isNullOrBlank()) return
+        serviceScope.launch {
+            VehiclePresenceDispatcher.forAutoTrip(applicationContext).dispatch(
+                VehiclePresenceEvent(
+                    state = state,
+                    source = VehiclePresenceSource.COMPANION_DEVICE,
+                    deviceAddress = address,
+                )
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/vehicle/presence/CompanionDevicePresence.kt
+++ b/android/app/src/main/java/com/evchargebook/vehicle/presence/CompanionDevicePresence.kt
@@ -1,19 +1,15 @@
 package com.evchargebook.vehicle.presence
 
-import android.companion.AssociationInfo
 import android.companion.AssociationRequest
 import android.companion.BluetoothDeviceFilter
 import android.companion.CompanionDeviceManager
 import android.companion.CompanionDeviceService
-import android.companion.DevicePresenceEvent
-import android.companion.ObservingDevicePresenceRequest
 import android.content.Context
 import android.content.IntentSender
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import androidx.core.content.ContextCompat
 import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,9 +43,13 @@ object CompanionPresencePolicy {
 /**
  * Optional #299 A2 adapter for Android Companion Device presence.
  *
- * The request is deliberately scoped to the already-selected classic-Bluetooth MAC. For classic
- * Bluetooth Android reports connection/disconnection presence, not vehicle telemetry. ACL remains
- * registered as the fallback path and both sources converge on VehiclePresenceDispatcher.
+ * This PoC deliberately uses the address-based Companion Device APIs that exist across Android
+ * 12-16. They are deprecated on newer Android releases, but retaining them for this experiment
+ * avoids loading API 33/36-only callback types on Android 12 while we collect OEM evidence.
+ *
+ * The association is scoped to the already-selected classic-Bluetooth MAC. For classic Bluetooth
+ * Android reports connection/disconnection presence, not vehicle telemetry. ACL remains registered
+ * as the fallback path and both sources converge on VehiclePresenceDispatcher.
  */
 class CompanionDevicePresenceController(
     private val context: Context,
@@ -108,26 +108,10 @@ class CompanionDevicePresenceController(
             override fun onDeviceFound(chooserLauncher: IntentSender) {
                 onPendingUserApproval(chooserLauncher)
             }
-
-            override fun onAssociationPending(intentSender: IntentSender) {
-                onPendingUserApproval(intentSender)
-            }
-
-            override fun onAssociationCreated(associationInfo: AssociationInfo) {
-                val createdAddress = associationInfo.deviceMacAddress?.toString()
-                    ?: normalizedAddress
-                ensureObservation(createdAddress)
-                    .onSuccess { onAssociated() }
-                    .onFailure { onFailure(it.message ?: "系统关联已创建，但连接观察启用失败") }
-            }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            companionManager.associate(request, ContextCompat.getMainExecutor(context), callback)
-        } else {
-            @Suppress("DEPRECATION")
-            companionManager.associate(request, callback, Handler(Looper.getMainLooper()))
-        }
+        @Suppress("DEPRECATION")
+        companionManager.associate(request, callback, Handler(Looper.getMainLooper()))
     }
 
     fun ensureObservation(deviceAddress: String): Result<Unit> {
@@ -142,17 +126,10 @@ class CompanionDevicePresenceController(
         }
 
         return runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
-                val association = findAssociation(normalizedAddress)
-                    ?: error("Associated device record unavailable")
-                val request = ObservingDevicePresenceRequest.Builder()
-                    .setAssociationId(association.id)
-                    .build()
-                companionManager.startObservingDevicePresence(request)
-            } else {
-                @Suppress("DEPRECATION")
-                companionManager.startObservingDevicePresence(normalizedAddress)
-            }
+            // Kept intentionally for the A2 matrix: this API spans Android 12-16 and delivers
+            // classic-Bluetooth connect/disconnect through the String callbacks below.
+            @Suppress("DEPRECATION")
+            companionManager.startObservingDevicePresence(normalizedAddress)
         }
     }
 
@@ -165,28 +142,12 @@ class CompanionDevicePresenceController(
         val normalizedAddress = normalize(deviceAddress)
 
         return runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                val association = findAssociation(normalizedAddress) ?: return@runCatching
-                runCatching {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
-                        val request = ObservingDevicePresenceRequest.Builder()
-                            .setAssociationId(association.id)
-                            .build()
-                        companionManager.stopObservingDevicePresence(request)
-                    } else {
-                        @Suppress("DEPRECATION")
-                        companionManager.stopObservingDevicePresence(normalizedAddress)
-                    }
-                }
-                companionManager.disassociate(association.id)
-            } else {
-                runCatching {
-                    @Suppress("DEPRECATION")
-                    companionManager.stopObservingDevicePresence(normalizedAddress)
-                }
+            runCatching {
                 @Suppress("DEPRECATION")
-                companionManager.disassociate(normalizedAddress)
+                companionManager.stopObservingDevicePresence(normalizedAddress)
             }
+            @Suppress("DEPRECATION")
+            companionManager.disassociate(normalizedAddress)
         }
     }
 
@@ -199,27 +160,11 @@ class CompanionDevicePresenceController(
         )
 
     private fun isAssociated(deviceAddress: String): Boolean {
-        val normalizedAddress = normalize(deviceAddress)
         val companionManager = manager ?: return false
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            companionManager.myAssociations.any { association ->
-                association.deviceMacAddress?.toString()
-                    ?.equals(normalizedAddress, ignoreCase = true) == true
-            }
-        } else {
-            @Suppress("DEPRECATION")
-            companionManager.associations.any { address ->
-                address.equals(normalizedAddress, ignoreCase = true)
-            }
-        }
-    }
-
-    private fun findAssociation(deviceAddress: String): AssociationInfo? {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
         val normalizedAddress = normalize(deviceAddress)
-        return manager?.myAssociations?.firstOrNull { association ->
-            association.deviceMacAddress?.toString()
-                ?.equals(normalizedAddress, ignoreCase = true) == true
+        @Suppress("DEPRECATION")
+        return companionManager.associations.any { address ->
+            address.equals(normalizedAddress, ignoreCase = true)
         }
     }
 
@@ -229,6 +174,9 @@ class CompanionDevicePresenceController(
 
 /**
  * System-bound presence callback. It never creates or ends Trips directly.
+ *
+ * Android 13+ keeps compatibility by forwarding non-self-managed AssociationInfo callbacks to
+ * these legacy String callbacks. The PoC therefore keeps one callback surface across API 31-36.
  */
 class CompanionVehiclePresenceService : CompanionDeviceService() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -241,37 +189,6 @@ class CompanionVehiclePresenceService : CompanionDeviceService() {
     @Suppress("DEPRECATION")
     override fun onDeviceDisappeared(address: String) {
         dispatch(address, CompanionPresencePolicy.classicCallbackState(appeared = false))
-    }
-
-    override fun onDeviceAppeared(associationInfo: AssociationInfo) {
-        dispatch(
-            associationInfo.deviceMacAddress?.toString(),
-            CompanionPresencePolicy.classicCallbackState(appeared = true),
-        )
-    }
-
-    override fun onDeviceDisappeared(associationInfo: AssociationInfo) {
-        dispatch(
-            associationInfo.deviceMacAddress?.toString(),
-            CompanionPresencePolicy.classicCallbackState(appeared = false),
-        )
-    }
-
-    override fun onDevicePresenceEvent(event: DevicePresenceEvent) {
-        val state = when (event.event) {
-            DevicePresenceEvent.EVENT_BT_CONNECTED -> VehiclePresenceState.CONNECTED
-            DevicePresenceEvent.EVENT_BT_DISCONNECTED -> VehiclePresenceState.DISCONNECTED
-            DevicePresenceEvent.EVENT_BLE_APPEARED -> VehiclePresenceState.PRESENT
-            else -> return
-        }
-        val associationId = event.associationId
-        if (associationId == DevicePresenceEvent.NO_ASSOCIATION) return
-        val address = getSystemService(CompanionDeviceManager::class.java)
-            ?.myAssociations
-            ?.firstOrNull { it.id == associationId }
-            ?.deviceMacAddress
-            ?.toString()
-        dispatch(address, state)
     }
 
     override fun onDestroy() {

--- a/android/app/src/test/java/com/evchargebook/vehicle/presence/CompanionPresencePolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/vehicle/presence/CompanionPresencePolicyTest.kt
@@ -1,0 +1,51 @@
+package com.evchargebook.vehicle.presence
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CompanionPresencePolicyTest {
+    @Test
+    fun `presence observation requires Android 12`() {
+        assertEquals(
+            CompanionPresenceSupport.ANDROID_TOO_OLD,
+            CompanionPresencePolicy.support(
+                sdkInt = 30,
+                hasCompanionSetupFeature = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `missing system feature fails closed`() {
+        assertEquals(
+            CompanionPresenceSupport.FEATURE_MISSING,
+            CompanionPresencePolicy.support(
+                sdkInt = 31,
+                hasCompanionSetupFeature = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `supported platform is capability gated`() {
+        assertEquals(
+            CompanionPresenceSupport.SUPPORTED,
+            CompanionPresencePolicy.support(
+                sdkInt = 31,
+                hasCompanionSetupFeature = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `classic companion callback is connection semantics`() {
+        assertEquals(
+            VehiclePresenceState.CONNECTED,
+            CompanionPresencePolicy.classicCallbackState(appeared = true),
+        )
+        assertEquals(
+            VehiclePresenceState.DISCONNECTED,
+            CompanionPresencePolicy.classicCallbackState(appeared = false),
+        )
+    }
+}


### PR DESCRIPTION
Refs #299
Refs #316
Physical acceptance: #315

## Summary

Optional A2 PoC on top of the merged Vehicle Presence boundary. Classic ACL remains the fallback and no second Trip/session authority is introduced.

- declare optional `android.software.companion_device_setup` support plus `REQUEST_OBSERVE_COMPANION_DEVICE_PRESENCE`;
- add one system-protected `CompanionDeviceService` and route callbacks into the existing `VehiclePresenceDispatcher` with source `COMPANION_DEVICE`;
- keep classic-Bluetooth Companion events as CONNECTED/DISCONNECTED semantics only;
- add an explicit experimental association card to the existing vehicle Bluetooth screen, filtered to the already-selected paired MAC;
- capability-gate the PoC to Android 12+ and the system Companion Device Setup feature;
- intentionally use the address-based observe/callback surface across Android 12-16 for this PoC, even though newer Android deprecates it, so API 33/36-only callback types are never loaded on Android 12;
- allow the user to revoke the system association; ACL fallback remains registered throughout;
- add pure JVM coverage for version/feature gating and classic callback semantics.

## Important boundary

For classic Bluetooth this does **not** discover SOC/range/odometer/BMS and it does **not** prove driving. Android's Companion Device path is being evaluated only as an alternate system delivery path for connect/disconnect presence, especially across process death/background OEM behavior.

No `REQUEST_COMPANION_RUN_IN_BACKGROUND`, no WorkManager keepalive, no extra tracking FGS, no remote command surface.

## Compatibility choice

For the A2 evidence phase we prefer one stable behavioral surface over the newest API shape: Android 12's address-based `startObservingDevicePresence(address)` and String callbacks remain the PoC contract through targetSdk 36. If #315 shows this is worth shipping, a later isolated API-36 adapter can adopt `ObservingDevicePresenceRequest` without exposing API-36 types to older releases.

## Current base

`main@50d4cc99d89e019c561ed795b5acffadcaa71ddc` after #303 merged.

Current head: `ac1c9d173016aa936074f04bf0f4b6fa66b2601e`.

## Validation

- [x] JVM tests / Android build on current head via Android Build #785
- [x] Debug APK uploaded by Android Build #785
- [x] current head mergeable; no review threads / blocking reviews
- [ ] ColorOS / OnePlus physical matrix (#315)
- [ ] second Android OEM physical matrix (#315)

This PR may land specifically to enable physical testing from `main`; do not close #299 or #315 on CI alone. Ship/defer remains evidence-based on the physical matrix.