### PR TITLE
fix(android): recover Trip 32 GPS gaps

### DIFF
--- a/android/app/src/main/java/com/evchargebook/domain/TripPlatformRecoveryPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripPlatformRecoveryPolicy.kt
@@ -1,0 +1,36 @@
+package com.evchargebook.domain
+
+/**
+ * Pure policy for the bounded platform-location recovery path.
+ *
+ * GPS is the preferred health authority whenever it was actually registered. Network callbacks
+ * may still be forwarded to Trip tracking, but they must not keep a dead GPS registration alive.
+ * Recovery attempts are budgeted for the whole Trip source session and are never reset by a single
+ * successful callback.
+ */
+object TripPlatformRecoveryPolicy {
+    const val GPS_PROVIDER = "gps"
+    const val NETWORK_PROVIDER = "network"
+
+    private val recoveryDelaysMillis = longArrayOf(30_000L, 60_000L)
+
+    fun monitoredProvider(registeredProviders: Set<String>): String? {
+        val normalized = registeredProviders.map { it.lowercase() }.toSet()
+        return when {
+            GPS_PROVIDER in normalized -> GPS_PROVIDER
+            NETWORK_PROVIDER in normalized -> NETWORK_PROVIDER
+            else -> null
+        }
+    }
+
+    fun callbackRefreshesWatchdog(
+        monitoredProvider: String?,
+        callbackProvider: String?,
+    ): Boolean =
+        monitoredProvider != null &&
+            callbackProvider != null &&
+            monitoredProvider.equals(callbackProvider, ignoreCase = true)
+
+    fun recoveryDelayMillis(completedAttempts: Int): Long? =
+        recoveryDelaysMillis.getOrNull(completedAttempts)
+}

--- a/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/TripSpeedTrustRules.kt
@@ -6,6 +6,14 @@ object TripSpeedTrustRules {
     private const val MAX_TRUSTED_HORIZONTAL_ACCURACY_METERS = 25.0
     private const val MAX_TRUSTED_SPEED_ACCURACY_MPS = 3.0
     private const val EXTREME_SPEED_REQUIRES_ACCURACY_MPS = 25.0
+    private const val STATIONARY_CONTRADICTION_IMPLIED_SPEED_MPS = 5.0
+
+    // A coarse accepted fix may legally have 100m horizontal accuracy. For a pair of such fixes,
+    // require displacement to exceed twice their combined accepted uncertainty before a reported
+    // near-zero speed is discarded. This keeps network jitter fail-closed while still catching the
+    // Trip 32 case (about 1.52km over 72s with a 100m network fix reporting speed=0).
+    private val stationaryContradictionMinDistanceMeters =
+        TripSamplingRules.MAX_HORIZONTAL_ACCURACY_METERS * 4.0
 
     fun eligibleForAggregate(
         reportedSpeedMps: Double?,
@@ -14,7 +22,14 @@ object TripSpeedTrustRules {
         continuityAllowsSpeed: Boolean
     ): Boolean {
         if (!continuityAllowsSpeed || reportedSpeedMps == null || !reportedSpeedMps.isFinite() || reportedSpeedMps < 0.0) return false
-        if (reportedSpeedMps < TripSamplingRules.MOVING_SPEED_MPS) return true
+        if (reportedSpeedMps < TripSamplingRules.MOVING_SPEED_MPS) {
+            if (deltaSeconds <= 0) return true
+            val impliedSpeed = trustedDistanceMeters / deltaSeconds
+            val stronglyContradictsStationary =
+                trustedDistanceMeters >= stationaryContradictionMinDistanceMeters &&
+                    impliedSpeed >= STATIONARY_CONTRADICTION_IMPLIED_SPEED_MPS
+            return !stronglyContradictsStationary
+        }
         if (deltaSeconds <= 0) return false
 
         val expectedDistance = reportedSpeedMps * deltaSeconds

--- a/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/FusedTripLocationSource.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.location.Location
 import android.os.Handler
 import android.os.Looper
+import com.evchargebook.domain.TripPlatformRecoveryPolicy
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -36,6 +37,9 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
     @Volatile private var running = false
     private var callback: LocationCallback? = null
     private var primarySilenceWatchdog: Runnable? = null
+    private var platformSilenceWatchdog: Runnable? = null
+    private var platformRecoveryAttempts: Int = 0
+    private var platformMonitoredProvider: String? = null
     private var lastReportedAvailability: Boolean? = null
 
     @SuppressLint("MissingPermission")
@@ -46,6 +50,8 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
         stop()
         running = true
         fallbackStarted.set(false)
+        platformRecoveryAttempts = 0
+        platformMonitoredProvider = null
         lastReportedAvailability = null
 
         if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) != ConnectionResult.SUCCESS) {
@@ -119,7 +125,40 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
                 detail = "fallback_started reason=$reason",
             )
         )
-        platformFallback.start(callback, signalCallback)
+        registerPlatformFallback(callback, signalCallback)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun registerPlatformFallback(
+        callback: (Location) -> Unit,
+        signalCallback: (TripLocationSourceSignal) -> Unit,
+    ) {
+        cancelPlatformSilenceWatchdog()
+        platformFallback.stop()
+        platformFallback.start(
+            callback = { location ->
+                if (!running || !fallbackStarted.get()) return@start
+                if (
+                    TripPlatformRecoveryPolicy.callbackRefreshesWatchdog(
+                        monitoredProvider = platformMonitoredProvider,
+                        callbackProvider = location.provider,
+                    )
+                ) {
+                    armPlatformSilenceWatchdog(callback, signalCallback)
+                }
+                callback(location)
+            },
+            signalCallback = signalCallback,
+        )
+        platformMonitoredProvider =
+            TripPlatformRecoveryPolicy.monitoredProvider(platformFallback.registeredProviders())
+        signalCallback(
+            TripLocationSourceSignal(
+                source = SOURCE_PLATFORM,
+                detail = "recovery_watchdog provider=${platformMonitoredProvider ?: "none"} completedAttempts=$platformRecoveryAttempts",
+            )
+        )
+        armPlatformSilenceWatchdog(callback, signalCallback)
     }
 
     private fun armPrimarySilenceWatchdog(
@@ -139,6 +178,41 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
         }
         primarySilenceWatchdog = watchdog
         mainHandler.postDelayed(watchdog, PRIMARY_SILENCE_TIMEOUT_MS)
+    }
+
+    private fun armPlatformSilenceWatchdog(
+        callback: (Location) -> Unit,
+        signalCallback: (TripLocationSourceSignal) -> Unit,
+    ) {
+        cancelPlatformSilenceWatchdog()
+        if (!running || !fallbackStarted.get()) return
+        val monitoredProvider = platformMonitoredProvider ?: return
+        val delayMillis =
+            TripPlatformRecoveryPolicy.recoveryDelayMillis(platformRecoveryAttempts) ?: return
+        val watchdog = Runnable {
+            if (!running || !fallbackStarted.get()) return@Runnable
+            val attempt = platformRecoveryAttempts + 1
+            platformRecoveryAttempts = attempt
+            signalCallback(
+                TripLocationSourceSignal(
+                    source = SOURCE_PLATFORM,
+                    detail = "recovery_reregister attempt=$attempt provider=$monitoredProvider silenceMs=$delayMillis",
+                )
+            )
+            runCatching {
+                registerPlatformFallback(callback, signalCallback)
+            }.onFailure { error ->
+                signalCallback(
+                    TripLocationSourceSignal(
+                        source = SOURCE_PLATFORM,
+                        detail = "recovery_reregister_failed attempt=$attempt provider=$monitoredProvider error=${error::class.java.simpleName}",
+                    )
+                )
+                armPlatformSilenceWatchdog(callback, signalCallback)
+            }
+        }
+        platformSilenceWatchdog = watchdog
+        mainHandler.postDelayed(watchdog, delayMillis)
     }
 
     private fun reportAvailability(
@@ -161,13 +235,21 @@ class FusedTripLocationSource(private val context: Context) : TripLocationSource
         primarySilenceWatchdog = null
     }
 
+    private fun cancelPlatformSilenceWatchdog() {
+        platformSilenceWatchdog?.let(mainHandler::removeCallbacks)
+        platformSilenceWatchdog = null
+    }
+
     override fun stop() {
         running = false
         cancelPrimarySilenceWatchdog()
+        cancelPlatformSilenceWatchdog()
         callback?.let(client::removeLocationUpdates)
         callback = null
         platformFallback.stop()
         fallbackStarted.set(false)
+        platformRecoveryAttempts = 0
+        platformMonitoredProvider = null
         lastReportedAvailability = null
     }
 

--- a/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
+++ b/android/app/src/main/java/com/evchargebook/location/PlatformTripLocationSource.kt
@@ -18,6 +18,9 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
     private var listener: LocationListener? = null
 
+    @Volatile
+    private var registeredProviderNames: Set<String> = emptySet()
+
     @SuppressLint("MissingPermission")
     override fun start(
         callback: (Location) -> Unit,
@@ -33,7 +36,7 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
                 provider in providers && runCatching { locationManager.isProviderEnabled(provider) }.getOrDefault(false)
             }
 
-        var successfulRegistrations = 0
+        val successfulProviders = linkedSetOf<String>()
         var lastFailure: Throwable? = null
         candidates.forEach { provider ->
             runCatching {
@@ -45,28 +48,33 @@ class PlatformTripLocationSource(context: Context) : TripLocationSource {
                     Looper.getMainLooper()
                 )
             }.onSuccess {
-                successfulRegistrations += 1
+                successfulProviders += provider
             }.onFailure { error ->
                 lastFailure = error
             }
         }
 
-        if (successfulRegistrations == 0) {
+        if (successfulProviders.isEmpty()) {
             listener = null
+            registeredProviderNames = emptySet()
             throw IllegalStateException("No enabled platform GPS/network provider could be registered", lastFailure)
         }
 
+        registeredProviderNames = successfulProviders.toSet()
         signalCallback(
             TripLocationSourceSignal(
                 source = SOURCE_PLATFORM,
-                detail = "registered providers=${candidates.joinToString(",")}",
+                detail = "registered providers=${successfulProviders.joinToString(",")}",
             )
         )
     }
 
+    fun registeredProviders(): Set<String> = registeredProviderNames
+
     override fun stop() {
         listener?.let { current -> runCatching { locationManager.removeUpdates(current) } }
         listener = null
+        registeredProviderNames = emptySet()
     }
 
     private companion object {

--- a/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripTrackingService.kt
@@ -443,7 +443,11 @@ class TripTrackingService : Service() {
         ) rawSpeed else null
         val decision = TripSamplingRules.decide(statsDeltaSeconds, trustedSegmentDistance, aggregateSpeed, accuracy)
         if (!decision.accept) {
-            rejectLocation(tripId, location.provider, "sampling_rejected")
+            rejectLocation(
+                tripId,
+                location.provider,
+                "sampling_rejected:${decision.reason ?: "unknown"}"
+            )
             return
         }
 

--- a/android/app/src/test/java/com/evchargebook/domain/TripPlatformRecoveryPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripPlatformRecoveryPolicyTest.kt
@@ -1,0 +1,49 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TripPlatformRecoveryPolicyTest {
+    @Test
+    fun `gps is monitored when gps and network are both registered`() {
+        assertEquals(
+            TripPlatformRecoveryPolicy.GPS_PROVIDER,
+            TripPlatformRecoveryPolicy.monitoredProvider(setOf("gps", "network"))
+        )
+    }
+
+    @Test
+    fun `network is monitored only when gps was not registered`() {
+        assertEquals(
+            TripPlatformRecoveryPolicy.NETWORK_PROVIDER,
+            TripPlatformRecoveryPolicy.monitoredProvider(setOf("network"))
+        )
+    }
+
+    @Test
+    fun `network callback cannot refresh a gps watchdog`() {
+        assertFalse(
+            TripPlatformRecoveryPolicy.callbackRefreshesWatchdog(
+                monitoredProvider = "gps",
+                callbackProvider = "network"
+            )
+        )
+        assertTrue(
+            TripPlatformRecoveryPolicy.callbackRefreshesWatchdog(
+                monitoredProvider = "gps",
+                callbackProvider = "gps"
+            )
+        )
+    }
+
+    @Test
+    fun `recovery budget is exhausted after two attempts`() {
+        assertEquals(30_000L, TripPlatformRecoveryPolicy.recoveryDelayMillis(0))
+        assertEquals(60_000L, TripPlatformRecoveryPolicy.recoveryDelayMillis(1))
+        assertNull(TripPlatformRecoveryPolicy.recoveryDelayMillis(2))
+        assertNull(TripPlatformRecoveryPolicy.recoveryDelayMillis(3))
+    }
+}

--- a/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/TripSpeedTrustRulesTest.kt
@@ -54,6 +54,50 @@ class TripSpeedTrustRulesTest {
     }
 
     @Test
+    fun `trip32 contradictory zero speed falls back to distance motion`() {
+        assertFalse(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 0.0,
+                deltaSeconds = 72,
+                trustedDistanceMeters = 1_523.5,
+                continuityAllowsSpeed = true
+            )
+        )
+        assertTrue(
+            TripSamplingRules.decide(
+                deltaSeconds = 72,
+                segmentDistanceMeters = 1_523.5,
+                reportedSpeedMps = null,
+                horizontalAccuracyMeters = 100.0
+            ).moving
+        )
+    }
+
+    @Test
+    fun `coarse displacement inside conservative accuracy envelope still trusts zero speed`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 0.0,
+                deltaSeconds = 60,
+                trustedDistanceMeters = 350.0,
+                continuityAllowsSpeed = true
+            )
+        )
+    }
+
+    @Test
+    fun `small stationary drift still trusts zero speed`() {
+        assertTrue(
+            TripSpeedTrustRules.eligibleForAggregate(
+                reportedSpeedMps = 0.0,
+                deltaSeconds = 2,
+                trustedDistanceMeters = 6.5,
+                continuityAllowsSpeed = true
+            )
+        )
+    }
+
+    @Test
     fun `network speed spike cannot update max speed even when distance corroborates it`() {
         assertFalse(
             TripSpeedTrustRules.eligibleForMaxSpeed(


### PR DESCRIPTION
## Summary

Trip 32 physical evidence on OnePlus PLU110 / API 36 exposed two distinct reliability failures:

- a 72s segment moved about 1.52km while a coarse fallback point reported `speed=0`, allowing the zero-speed aggregate signal to suppress real movement;
- after Fused correctly fell back to platform GPS/network, GPS delivery later went silent for about 200s while the Trip and coarse network callbacks could remain alive.

This PR is rebased/normalized onto current `main` and applies the smallest evidence-driven fixes while keeping Trip truth fail-closed.

## Changes

1. **Provider-specific bounded recovery**
   - platform fallback records the providers that actually registered successfully;
   - when GPS registered, GPS callbacks are the recovery watchdog authority; network callbacks are still forwarded but cannot keep a dead GPS registration alive;
   - when only network registered, network becomes the watchdog authority;
   - recovery budget is session-scoped: 30s silence -> re-register once, then 60s silence -> re-register once more, then stop active retries;
   - a successful callback does not reset the retry budget.

2. **Conservative zero-speed contradiction**
   - reported near-zero speed remains authoritative for normal stationary drift and coarse uncertainty;
   - it is discarded only when displacement exceeds a conservative worst-accepted-accuracy envelope (400m) and implied speed is at least 5m/s;
   - this covers Trip 32's ~1523.5m / 72s case without reopening tens-of-metres network-jitter distance inflation.

3. **Actionable rejection diagnostics**
   - sampled `LOCATION_REJECTED` events now preserve `TripSamplingDecision.reason` instead of collapsing every sampling rejection into bare `sampling_rejected`;
   - this lets the next physical CSV distinguish poor accuracy, jump rejection, stationary throttling, etc. during the separate "callbacks arrive but no accepted point" failure mode.

4. **Regression coverage**
   - GPS is preferred over network as platform watchdog authority;
   - network callback cannot refresh a GPS watchdog;
   - retry budget ends after two attempts;
   - Trip 32 zero-speed contradiction falls back to distance motion;
   - a coarse 350m displacement and normal small stationary drift remain fail-closed.

## Truth boundaries preserved

- `LONG_GAP_SECONDS = 120` unchanged.
- No synthetic points.
- No distance/speed fabrication across a true long gap.
- No second tracking Service, WorkManager/Alarm heartbeat, long WakeLock, or battery-optimization exemption.
- Platform fallback still only uses successfully registered enabled GPS/network providers.
- No Fused re-probe in this slice.
- Accepted-point starvation alone does not automatically trigger source switching yet; the new reject-reason diagnostics collect the evidence needed before authorizing that behavior.

Refs #77
Refs #137
Refs #283
