### PR TITLE
ui(trip): redesign trajectory surface and isolate replay to data

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailDataSectionV07.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailDataSectionV07.kt
@@ -27,11 +27,9 @@ import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Terrain
 import androidx.compose.material.icons.filled.TrendingDown
 import androidx.compose.material.icons.filled.TrendingUp
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -255,7 +253,6 @@ internal fun CompletedTripDiagnosticsV07(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TripPlaybackInlineActionV07(points: List<TripPointEntity>) {
     var showPlayback by remember(points.firstOrNull()?.tripId) { mutableStateOf(false) }
@@ -263,26 +260,16 @@ private fun TripPlaybackInlineActionV07(points: List<TripPointEntity>) {
     TripDataActionRowV07(
         icon = Icons.Default.PlayCircle,
         title = "轨迹回放",
-        subtitle = "按时间回看这段行程轨迹",
+        subtitle = "全屏按时间回看，拖动/缩放不会触发页面收缩",
         enabled = points.size >= 2,
         onClick = { showPlayback = true },
     )
 
     if (showPlayback) {
-        ModalBottomSheet(onDismissRequest = { showPlayback = false }) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    "按可信 GPS 速度分段着色；灰色代表速度不可可信，真实长缺口保持断开。",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                TripPlaybackRouteCardV06(points = points)
-                Spacer(Modifier.size(16.dp))
-            }
-        }
+        TripPlaybackFullScreenV07(
+            points = points,
+            onDismiss = { showPlayback = false },
+        )
     }
 }
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -1,5 +1,6 @@
 package com.evchargebook.ui.trip
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Flag
@@ -497,6 +499,7 @@ private fun SummaryMetricGridV06(metrics: List<SummaryMetricV06>) {
 
 @Composable
 private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEndpoint: Boolean) {
+    val accent = EVDesignTokens.Energy.green
     val geometry = remember(points) {
         TripRouteGeometryBuilder.build(points.map { it.toV06RoutePoint() })
     } ?: return
@@ -504,35 +507,68 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEnd
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .16f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text("轨迹", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(
-                    if (geometry.gapCount > 0) "${geometry.gapCount} 个长缺口" else "${geometry.points.size} 个 GPS 点",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (geometry.gapCount > 0) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(22.dp),
                 )
+                Spacer(Modifier.width(9.dp))
+                Text(
+                    "轨迹",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                if (geometry.gapCount > 0) {
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.error.copy(alpha = .10f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = .28f)),
+                    ) {
+                        Text(
+                            "${geometry.gapCount} 个长缺口",
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                } else {
+                    Text(
+                        "${geometry.points.size} 个 GPS 点",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             TripRouteViewportV07(
                 points = points,
                 finalEndpoint = finalEndpoint,
-                height = 190.dp,
+                height = 250.dp,
             )
 
-            if (geometry.gapCount > 0) {
-                Text(
-                    "GPS 长缺口不会用实线补齐。",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            Text(
+                if (geometry.gapCount > 0) {
+                    "GPS 长缺口仅用灰色虚线提示未知区间，不会当作真实道路轨迹。"
+                } else {
+                    "轨迹颜色来自可信 GPS 时速；拖动或双指缩放不会修改行程数据。"
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -193,7 +193,7 @@ internal fun TripDetailScreenV06(
                             )
                         }
                     }
-                    item { CompletedTripTrendsV06(points) }
+                    item { CompletedTripTrendsV06(trip = trip, points = points) }
                 }
 
                 TripDetailSectionV06.DATA -> {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -1,6 +1,5 @@
 package com.evchargebook.ui.trip
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -40,13 +39,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
@@ -73,9 +67,8 @@ private enum class TripDetailSectionV06(val label: String) {
 /**
  * v0.6 completed/selected Trip detail.
  *
- * The approved design treats overview, route and diagnostics as distinct reading surfaces. This
- * screen keeps one route but separates those supported facts into lightweight tabs; unsupported
- * charging/notes/destination concepts are intentionally not exposed.
+ * Overview, route and diagnostics stay separate reading surfaces. Route rendering is delegated to
+ * the shared interactive viewport used by playback so pan/zoom/speed semantics cannot drift.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -504,7 +497,6 @@ private fun SummaryMetricGridV06(metrics: List<SummaryMetricV06>) {
 
 @Composable
 private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEndpoint: Boolean) {
-    val accent = EVDesignTokens.Energy.green
     val geometry = remember(points) {
         TripRouteGeometryBuilder.build(points.map { it.toV06RoutePoint() })
     } ?: return
@@ -528,65 +520,11 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEnd
                 )
             }
 
-            val endColor = MaterialTheme.colorScheme.error
-            Canvas(
-                Modifier
-                    .fillMaxWidth()
-                    .height(150.dp)
-                    .semantics {
-                        contentDescription = if (finalEndpoint) {
-                            "真实行程轨迹；绿色播放标记为起点，红旗标记为终点，长 GPS 缺口保持断开"
-                        } else {
-                            "真实行程轨迹；绿色播放标记为起点，绿色圆点为当前或最后记录点，长 GPS 缺口保持断开"
-                        }
-                    }
-            ) {
-                val pad = 12.dp.toPx()
-                val width = (size.width - pad * 2).coerceAtLeast(1f)
-                val height = (size.height - pad * 2).coerceAtLeast(1f)
-                fun offset(x: Float, y: Float) = Offset(pad + x * width, pad + y * height)
-
-                geometry.segments.forEach { segment ->
-                    segment.zipWithNext().forEach { (from, to) ->
-                        drawLine(
-                            color = accent.copy(alpha = .78f),
-                            start = offset(from.x, from.y),
-                            end = offset(to.x, to.y),
-                            strokeWidth = 3.dp.toPx(),
-                            cap = StrokeCap.Round
-                        )
-                    }
-                }
-
-                val start = geometry.points.first().let { offset(it.x, it.y) }
-                val end = geometry.points.last().let { offset(it.x, it.y) }
-                val marker = 6.dp.toPx()
-                val startTriangle = Path().apply {
-                    moveTo(start.x - marker * .45f, start.y - marker)
-                    lineTo(start.x + marker, start.y)
-                    lineTo(start.x - marker * .45f, start.y + marker)
-                    close()
-                }
-                drawPath(startTriangle, accent)
-
-                if (finalEndpoint) {
-                    val poleHeight = 13.dp.toPx()
-                    val flagWidth = 9.dp.toPx()
-                    val flagHeight = 6.dp.toPx()
-                    drawLine(endColor, end, Offset(end.x, end.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
-                    val flag = Path().apply {
-                        moveTo(end.x, end.y - poleHeight)
-                        lineTo(end.x + flagWidth, end.y - poleHeight)
-                        lineTo(end.x + flagWidth, end.y - poleHeight + flagHeight)
-                        lineTo(end.x, end.y - poleHeight + flagHeight)
-                        close()
-                    }
-                    drawPath(flag, endColor)
-                } else {
-                    drawCircle(accent.copy(alpha = .22f), 6.dp.toPx(), end)
-                    drawCircle(accent, 3.dp.toPx(), end)
-                }
-            }
+            TripRouteViewportV07(
+                points = points,
+                finalEndpoint = finalEndpoint,
+                height = 190.dp,
+            )
 
             if (geometry.gapCount > 0) {
                 Text(
@@ -594,100 +532,6 @@ private fun CompletedTripRoutePreviewV06(points: List<TripPointEntity>, finalEnd
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CompletedTripAltitudeCardV06(trip: TripSessionEntity, points: List<TripPointEntity>) {
-    val summary = remember(points) { TripElevationAnalytics.summarize(points) }
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-        ) {
-            Text("海拔", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-            SummaryMetricGridV06(
-                listOf(
-                    SummaryMetricV06("起点", formatV06Altitude(summary?.startAltitudeMeters ?: trip.startAltitudeMeters)),
-                    SummaryMetricV06("终点", formatV06Altitude(summary?.endAltitudeMeters ?: trip.endAltitudeMeters)),
-                    SummaryMetricV06("最低", formatV06Altitude(summary?.minAltitudeMeters ?: trip.minAltitudeMeters)),
-                    SummaryMetricV06("最高", formatV06Altitude(summary?.maxAltitudeMeters ?: trip.maxAltitudeMeters)),
-                    SummaryMetricV06("累计爬升", if (summary?.hasCumulativeEstimate == true) formatV06Altitude(summary.elevationGainMeters) else "--"),
-                    SummaryMetricV06("累计下降", if (summary?.hasCumulativeEstimate == true) formatV06Altitude(summary.elevationLossMeters) else "--")
-                )
-            )
-            if ((summary?.skippedLongGapCount ?: 0) > 0) {
-                Text(
-                    "${summary?.skippedLongGapCount} 个 GPS 长缺口已从累计海拔变化中断开。",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CompletedTripDiagnosticsV06(
-    points: List<TripPointEntity>,
-    gapCount: Int,
-    expanded: Boolean,
-    onToggle: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
-    ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md)) {
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Column(Modifier.weight(1f)) {
-                    Text("GPS 诊断", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        "${points.size} 点${if (gapCount > 0) " · $gapCount 个长缺口" else " · 未检测到长缺口"}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                TextButton(onClick = onToggle) { Text(if (expanded) "收起" else "查看轨迹点") }
-            }
-
-            if (expanded) {
-                Spacer(Modifier.height(MaterialTheme.spacing.xs))
-                if (points.isEmpty()) {
-                    Text("本次没有保存有效 GPS 轨迹点。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                } else {
-                    points.takeLast(6).reversed().forEachIndexed { index, point ->
-                        if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .16f))
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = MaterialTheme.spacing.xs),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(Modifier.weight(1f)) {
-                                Text(
-                                    SimpleDateFormat("HH:mm:ss", Locale.SIMPLIFIED_CHINESE).format(Date(point.capturedAtEpochMillis)),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                Text(
-                                    "${formatV06Coordinate(point.latitude)}, ${formatV06Coordinate(point.longitude)}",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            point.horizontalAccuracyMeters?.takeIf { it.isFinite() }?.let {
-                                Text("±${it.toInt()} m", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            }
-                        }
-                    }
-                }
             }
         }
     }
@@ -748,9 +592,6 @@ private fun formatV06MileageRange(start: Double?, end: Double?): String = when {
 
 private fun formatV06Mileage(value: Double): String =
     if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
-
-private fun formatV06Altitude(value: Double?): String =
-    value?.takeIf { it.isFinite() }?.let { String.format(Locale.US, "%.0f m", it) } ?: "--"
 
 private fun formatV06Coordinate(value: Double): String = String.format(Locale.US, "%.6f", value)
 

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
+import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.domain.TripSpeedTrustRules
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
@@ -39,7 +40,10 @@ import java.util.Locale
 private const val DETAIL_TREND_LONG_GAP_MS = 120_000L
 
 @Composable
-internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
+internal fun CompletedTripTrendsV06(
+    trip: TripSessionEntity,
+    points: List<TripPointEntity>,
+) {
     val speedSamples = remember(points) {
         points.mapNotNull { point ->
             trustedDetailSpeedV06(point)?.let {
@@ -51,34 +55,34 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
             }
         }
     }
-    val routeTimeline = remember(points) {
-        buildTripTrendTimelineV06(
-            samples = points.map { point ->
-                TripTrendSampleV06(
-                    timestamp = point.capturedAtEpochMillis,
-                    value = 0.0,
-                    capturedAtElapsedRealtimeNanos = point.capturedAtElapsedRealtimeNanos,
-                )
-            },
-            longGapMs = DETAIL_TREND_LONG_GAP_MS,
-        )
+    val fallbackAverageMps = if (trip.elapsedSeconds > 0L && trip.distanceMeters.isFinite() && trip.distanceMeters >= 0.0) {
+        trip.distanceMeters / trip.elapsedSeconds
+    } else {
+        null
     }
-
-    val averageSpeed = speedSamples.takeIf { it.isNotEmpty() }?.map { it.value }?.average()
-    val maxSpeed = speedSamples.maxOfOrNull { it.value }
-    val durationMillis = routeTimeline.lastOrNull()?.timelineMillis ?: 0L
+    val averageSpeedKph = (trip.averageSpeedMps ?: fallbackAverageMps)
+        ?.takeIf { it.isFinite() && it >= 0.0 }
+        ?.times(3.6)
+    val maxSpeedKph = trip.maxSpeedMps
+        ?.takeIf { it.isFinite() && it >= 0.0 }
+        ?.times(3.6)
+        ?: speedSamples.maxOfOrNull { it.value }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
     ) {
         RouteSnapshotBarV07(
-            gpsPointCount = points.size,
-            durationMillis = durationMillis,
-            averageSpeedKph = averageSpeed,
-            maxSpeedKph = maxSpeed,
+            distanceMeters = trip.distanceMeters,
+            elapsedSeconds = trip.elapsedSeconds,
+            averageSpeedKph = averageSpeedKph,
+            maxSpeedKph = maxSpeedKph,
         )
-        SpeedTrendCardV07(speedSamples)
+        SpeedTrendCardV07(
+            samples = speedSamples,
+            averageSpeedKph = averageSpeedKph,
+            maxSpeedKph = maxSpeedKph,
+        )
     }
 }
 
@@ -90,16 +94,16 @@ private data class RouteSnapshotMetricV07(
 
 @Composable
 private fun RouteSnapshotBarV07(
-    gpsPointCount: Int,
-    durationMillis: Long,
+    distanceMeters: Double,
+    elapsedSeconds: Long,
     averageSpeedKph: Double?,
     maxSpeedKph: Double?,
 ) {
     val metrics = listOf(
-        RouteSnapshotMetricV07(Icons.Default.LocationOn, "GPS 点", gpsPointCount.toString()),
-        RouteSnapshotMetricV07(Icons.Default.Schedule, "记录时长", formatTrendDurationV07(durationMillis)),
-        RouteSnapshotMetricV07(Icons.Default.Speed, "样本均速", formatSpeedMetricV07(averageSpeedKph)),
-        RouteSnapshotMetricV07(Icons.Default.ShowChart, "最高可信", formatSpeedMetricV07(maxSpeedKph)),
+        RouteSnapshotMetricV07(Icons.Default.LocationOn, "轨迹里程", formatRouteDistanceV07(distanceMeters)),
+        RouteSnapshotMetricV07(Icons.Default.Schedule, "行驶时长", formatTrendDurationV07(elapsedSeconds)),
+        RouteSnapshotMetricV07(Icons.Default.Speed, "平均速度", formatSpeedMetricV07(averageSpeedKph)),
+        RouteSnapshotMetricV07(Icons.Default.ShowChart, "最高速度", formatSpeedMetricV07(maxSpeedKph)),
     )
 
     Surface(
@@ -184,10 +188,12 @@ private fun RouteSnapshotMetricCellV07(
 }
 
 @Composable
-private fun SpeedTrendCardV07(samples: List<TripTrendSampleV06>) {
+private fun SpeedTrendCardV07(
+    samples: List<TripTrendSampleV06>,
+    averageSpeedKph: Double?,
+    maxSpeedKph: Double?,
+) {
     val accent = EVDesignTokens.Energy.green
-    val average = samples.takeIf { it.isNotEmpty() }?.map { it.value }?.average()
-    val max = samples.maxOfOrNull { it.value }
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -241,12 +247,12 @@ private fun SpeedTrendCardV07(samples: List<TripTrendSampleV06>) {
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         Row(Modifier.fillMaxWidth()) {
-                            TrendHeroMetricV07("平均", average, Modifier.weight(1f))
+                            TrendHeroMetricV07("平均", averageSpeedKph, Modifier.weight(1f))
                             VerticalDivider(
                                 modifier = Modifier.height(48.dp),
                                 color = MaterialTheme.colorScheme.outline.copy(alpha = .16f),
                             )
-                            TrendHeroMetricV07("最高", max, Modifier.weight(1f))
+                            TrendHeroMetricV07("最高", maxSpeedKph, Modifier.weight(1f))
                         }
                         HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .13f))
                         TripTrendPlotV06(
@@ -311,14 +317,22 @@ private fun trustedDetailSpeedV06(point: TripPointEntity): Double? {
     }
 }
 
-private fun formatSpeedMetricV07(value: Double?): String =
-    value?.takeIf { it.isFinite() }?.let { String.format(Locale.US, "%.0f km/h", it) } ?: "--"
+private fun formatRouteDistanceV07(meters: Double): String = when {
+    !meters.isFinite() || meters < 0.0 -> "--"
+    meters >= 1000.0 -> String.format(Locale.US, "%.1f km", meters / 1000.0)
+    else -> String.format(Locale.US, "%.0f m", meters)
+}
 
-private fun formatTrendDurationV07(durationMillis: Long): String {
-    val totalSeconds = (durationMillis / 1_000L).coerceAtLeast(0L)
-    val hours = totalSeconds / 3_600L
-    val minutes = (totalSeconds % 3_600L) / 60L
-    val seconds = totalSeconds % 60L
+private fun formatSpeedMetricV07(valueKph: Double?): String =
+    valueKph?.takeIf { it.isFinite() && it >= 0.0 }
+        ?.let { String.format(Locale.US, "%.0f km/h", it) }
+        ?: "--"
+
+private fun formatTrendDurationV07(totalSeconds: Long): String {
+    val secondsSafe = totalSeconds.coerceAtLeast(0L)
+    val hours = secondsSafe / 3_600L
+    val minutes = (secondsSafe % 3_600L) / 60L
+    val seconds = secondsSafe % 60L
     return if (hours > 0L) {
         String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
     } else {

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -1,23 +1,36 @@
 package com.evchargebook.ui.trip
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.ShowChart
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.domain.TripSpeedTrustRules
-import com.evchargebook.domain.trip.TripElevationAnalytics
+import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 
@@ -36,47 +49,91 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
             }
         }
     }
-    val altitudeSamples = remember(points) {
-        TripElevationAnalytics.filteredSeries(points).map { sample ->
-            TripTrendSampleV06(
-                timestamp = sample.capturedAtEpochMillis,
-                value = sample.altitudeMeters,
-                capturedAtElapsedRealtimeNanos = sample.capturedAtElapsedRealtimeNanos,
-            )
-        }
+    val routeTimeline = remember(points) {
+        buildTripTrendTimelineV06(
+            samples = points.map { point ->
+                TripTrendSampleV06(
+                    timestamp = point.capturedAtEpochMillis,
+                    value = 0.0,
+                    capturedAtElapsedRealtimeNanos = point.capturedAtElapsedRealtimeNanos,
+                )
+            },
+            longGapMs = DETAIL_TREND_LONG_GAP_MS,
+        )
     }
+
+    val averageSpeed = speedSamples.takeIf { it.isNotEmpty() }?.map { it.value }?.average()
+    val maxSpeed = speedSamples.maxOfOrNull { it.value }
+    val durationMillis = routeTimeline.lastOrNull()?.timelineMillis ?: 0L
 
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
     ) {
-        TripPlaybackRouteCardV06(points = points)
+        RouteSnapshotBarV07(
+            gpsPointCount = points.size,
+            durationMillis = durationMillis,
+            averageSpeedKph = averageSpeed,
+            maxSpeedKph = maxSpeed,
+        )
+        SpeedTrendCardV07(speedSamples)
+    }
+}
 
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = MaterialTheme.shapes.large,
-            color = MaterialTheme.colorScheme.surfaceContainerLow
+private data class RouteSnapshotMetricV07(
+    val icon: ImageVector,
+    val label: String,
+    val value: String,
+)
+
+@Composable
+private fun RouteSnapshotBarV07(
+    gpsPointCount: Int,
+    durationMillis: Long,
+    averageSpeedKph: Double?,
+    maxSpeedKph: Double?,
+) {
+    val metrics = listOf(
+        RouteSnapshotMetricV07(Icons.Default.LocationOn, "GPS 点", gpsPointCount.toString()),
+        RouteSnapshotMetricV07(Icons.Default.Schedule, "记录时长", formatTrendDurationV07(durationMillis)),
+        RouteSnapshotMetricV07(Icons.Default.Speed, "样本均速", formatSpeedMetricV07(averageSpeedKph)),
+        RouteSnapshotMetricV07(Icons.Default.ShowChart, "最高可信", formatSpeedMetricV07(maxSpeedKph)),
+    )
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .16f)),
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-            ) {
-                Text("趋势", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-
-                BoxWithConstraints(Modifier.fillMaxWidth()) {
-                    val compact = maxWidth < 360.dp
-                    if (compact) {
-                        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                            DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.fillMaxWidth(), "暂无可信速度样本")
-                            DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.fillMaxWidth(), "暂无可信海拔样本")
-                        }
-                    } else {
+            if (maxWidth < 360.dp) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    metrics.chunked(2).forEach { rowMetrics ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            DetailTrendCardV06("速度", "km/h", speedSamples, Modifier.weight(1f), "暂无可信速度样本")
-                            DetailTrendCardV06("海拔", "m", altitudeSamples, Modifier.weight(1f), "暂无可信海拔样本")
+                            rowMetrics.forEach { metric ->
+                                RouteSnapshotMetricCellV07(metric, Modifier.weight(1f))
+                            }
+                        }
+                    }
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    metrics.forEachIndexed { index, metric ->
+                        RouteSnapshotMetricCellV07(metric, Modifier.weight(1f))
+                        if (index < metrics.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.width(1.dp).size(width = 1.dp, height = 42.dp),
+                                color = MaterialTheme.colorScheme.outline.copy(alpha = .18f),
+                            )
                         }
                     }
                 }
@@ -86,36 +143,122 @@ internal fun CompletedTripTrendsV06(points: List<TripPointEntity>) {
 }
 
 @Composable
-private fun DetailTrendCardV06(
-    title: String,
-    unit: String,
-    samples: List<TripTrendSampleV06>,
+private fun RouteSnapshotMetricCellV07(
+    metric: RouteSnapshotMetricV07,
     modifier: Modifier,
-    emptyText: String
 ) {
-    Surface(
+    val accent = EVDesignTokens.Energy.green
+    Row(
         modifier = modifier,
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surfaceContainer
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = accent.copy(alpha = .12f),
+        ) {
+            Icon(
+                metric.icon,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.padding(7.dp).size(18.dp),
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            Text(
+                metric.label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+            Text(
+                metric.value,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpeedTrendCardV07(samples: List<TripTrendSampleV06>) {
+    val accent = EVDesignTokens.Energy.green
+    val average = samples.takeIf { it.isNotEmpty() }?.map { it.value }?.average()
+    val max = samples.maxOfOrNull { it.value }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .16f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.sm),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text(title, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.ShowChart,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(21.dp),
+                )
+                Spacer(Modifier.width(9.dp))
+                Text(
+                    "速度趋势",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "可信 GPS",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             if (samples.size < 2) {
                 Text(
-                    emptyText,
-                    modifier = Modifier.height(96.dp),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    "暂无足够可信速度样本",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             } else {
-                TrendSummaryV06(unit = unit, samples = samples)
-                TripTrendPlotV06(
-                    samples = samples,
-                    unit = unit,
-                    longGapMs = DETAIL_TREND_LONG_GAP_MS
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .13f)),
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Row(Modifier.fillMaxWidth()) {
+                            TrendHeroMetricV07("平均", average, Modifier.weight(1f))
+                            HorizontalDivider(
+                                modifier = Modifier.width(1.dp).size(width = 1.dp, height = 48.dp),
+                                color = MaterialTheme.colorScheme.outline.copy(alpha = .16f),
+                            )
+                            TrendHeroMetricV07("最高", max, Modifier.weight(1f))
+                        }
+                        HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .13f))
+                        TripTrendPlotV06(
+                            samples = samples,
+                            unit = "km/h",
+                            longGapMs = DETAIL_TREND_LONG_GAP_MS,
+                        )
+                    }
+                }
+
+                Text(
+                    "长按查看读点 · 拖动时间轴 · 双指缩放区间",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -123,33 +266,33 @@ private fun DetailTrendCardV06(
 }
 
 @Composable
-private fun TrendSummaryV06(unit: String, samples: List<TripTrendSampleV06>) {
-    val min = samples.minOf { it.value }
-    val max = samples.maxOf { it.value }
-    val average = samples.map { it.value }.average()
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
+private fun TrendHeroMetricV07(
+    label: String,
+    value: Double?,
+    modifier: Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        if (unit == "km/h") {
-            TrendSummaryValueV06("平均", average, unit)
-            TrendSummaryValueV06("最高", max, unit)
-        } else {
-            TrendSummaryValueV06("最低", min, unit)
-            TrendSummaryValueV06("最高", max, unit)
-        }
-    }
-}
-
-@Composable
-private fun TrendSummaryValueV06(label: String, value: Double, unit: String) {
-    Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
-        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(
-            formatDetailTrendValueV06(value, unit),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                value?.let { String.format(Locale.US, "%.0f", it) } ?: "--",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                "km/h",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 
@@ -161,10 +304,22 @@ private fun trustedDetailSpeedV06(point: TripPointEntity): Double? {
             reportedSpeedMps = speed,
             provider = point.provider,
             horizontalAccuracyMeters = point.horizontalAccuracyMeters,
-            speedAccuracyMps = point.speedAccuracyMps
+            speedAccuracyMps = point.speedAccuracyMps,
         )
     }
 }
 
-private fun formatDetailTrendValueV06(value: Double, unit: String): String =
-    String.format(Locale.US, "%.0f %s", value, unit)
+private fun formatSpeedMetricV07(value: Double?): String =
+    value?.takeIf { it.isFinite() }?.let { String.format(Locale.US, "%.0f km/h", it) } ?: "--"
+
+private fun formatTrendDurationV07(durationMillis: Long): String {
+    val totalSeconds = (durationMillis / 1_000L).coerceAtLeast(0L)
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    val seconds = totalSeconds % 60L
+    return if (hours > 0L) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -259,6 +259,9 @@ private fun SpeedTrendCardV07(
                             samples = samples,
                             unit = "km/h",
                             longGapMs = DETAIL_TREND_LONG_GAP_MS,
+                            plotHeight = 168.dp,
+                            fillArea = true,
+                            showInteractionHeader = false,
                         )
                     }
                 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -21,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -130,8 +132,8 @@ private fun RouteSnapshotBarV07(
                     metrics.forEachIndexed { index, metric ->
                         RouteSnapshotMetricCellV07(metric, Modifier.weight(1f))
                         if (index < metrics.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.width(1.dp).size(width = 1.dp, height = 42.dp),
+                            VerticalDivider(
+                                modifier = Modifier.height(42.dp),
                                 color = MaterialTheme.colorScheme.outline.copy(alpha = .18f),
                             )
                         }
@@ -240,8 +242,8 @@ private fun SpeedTrendCardV07(samples: List<TripTrendSampleV06>) {
                     ) {
                         Row(Modifier.fillMaxWidth()) {
                             TrendHeroMetricV07("平均", average, Modifier.weight(1f))
-                            HorizontalDivider(
-                                modifier = Modifier.width(1.dp).size(width = 1.dp, height = 48.dp),
+                            VerticalDivider(
+                                modifier = Modifier.height(48.dp),
                                 color = MaterialTheme.colorScheme.outline.copy(alpha = .16f),
                             )
                             TrendHeroMetricV07("最高", max, Modifier.weight(1f))

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailTrendsV06.kt
@@ -111,7 +111,7 @@ private fun RouteSnapshotBarV07(
         BoxWithConstraints(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
         ) {
-            if (maxWidth < 360.dp) {
+            if (maxWidth < 400.dp) {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     metrics.chunked(2).forEach { rowMetrics ->
                         Row(

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackFullScreenV07.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackFullScreenV07.kt
@@ -1,0 +1,77 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.evchargebook.data.entity.TripPointEntity
+
+/**
+ * Playback intentionally uses a full-screen non-draggable container. Route pan/pinch gestures must
+ * never compete with a bottom-sheet collapse/dismiss gesture.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TripPlaybackFullScreenV07(
+    points: List<TripPointEntity>,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Scaffold(
+                modifier = Modifier.fillMaxSize(),
+                contentWindowInsets = WindowInsets(0, 0, 0, 0),
+                containerColor = MaterialTheme.colorScheme.background,
+                topBar = {
+                    TopAppBar(
+                        title = { Text("轨迹回放") },
+                        navigationIcon = {
+                            IconButton(onClick = onDismiss) {
+                                Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                            }
+                        },
+                        windowInsets = WindowInsets(0, 0, 0, 0),
+                        colors = TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.background,
+                        ),
+                    )
+                },
+            ) { padding ->
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    item {
+                        TripPlaybackRouteCardV06(points = points)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackOverlayAction.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackOverlayAction.kt
@@ -1,17 +1,9 @@
 package com.evchargebook.ui.trip
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayCircle
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,11 +11,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 
 /** Makes the trusted speed-colored route/playback reachable from the v0.6 detail surface. */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun TripPlaybackOverlayAction(
     points: List<TripPointEntity>,
@@ -39,21 +29,9 @@ internal fun TripPlaybackOverlayAction(
     )
 
     if (showPlayback) {
-        ModalBottomSheet(onDismissRequest = { showPlayback = false }) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            ) {
-                Text(
-                    "按可信 GPS 速度分段着色；灰色代表速度不可可信，真实长缺口保持断开。",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(8.dp))
-                TripPlaybackRouteCardV06(points = points)
-                Spacer(Modifier.height(24.dp))
-            }
-        }
+        TripPlaybackFullScreenV07(
+            points = points,
+            onDismiss = { showPlayback = false },
+        )
     }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
@@ -1,31 +1,13 @@
 package com.evchargebook.ui.trip
 
 import android.os.SystemClock
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -42,20 +24,10 @@ import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 import kotlinx.coroutines.delay
 
-/**
- * Full playback control card. The route itself is rendered by [TripRouteViewportV07], which is
- * also used by the normal completed route page so gesture, speed-color and gap semantics cannot
- * drift into two separate implementations again.
- */
 @Composable
-internal fun TripPlaybackRouteCardV06(
-    points: List<TripPointEntity>,
-    modifier: Modifier = Modifier,
-) {
+internal fun TripPlaybackRouteCardV06(points: List<TripPointEntity>, modifier: Modifier = Modifier) {
     val accent = EVDesignTokens.Energy.green
-    val playbackPoints = remember(points) {
-        points.filter { it.latitude.isFinite() && it.longitude.isFinite() }
-    }
+    val playbackPoints = remember(points) { points.filter { it.latitude.isFinite() && it.longitude.isFinite() } }
     val samples = remember(playbackPoints) {
         playbackPoints.map {
             TripPlaybackSample(
@@ -68,34 +40,24 @@ internal fun TripPlaybackRouteCardV06(
         }
     }
     val geometry = remember(playbackPoints) {
-        TripRouteGeometryBuilder.build(
-            playbackPoints.map {
-                TripGeoPoint(
-                    latitude = it.latitude,
-                    longitude = it.longitude,
-                    capturedAtEpochMillis = it.capturedAtEpochMillis,
-                    speedMps = trustedTripSpeedMpsV07(it),
-                    capturedAtElapsedRealtimeNanos = it.capturedAtElapsedRealtimeNanos,
-                )
-            }
-        )
+        TripRouteGeometryBuilder.build(playbackPoints.map {
+            TripGeoPoint(
+                latitude = it.latitude,
+                longitude = it.longitude,
+                capturedAtEpochMillis = it.capturedAtEpochMillis,
+                speedMps = trustedTripSpeedMpsV07(it),
+                capturedAtElapsedRealtimeNanos = it.capturedAtElapsedRealtimeNanos,
+            )
+        })
     }
     val totalMillis = remember(samples) { TripPlaybackTimeline.durationMillis(samples) }
-    val playable = geometry?.isDrawable == true &&
-        totalMillis > 0L &&
-        TripPlaybackTimeline.isChronological(samples)
-
+    val playable = geometry?.isDrawable == true && totalMillis > 0L && TripPlaybackTimeline.isChronological(samples)
     var playing by remember(playbackPoints.firstOrNull()?.tripId) { mutableStateOf(false) }
     var elapsedMillis by remember(playbackPoints.firstOrNull()?.tripId) { mutableLongStateOf(0L) }
     var speed by remember(playbackPoints.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
-
-    val frame = remember(samples, elapsedMillis) {
-        TripPlaybackTimeline.frameAt(samples, elapsedMillis)
-    }
-    val currentTrustedSpeedKph = frame
-        ?.let { playbackPoints.getOrNull(it.currentSampleIndex) }
-        ?.let(::trustedTripSpeedMpsV07)
-        ?.times(3.6)
+    val frame = remember(samples, elapsedMillis) { TripPlaybackTimeline.frameAt(samples, elapsedMillis) }
+    val currentTrustedSpeedKph = frame?.let { playbackPoints.getOrNull(it.currentSampleIndex) }
+        ?.let(::trustedTripSpeedMpsV07)?.times(3.6)
 
     LaunchedEffect(playing, speed, totalMillis) {
         if (!playing || totalMillis <= 0L) return@LaunchedEffect
@@ -103,139 +65,68 @@ internal fun TripPlaybackRouteCardV06(
         while (playing) {
             delay(50L)
             val now = SystemClock.elapsedRealtime()
-            val realDelta = (now - previousRealtime).coerceAtLeast(0L)
-            previousRealtime = now
             elapsedMillis = TripPlaybackTimeline.advanceElapsed(
                 currentElapsedMillis = elapsedMillis,
-                realDeltaMillis = realDelta,
+                realDeltaMillis = (now - previousRealtime).coerceAtLeast(0L),
                 speedMultiplier = speed,
                 totalMillis = totalMillis,
             )
+            previousRealtime = now
             if (elapsedMillis >= totalMillis) playing = false
         }
     }
 
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(
-                    "轨迹回放",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    when {
-                        !playable -> "当前轨迹不足以进行可信回放"
-                        frame?.isLongGap == true -> "GPS 缺口 · 保持最后真实定位点"
-                        else -> listOfNotNull(
-                            "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
-                            formatPlaybackSpeed(speed),
-                            currentTrustedSpeedKph?.let { String.format(Locale.US, "%.1f km/h", it) },
-                        ).joinToString(" · ")
-                    },
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (frame?.isLongGap == true) {
-                        MaterialTheme.colorScheme.error
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                )
-            }
+    Surface(modifier.fillMaxWidth(), shape = MaterialTheme.shapes.extraLarge, color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md), verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
+            Text("轨迹回放", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(
+                when {
+                    !playable -> "当前轨迹不足以进行可信回放"
+                    frame?.isLongGap == true -> "GPS 缺口 · 保持最后真实定位点"
+                    else -> listOfNotNull(
+                        "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
+                        formatPlaybackSpeed(speed),
+                        currentTrustedSpeedKph?.let { String.format(Locale.US, "%.1f km/h", it) },
+                    ).joinToString(" · ")
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = if (frame?.isLongGap == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
 
             if (playable) {
-                TripRouteViewportV07(
-                    points = playbackPoints,
-                    frame = frame,
-                    playbackMode = true,
-                    finalEndpoint = true,
-                )
-
+                TripRouteViewportV07(points = playbackPoints, frame = frame, playbackMode = true, finalEndpoint = true)
                 Slider(
                     value = elapsedMillis.toFloat().coerceIn(0f, totalMillis.toFloat()),
-                    onValueChange = {
-                        playing = false
-                        elapsedMillis = it.toLong().coerceIn(0L, totalMillis)
-                    },
+                    onValueChange = { playing = false; elapsedMillis = it.toLong().coerceIn(0L, totalMillis) },
                     valueRange = 0f..totalMillis.toFloat().coerceAtLeast(1f),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics { contentDescription = "行程回放进度" },
+                    modifier = Modifier.fillMaxWidth().semantics { contentDescription = "行程回放进度" },
                 )
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(
-                        onClick = {
-                            elapsedMillis = 0L
-                            playing = false
-                        },
-                        modifier = Modifier.size(48.dp),
-                    ) {
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = { elapsedMillis = 0L; playing = false }, modifier = Modifier.size(48.dp)) {
                         Icon(Icons.Default.Replay, contentDescription = "重新开始回放")
                     }
                     Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                    IconButton(
-                        onClick = {
-                            if (elapsedMillis >= totalMillis) elapsedMillis = 0L
-                            playing = !playing
-                        },
-                        modifier = Modifier.size(48.dp),
-                    ) {
-                        Icon(
-                            if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,
-                            contentDescription = if (playing) "暂停回放" else "开始回放",
-                        )
+                    IconButton(onClick = { if (elapsedMillis >= totalMillis) elapsedMillis = 0L; playing = !playing }, modifier = Modifier.size(48.dp)) {
+                        Icon(if (playing) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = if (playing) "暂停回放" else "开始回放")
                     }
                     Spacer(Modifier.width(MaterialTheme.spacing.sm))
-                    Text(
-                        "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
-                        modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Text("${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
-                ) {
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
                     TripPlaybackTimeline.speedPresets.forEach { preset ->
                         val selected = speed == preset
                         Surface(
                             onClick = { speed = preset },
                             modifier = Modifier.weight(1f).heightIn(min = 48.dp),
                             shape = MaterialTheme.shapes.medium,
-                            color = if (selected) {
-                                accent.copy(alpha = .12f)
-                            } else {
-                                MaterialTheme.colorScheme.surfaceContainerHigh
-                            },
+                            color = if (selected) accent.copy(alpha = .12f) else MaterialTheme.colorScheme.surfaceContainerHigh,
                         ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
-                                horizontalArrangement = Arrangement.Center,
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(
-                                    formatPlaybackSpeed(preset),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                                    color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                            Row(Modifier.fillMaxWidth().padding(vertical = 12.dp), horizontalArrangement = Arrangement.Center) {
+                                Text(formatPlaybackSpeed(preset), color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant, fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal)
                             }
                         }
                     }
                 }
-
                 if (frame?.isLongGap == true) {
                     Text(
                         "GPS 缺口 · ${formatPlaybackTime(frame.longGapStartElapsedMillis ?: 0L)} → ${formatPlaybackTime(frame.longGapEndElapsedMillis ?: elapsedMillis)}。缺失区间不会插值成连续驾驶。",
@@ -248,18 +139,13 @@ internal fun TripPlaybackRouteCardV06(
     }
 }
 
-private fun formatPlaybackSpeed(value: Float): String =
-    if (value % 1f == 0f) "${value.toInt()}×"
-    else String.format(Locale.US, "%.1f×", value)
+private fun formatPlaybackSpeed(value: Float): String = if (value % 1f == 0f) "${value.toInt()}×" else String.format(Locale.US, "%.1f×", value)
 
 private fun formatPlaybackTime(valueMillis: Long): String {
     val totalSeconds = valueMillis.coerceAtLeast(0L) / 1_000L
     val hours = totalSeconds / 3_600L
     val minutes = (totalSeconds % 3_600L) / 60L
     val seconds = totalSeconds % 60L
-    return if (hours > 0L) {
-        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
-    } else {
-        String.format(Locale.US, "%02d:%02d", minutes, seconds)
-    }
+    return if (hours > 0L) String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    else String.format(Locale.US, "%02d:%02d", minutes, seconds)
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripPlaybackRouteCardV06.kt
@@ -1,24 +1,14 @@
 package com.evchargebook.ui.trip
 
 import android.os.SystemClock
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -29,62 +19,38 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.rotate
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
-import com.evchargebook.domain.TripCaptureTimeRules
-import com.evchargebook.domain.TripContinuityRules
-import com.evchargebook.domain.TripPlaybackFrame
 import com.evchargebook.domain.TripPlaybackSample
 import com.evchargebook.domain.TripPlaybackTimeline
-import com.evchargebook.domain.TripSpeedTrustRules
 import com.evchargebook.domain.trip.TripGeoPoint
 import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-
-private val SpeedDeepRedV06 = Color(0xFFD32F2F)
-private val SpeedRedV06 = Color(0xFFE53935)
-private val SpeedAmberV06 = Color(0xFFFF9800)
-private val SpeedYellowV06 = Color(0xFFFDD835)
-private val SpeedGreenV06 = Color(0xFF43A047)
-private val SpeedBlueV06 = Color(0xFF1E88E5)
-private val SpeedDeepBlueV06 = Color(0xFF1565C0)
-private val SpeedUnknownV06 = Color(0xFF7A7F86)
 
 /**
- * Completed-Trip playback surface for the current no-basemap renderer.
- *
- * Playback is presentation-only. It reads persisted TripPoint chronology and delegates seek/gap
- * semantics to TripPlaybackTimeline; no TripPoint or TripSession is ever changed here.
+ * Full playback control card. The route itself is rendered by [TripRouteViewportV07], which is
+ * also used by the normal completed route page so gesture, speed-color and gap semantics cannot
+ * drift into two separate implementations again.
  */
 @Composable
 internal fun TripPlaybackRouteCardV06(
     points: List<TripPointEntity>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val accent = EVDesignTokens.Energy.green
     val playbackPoints = remember(points) {
@@ -108,16 +74,17 @@ internal fun TripPlaybackRouteCardV06(
                     latitude = it.latitude,
                     longitude = it.longitude,
                     capturedAtEpochMillis = it.capturedAtEpochMillis,
-                    speedMps = trustedPlaybackSpeed(it),
+                    speedMps = trustedTripSpeedMpsV07(it),
                     capturedAtElapsedRealtimeNanos = it.capturedAtElapsedRealtimeNanos,
                 )
             }
         )
     }
     val totalMillis = remember(samples) { TripPlaybackTimeline.durationMillis(samples) }
-    val playable = geometry?.isDrawable == true && totalMillis > 0L && TripPlaybackTimeline.isChronological(samples)
+    val playable = geometry?.isDrawable == true &&
+        totalMillis > 0L &&
+        TripPlaybackTimeline.isChronological(samples)
 
-    var playbackMode by remember(playbackPoints.firstOrNull()?.tripId) { mutableStateOf(false) }
     var playing by remember(playbackPoints.firstOrNull()?.tripId) { mutableStateOf(false) }
     var elapsedMillis by remember(playbackPoints.firstOrNull()?.tripId) { mutableLongStateOf(0L) }
     var speed by remember(playbackPoints.firstOrNull()?.tripId) { mutableFloatStateOf(1f) }
@@ -127,7 +94,7 @@ internal fun TripPlaybackRouteCardV06(
     }
     val currentTrustedSpeedKph = frame
         ?.let { playbackPoints.getOrNull(it.currentSampleIndex) }
-        ?.let(::trustedPlaybackSpeed)
+        ?.let(::trustedTripSpeedMpsV07)
         ?.times(3.6)
 
     LaunchedEffect(playing, speed, totalMillis) {
@@ -142,7 +109,7 @@ internal fun TripPlaybackRouteCardV06(
                 currentElapsedMillis = elapsedMillis,
                 realDeltaMillis = realDelta,
                 speedMultiplier = speed,
-                totalMillis = totalMillis
+                totalMillis = totalMillis,
             )
             if (elapsedMillis >= totalMillis) playing = false
         }
@@ -150,61 +117,45 @@ internal fun TripPlaybackRouteCardV06(
 
     Surface(
         modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-                    Text("轨迹回放", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                    Text(
-                        when {
-                            !playable -> "当前轨迹不足以进行可信回放"
-                            playbackMode && frame?.isLongGap == true -> "GPS 缺口 · 保持最后真实定位点"
-                            playbackMode -> listOfNotNull(
-                                "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
-                                formatPlaybackSpeed(speed),
-                                currentTrustedSpeedKph?.let { String.format(Locale.US, "%.1f km/h", it) }
-                            ).joinToString(" · ")
-                            else -> "${playbackPoints.size} 个 GPS 点 · 按真实时间推进"
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (playbackMode && frame?.isLongGap == true) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                TextButton(
-                    onClick = {
-                        playbackMode = !playbackMode
-                        playing = false
-                        if (!playbackMode) elapsedMillis = 0L
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    "轨迹回放",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    when {
+                        !playable -> "当前轨迹不足以进行可信回放"
+                        frame?.isLongGap == true -> "GPS 缺口 · 保持最后真实定位点"
+                        else -> listOfNotNull(
+                            "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
+                            formatPlaybackSpeed(speed),
+                            currentTrustedSpeedKph?.let { String.format(Locale.US, "%.1f km/h", it) },
+                        ).joinToString(" · ")
                     },
-                    enabled = playable,
-                    modifier = Modifier.heightIn(min = 48.dp)
-                ) {
-                    Text(if (playbackMode) "退出" else "回放")
-                }
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (frame?.isLongGap == true) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
             }
 
-            SpeedLegendV06()
-
-            if (playbackMode && playable) {
-                geometry?.takeIf { it.isDrawable }?.let { routeGeometry ->
-                    PlaybackCanvasV06(
-                        points = playbackPoints,
-                        frame = frame,
-                        minLatitude = routeGeometry.minLatitude,
-                        maxLatitude = routeGeometry.maxLatitude,
-                        minLongitude = routeGeometry.minLongitude,
-                        maxLongitude = routeGeometry.maxLongitude,
-                        accent = accent
-                    )
-                }
+            if (playable) {
+                TripRouteViewportV07(
+                    points = playbackPoints,
+                    frame = frame,
+                    playbackMode = true,
+                    finalEndpoint = true,
+                )
 
                 Slider(
                     value = elapsedMillis.toFloat().coerceIn(0f, totalMillis.toFloat()),
@@ -213,11 +164,22 @@ internal fun TripPlaybackRouteCardV06(
                         elapsedMillis = it.toLong().coerceIn(0L, totalMillis)
                     },
                     valueRange = 0f..totalMillis.toFloat().coerceAtLeast(1f),
-                    modifier = Modifier.fillMaxWidth().semantics { contentDescription = "行程回放进度" }
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = "行程回放进度" },
                 )
 
-                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = { elapsedMillis = 0L; playing = false }, modifier = Modifier.size(48.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(
+                        onClick = {
+                            elapsedMillis = 0L
+                            playing = false
+                        },
+                        modifier = Modifier.size(48.dp),
+                    ) {
                         Icon(Icons.Default.Replay, contentDescription = "重新开始回放")
                     }
                     Spacer(Modifier.width(MaterialTheme.spacing.xs))
@@ -226,38 +188,48 @@ internal fun TripPlaybackRouteCardV06(
                             if (elapsedMillis >= totalMillis) elapsedMillis = 0L
                             playing = !playing
                         },
-                        modifier = Modifier.size(48.dp)
+                        modifier = Modifier.size(48.dp),
                     ) {
-                        Icon(if (playing) Icons.Default.Pause else Icons.Default.PlayArrow, contentDescription = if (playing) "暂停回放" else "开始回放")
+                        Icon(
+                            if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            contentDescription = if (playing) "暂停回放" else "开始回放",
+                        )
                     }
                     Spacer(Modifier.width(MaterialTheme.spacing.sm))
                     Text(
                         "${formatPlaybackTime(elapsedMillis)} / ${formatPlaybackTime(totalMillis)}",
                         modifier = Modifier.weight(1f),
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
 
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.xs),
+                ) {
                     TripPlaybackTimeline.speedPresets.forEach { preset ->
                         val selected = speed == preset
                         Surface(
                             onClick = { speed = preset },
                             modifier = Modifier.weight(1f).heightIn(min = 48.dp),
                             shape = MaterialTheme.shapes.medium,
-                            color = if (selected) accent.copy(alpha = .12f) else MaterialTheme.colorScheme.surfaceContainerHigh
+                            color = if (selected) {
+                                accent.copy(alpha = .12f)
+                            } else {
+                                MaterialTheme.colorScheme.surfaceContainerHigh
+                            },
                         ) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
                                 horizontalArrangement = Arrangement.Center,
-                                verticalAlignment = Alignment.CenterVertically
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 Text(
                                     formatPlaybackSpeed(preset),
                                     style = MaterialTheme.typography.labelMedium,
                                     fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                                    color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant
+                                    color = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                         }
@@ -268,7 +240,7 @@ internal fun TripPlaybackRouteCardV06(
                     Text(
                         "GPS 缺口 · ${formatPlaybackTime(frame.longGapStartElapsedMillis ?: 0L)} → ${formatPlaybackTime(frame.longGapEndElapsedMillis ?: elapsedMillis)}。缺失区间不会插值成连续驾驶。",
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.error
+                        color = MaterialTheme.colorScheme.error,
                     )
                 }
             }
@@ -276,243 +248,18 @@ internal fun TripPlaybackRouteCardV06(
     }
 }
 
-@Composable
-private fun SpeedLegendV06() {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        SpeedLegendItemV06("低速", SpeedRedV06)
-        SpeedLegendItemV06("中速", SpeedYellowV06)
-        SpeedLegendItemV06("较快", SpeedGreenV06)
-        SpeedLegendItemV06("高速", SpeedBlueV06)
-        SpeedLegendItemV06("未知", SpeedUnknownV06)
-    }
-}
-
-@Composable
-private fun SpeedLegendItemV06(label: String, color: Color) {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Box(Modifier.size(6.dp).background(color, CircleShape))
-        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-}
-
-@Composable
-private fun PlaybackCanvasV06(
-    points: List<TripPointEntity>,
-    frame: TripPlaybackFrame?,
-    minLatitude: Double,
-    maxLatitude: Double,
-    minLongitude: Double,
-    maxLongitude: Double,
-    accent: Color
-) {
-    val endColor = MaterialTheme.colorScheme.error
-    val viewportKey = points.firstOrNull()?.tripId
-    var zoom by remember(viewportKey) { mutableFloatStateOf(1f) }
-    var pan by remember(viewportKey) { mutableStateOf(Offset.Zero) }
-    val scope = rememberCoroutineScope()
-    val viewportChanged = zoom > 1.001f || pan != Offset.Zero
-
-    fun animateBackToFullRoute() {
-        val startZoom = zoom
-        val startPan = pan
-        scope.launch {
-            animate(
-                initialValue = 0f,
-                targetValue = 1f,
-                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing)
-            ) { fraction, _ ->
-                zoom = startZoom + (1f - startZoom) * fraction
-                pan = Offset(startPan.x * (1f - fraction), startPan.y * (1f - fraction))
-            }
-        }
-    }
-
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                "双指缩放 · 拖动查看 · 颜色表示可信 GPS 速度区段",
-                modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            if (viewportChanged) {
-                TextButton(onClick = ::animateBackToFullRoute) { Text("回到全程", style = MaterialTheme.typography.labelSmall) }
-            }
-        }
-
-        Canvas(
-            Modifier
-                .fillMaxWidth()
-                .height(190.dp)
-                .pointerInput(viewportKey) {
-                    detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
-                        val oldZoom = zoom.coerceAtLeast(1f)
-                        val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
-                        val ratio = newZoom / oldZoom
-                        val center = Offset(size.width / 2f, size.height / 2f)
-                        val anchoredPan = Offset(
-                            x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
-                            y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio
-                        )
-                        val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
-                        val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
-                        zoom = newZoom
-                        pan = Offset(
-                            x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
-                            y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY)
-                        )
-                    }
-                }
-                .semantics {
-                    contentDescription = if (frame?.isLongGap == true) {
-                        "可拖动缩放的行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
-                    } else {
-                        "可拖动缩放的行程轨迹回放；轨迹颜色表示可信 GPS 速度区段，移动标记沿真实定位时间推进"
-                    }
-                }
-        ) {
-            if (points.isEmpty()) return@Canvas
-            val pad = 12.dp.toPx()
-            val width = (size.width - pad * 2).coerceAtLeast(1f)
-            val height = (size.height - pad * 2).coerceAtLeast(1f)
-            val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.0 } ?: 1.0
-            val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.0 } ?: 1.0
-            val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
-            val center = Offset(size.width / 2f, size.height / 2f)
-
-            fun project(latitude: Double, longitude: Double): Offset {
-                val x = ((longitude - minLongitude) / lonSpan).toFloat().coerceIn(0f, 1f)
-                val y = (1.0 - (latitude - minLatitude) / latSpan).toFloat().coerceIn(0f, 1f)
-                val base = Offset(pad + x * width, pad + y * height)
-                return Offset(
-                    x = center.x + (base.x - center.x) * zoom + pan.x,
-                    y = center.y + (base.y - center.y) * zoom + pan.y
-                )
-            }
-
-            fun segmentStyle(from: TripPointEntity, to: TripPointEntity): Pair<Color, Float> {
-                val speedMps = trustedPlaybackSpeed(to) ?: trustedPlaybackSpeed(from)
-                val speedKph = speedMps?.times(3.6)
-                val color = trustedSpeedColorV06(speedKph)
-                val normalized = speedKph?.let { (it / 120.0).toFloat().coerceIn(0f, 1f) } ?: 0f
-                val stroke = (2.7f + normalized * 1.7f).dp.toPx()
-                return color to stroke
-            }
-
-            points.zipWithNext().forEachIndexed { index, (from, to) ->
-                val timing = TripCaptureTimeRules.between(
-                    previousEpochMillis = from.capturedAtEpochMillis,
-                    previousElapsedRealtimeNanos = from.capturedAtElapsedRealtimeNanos,
-                    currentEpochMillis = to.capturedAtEpochMillis,
-                    currentElapsedRealtimeNanos = to.capturedAtElapsedRealtimeNanos,
-                )
-                if (!timing.accepted || timing.breaksContinuity(longGapMillis)) return@forEachIndexed
-
-                val start = project(from.latitude, from.longitude)
-                val end = project(to.latitude, to.longitude)
-                val (segmentColor, segmentStroke) = segmentStyle(from, to)
-                drawLine(
-                    color = segmentColor.copy(alpha = .25f),
-                    start = start,
-                    end = end,
-                    strokeWidth = segmentStroke,
-                    cap = StrokeCap.Round
-                )
-
-                val currentFrame = frame
-                when {
-                    currentFrame == null -> Unit
-                    index < currentFrame.currentSampleIndex ->
-                        drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
-                    index == currentFrame.currentSampleIndex &&
-                        currentFrame.nextSampleIndex == index + 1 &&
-                        !currentFrame.isLongGap -> {
-                        val fraction = currentFrame.segmentFraction.toFloat().coerceIn(0f, 1f)
-                        val partial = Offset(
-                            x = start.x + (end.x - start.x) * fraction,
-                            y = start.y + (end.y - start.y) * fraction
-                        )
-                        drawLine(segmentColor, start, partial, segmentStroke, StrokeCap.Round)
-                    }
-                }
-            }
-
-            val startPoint = project(points.first().latitude, points.first().longitude)
-            val endPoint = project(points.last().latitude, points.last().longitude)
-            val markerSize = 6.dp.toPx()
-            val startTriangle = Path().apply {
-                moveTo(startPoint.x - markerSize * .45f, startPoint.y - markerSize)
-                lineTo(startPoint.x + markerSize, startPoint.y)
-                lineTo(startPoint.x - markerSize * .45f, startPoint.y + markerSize)
-                close()
-            }
-            drawPath(startTriangle, accent)
-
-            val poleHeight = 13.dp.toPx()
-            val flagWidth = 9.dp.toPx()
-            val flagHeight = 6.dp.toPx()
-            drawLine(endColor, endPoint, Offset(endPoint.x, endPoint.y - poleHeight), strokeWidth = 2.dp.toPx(), cap = StrokeCap.Round)
-            val flag = Path().apply {
-                moveTo(endPoint.x, endPoint.y - poleHeight)
-                lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight)
-                lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight + flagHeight)
-                lineTo(endPoint.x, endPoint.y - poleHeight + flagHeight)
-                close()
-            }
-            drawPath(flag, endColor)
-
-            frame?.let { current ->
-                val currentOffset = project(current.latitude, current.longitude)
-                val direction = current.bearingDegrees?.takeIf { it.isFinite() }?.toFloat() ?: 0f
-                val vehicleSize = 7.dp.toPx()
-                val vehicle = Path().apply {
-                    moveTo(currentOffset.x, currentOffset.y - vehicleSize)
-                    lineTo(currentOffset.x + vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
-                    lineTo(currentOffset.x, currentOffset.y + vehicleSize * .30f)
-                    lineTo(currentOffset.x - vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
-                    close()
-                }
-                rotate(degrees = direction, pivot = currentOffset) { drawPath(vehicle, accent) }
-            }
-        }
-    }
-}
-
-private fun trustedSpeedColorV06(speedKph: Double?): Color = when {
-    speedKph == null || !speedKph.isFinite() -> SpeedUnknownV06
-    speedKph < 5.0 -> SpeedDeepRedV06
-    speedKph < 15.0 -> SpeedRedV06
-    speedKph < 30.0 -> SpeedAmberV06
-    speedKph < 50.0 -> SpeedYellowV06
-    speedKph < 70.0 -> SpeedGreenV06
-    speedKph < 90.0 -> SpeedBlueV06
-    else -> SpeedDeepBlueV06
-}
-
-private fun trustedPlaybackSpeed(point: TripPointEntity): Double? {
-    val value = point.speedMps ?: return null
-    return value.takeIf {
-        TripSpeedTrustRules.eligibleForMeasuredSpeed(
-            reportedSpeedMps = value,
-            provider = point.provider,
-            horizontalAccuracyMeters = point.horizontalAccuracyMeters,
-            speedAccuracyMps = point.speedAccuracyMps
-        )
-    }
-}
-
 private fun formatPlaybackSpeed(value: Float): String =
-    if (value % 1f == 0f) "${value.toInt()}×" else String.format(Locale.US, "%.1f×", value)
+    if (value % 1f == 0f) "${value.toInt()}×"
+    else String.format(Locale.US, "%.1f×", value)
 
 private fun formatPlaybackTime(valueMillis: Long): String {
     val totalSeconds = valueMillis.coerceAtLeast(0L) / 1_000L
     val hours = totalSeconds / 3_600L
     val minutes = (totalSeconds % 3_600L) / 60L
     val seconds = totalSeconds % 60L
-    return if (hours > 0L) String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
-    else String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    return if (hours > 0L) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripRouteViewportV07.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripRouteViewportV07.kt
@@ -3,20 +3,24 @@ package com.evchargebook.ui.trip
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -29,11 +33,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
@@ -46,18 +52,19 @@ import com.evchargebook.domain.trip.TripRouteGeometryBuilder
 import com.evchargebook.ui.theme.EVDesignTokens
 import kotlinx.coroutines.launch
 
-private val SpeedDeepRedV07 = Color(0xFFD32F2F)
-private val SpeedRedV07 = Color(0xFFE53935)
-private val SpeedAmberV07 = Color(0xFFFF9800)
-private val SpeedYellowV07 = Color(0xFFFDD835)
-private val SpeedGreenV07 = Color(0xFF43A047)
-private val SpeedBlueV07 = Color(0xFF1E88E5)
-private val SpeedDeepBlueV07 = Color(0xFF1565C0)
-private val SpeedUnknownV07 = Color(0xFF7A7F86)
+private val SpeedLowV07 = Color(0xFFFF4D5A)
+private val SpeedLowMidV07 = Color(0xFFFF982E)
+private val SpeedMidV07 = Color(0xFFFFD928)
+private val SpeedCruiseV07 = Color(0xFF2FE36F)
+private val SpeedFastV07 = Color(0xFF2BD9E8)
+private val SpeedHighV07 = Color(0xFF4C7DFF)
+private val SpeedVeryHighV07 = Color(0xFFB64CFF)
+private val SpeedUnknownV07 = Color(0xFF78818D)
 
 /**
  * Shared completed-Trip route renderer used by both the normal route page and playback.
- * Geometry is presentation-only and never mutates persisted TripPoint facts.
+ * The decorative grid is intentionally non-geographic; persisted TripPoint coordinates remain the
+ * only route truth and real long gaps/rebases never become a continuous route.
  */
 @Composable
 internal fun TripRouteViewportV07(
@@ -66,7 +73,7 @@ internal fun TripRouteViewportV07(
     frame: TripPlaybackFrame? = null,
     playbackMode: Boolean = false,
     finalEndpoint: Boolean = true,
-    height: Dp = 190.dp,
+    height: Dp = 230.dp,
 ) {
     val routePoints = remember(points) {
         points.filter { it.latitude.isFinite() && it.longitude.isFinite() }
@@ -89,9 +96,8 @@ internal fun TripRouteViewportV07(
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        TripSpeedLegendV07()
         InteractiveTripRouteCanvasV07(
             points = routePoints,
             frame = frame,
@@ -103,37 +109,75 @@ internal fun TripRouteViewportV07(
             maxLongitude = geometry.maxLongitude,
             height = height,
         )
+        TripSpeedLegendV07()
     }
 }
 
 @Composable
 internal fun TripSpeedLegendV07(modifier: Modifier = Modifier) {
-    Column(
+    Surface(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(5.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .56f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .20f)),
     ) {
-        Text(
-            "可信 GPS 时速区间 · km/h",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            SpeedLegendCellV07("0–5", SpeedDeepRedV07, Modifier.weight(1f))
-            SpeedLegendCellV07("5–15", SpeedRedV07, Modifier.weight(1f))
-            SpeedLegendCellV07("15–30", SpeedAmberV07, Modifier.weight(1f))
-            SpeedLegendCellV07("30–50", SpeedYellowV07, Modifier.weight(1f))
+            Text(
+                "速度（km/h）",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                if (maxWidth < 390.dp) {
+                    Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+                        LegendRowV07(
+                            listOf(
+                                "0–5" to SpeedLowV07,
+                                "5–15" to SpeedLowMidV07,
+                                "15–30" to SpeedMidV07,
+                                "30–50" to SpeedCruiseV07,
+                            )
+                        )
+                        LegendRowV07(
+                            listOf(
+                                "50–70" to SpeedFastV07,
+                                "70–90" to SpeedHighV07,
+                                "90+" to SpeedVeryHighV07,
+                                "未知" to SpeedUnknownV07,
+                            )
+                        )
+                    }
+                } else {
+                    LegendRowV07(
+                        listOf(
+                            "0–5" to SpeedLowV07,
+                            "5–15" to SpeedLowMidV07,
+                            "15–30" to SpeedMidV07,
+                            "30–50" to SpeedCruiseV07,
+                            "50–70" to SpeedFastV07,
+                            "70–90" to SpeedHighV07,
+                            "90+" to SpeedVeryHighV07,
+                            "未知" to SpeedUnknownV07,
+                        )
+                    )
+                }
+            }
         }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            SpeedLegendCellV07("50–70", SpeedGreenV07, Modifier.weight(1f))
-            SpeedLegendCellV07("70–90", SpeedBlueV07, Modifier.weight(1f))
-            SpeedLegendCellV07("90+", SpeedDeepBlueV07, Modifier.weight(1f))
-            SpeedLegendCellV07("未知", SpeedUnknownV07, Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun LegendRowV07(items: List<Pair<String, Color>>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items.forEach { (label, color) ->
+            SpeedLegendCellV07(label, color, Modifier.weight(1f))
         }
     }
 }
@@ -170,6 +214,9 @@ private fun InteractiveTripRouteCanvasV07(
     val accent = EVDesignTokens.Energy.green
     val endColor = MaterialTheme.colorScheme.error
     val viewportKey = points.firstOrNull()?.tripId
+    val gridColor = MaterialTheme.colorScheme.outline.copy(alpha = .075f)
+    val gapColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .66f)
+    val markerOutline = MaterialTheme.colorScheme.onSurface.copy(alpha = .92f)
     var zoom by remember(viewportKey) { mutableFloatStateOf(1f) }
     var pan by remember(viewportKey) { mutableStateOf(Offset.Zero) }
     val scope = rememberCoroutineScope()
@@ -193,175 +240,242 @@ private fun InteractiveTripRouteCanvasV07(
         }
     }
 
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                "双指缩放 · 单指拖动查看",
-                modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            if (viewportChanged) {
-                TextButton(onClick = ::animateBackToFullRoute) {
-                    Text("回到全程", style = MaterialTheme.typography.labelSmall)
-                }
-            }
-        }
-
-        Canvas(
-            Modifier
-                .fillMaxWidth()
-                .height(height)
-                .pointerInput(viewportKey) {
-                    detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
-                        val oldZoom = zoom.coerceAtLeast(1f)
-                        val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
-                        val ratio = newZoom / oldZoom
-                        val center = Offset(size.width / 2f, size.height / 2f)
-                        val anchoredPan = Offset(
-                            x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
-                            y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio,
-                        )
-                        val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
-                        val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
-                        zoom = newZoom
-                        pan = Offset(
-                            x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
-                            y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY),
-                        )
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLowest,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .17f)),
+    ) {
+        Box(Modifier.fillMaxWidth()) {
+            Canvas(
+                Modifier
+                    .fillMaxWidth()
+                    .height(height)
+                    .pointerInput(viewportKey) {
+                        detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
+                            val oldZoom = zoom.coerceAtLeast(1f)
+                            val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
+                            val ratio = newZoom / oldZoom
+                            val center = Offset(size.width / 2f, size.height / 2f)
+                            val anchoredPan = Offset(
+                                x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
+                                y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio,
+                            )
+                            val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
+                            val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
+                            zoom = newZoom
+                            pan = Offset(
+                                x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
+                                y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY),
+                            )
+                        }
                     }
+                    .semantics {
+                        contentDescription = when {
+                            playbackMode && frame?.isLongGap == true ->
+                                "可拖动缩放的行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
+                            playbackMode ->
+                                "可拖动缩放的行程轨迹回放；轨迹颜色表示可信 GPS 时速区间"
+                            else ->
+                                "可拖动缩放的真实行程轨迹；轨迹颜色表示可信 GPS 时速区间；灰色虚线仅标识 GPS 长缺口，并非真实道路轨迹"
+                        }
+                    },
+            ) {
+                if (points.isEmpty()) return@Canvas
+
+                val gridStep = 42.dp.toPx()
+                var gridX = 0f
+                while (gridX <= size.width) {
+                    drawLine(gridColor, Offset(gridX, 0f), Offset(gridX, size.height), 1.dp.toPx())
+                    gridX += gridStep
                 }
-                .semantics {
-                    contentDescription = when {
-                        playbackMode && frame?.isLongGap == true ->
-                            "可拖动缩放的行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
-                        playbackMode ->
-                            "可拖动缩放的行程轨迹回放；轨迹颜色表示可信 GPS 时速区间"
-                        else ->
-                            "可拖动缩放的真实行程轨迹；轨迹颜色表示可信 GPS 时速区间，断开表示 GPS 长缺口"
+                var gridY = 0f
+                while (gridY <= size.height) {
+                    drawLine(gridColor, Offset(0f, gridY), Offset(size.width, gridY), 1.dp.toPx())
+                    gridY += gridStep
+                }
+
+                val padX = 18.dp.toPx()
+                val padTop = 18.dp.toPx()
+                val padBottom = 58.dp.toPx()
+                val width = (size.width - padX * 2).coerceAtLeast(1f)
+                val canvasHeight = (size.height - padTop - padBottom).coerceAtLeast(1f)
+                val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.0 } ?: 1.0
+                val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.0 } ?: 1.0
+                val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+                val center = Offset(size.width / 2f, (padTop + canvasHeight / 2f))
+                val gapDash = PathEffect.dashPathEffect(
+                    floatArrayOf(7.dp.toPx(), 7.dp.toPx()),
+                )
+
+                fun project(latitude: Double, longitude: Double): Offset {
+                    val x = ((longitude - minLongitude) / lonSpan).toFloat().coerceIn(0f, 1f)
+                    val y = (1.0 - (latitude - minLatitude) / latSpan).toFloat().coerceIn(0f, 1f)
+                    val base = Offset(padX + x * width, padTop + y * canvasHeight)
+                    return Offset(
+                        x = center.x + (base.x - center.x) * zoom + pan.x,
+                        y = center.y + (base.y - center.y) * zoom + pan.y,
+                    )
+                }
+
+                fun segmentStyle(from: TripPointEntity, to: TripPointEntity): Pair<Color, Float> {
+                    val speedKph = (trustedTripSpeedMpsV07(to) ?: trustedTripSpeedMpsV07(from))?.times(3.6)
+                    val normalized = speedKph?.let { (it / 120.0).toFloat().coerceIn(0f, 1f) } ?: 0f
+                    return trustedSpeedColorV07(speedKph) to (3.2f + normalized * 1.7f).dp.toPx()
+                }
+
+                points.zipWithNext().forEachIndexed { index, (from, to) ->
+                    val timing = TripCaptureTimeRules.between(
+                        previousEpochMillis = from.capturedAtEpochMillis,
+                        previousElapsedRealtimeNanos = from.capturedAtElapsedRealtimeNanos,
+                        currentEpochMillis = to.capturedAtEpochMillis,
+                        currentElapsedRealtimeNanos = to.capturedAtElapsedRealtimeNanos,
+                    )
+                    if (!timing.accepted) return@forEachIndexed
+
+                    val start = project(from.latitude, from.longitude)
+                    val end = project(to.latitude, to.longitude)
+                    if (timing.breaksContinuity(longGapMillis)) {
+                        drawLine(
+                            color = gapColor,
+                            start = start,
+                            end = end,
+                            strokeWidth = 2.dp.toPx(),
+                            cap = StrokeCap.Round,
+                            pathEffect = gapDash,
+                        )
+                        return@forEachIndexed
                     }
-                },
-        ) {
-            if (points.isEmpty()) return@Canvas
-            val pad = 12.dp.toPx()
-            val width = (size.width - pad * 2).coerceAtLeast(1f)
-            val canvasHeight = (size.height - pad * 2).coerceAtLeast(1f)
-            val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.0 } ?: 1.0
-            val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.0 } ?: 1.0
-            val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
-            val center = Offset(size.width / 2f, size.height / 2f)
 
-            fun project(latitude: Double, longitude: Double): Offset {
-                val x = ((longitude - minLongitude) / lonSpan).toFloat().coerceIn(0f, 1f)
-                val y = (1.0 - (latitude - minLatitude) / latSpan).toFloat().coerceIn(0f, 1f)
-                val base = Offset(pad + x * width, pad + y * canvasHeight)
-                return Offset(
-                    x = center.x + (base.x - center.x) * zoom + pan.x,
-                    y = center.y + (base.y - center.y) * zoom + pan.y,
-                )
-            }
-
-            fun segmentStyle(from: TripPointEntity, to: TripPointEntity): Pair<Color, Float> {
-                val speedKph = (trustedTripSpeedMpsV07(to) ?: trustedTripSpeedMpsV07(from))?.times(3.6)
-                val normalized = speedKph?.let { (it / 120.0).toFloat().coerceIn(0f, 1f) } ?: 0f
-                return trustedSpeedColorV07(speedKph) to (2.7f + normalized * 1.7f).dp.toPx()
-            }
-
-            points.zipWithNext().forEachIndexed { index, (from, to) ->
-                val timing = TripCaptureTimeRules.between(
-                    previousEpochMillis = from.capturedAtEpochMillis,
-                    previousElapsedRealtimeNanos = from.capturedAtElapsedRealtimeNanos,
-                    currentEpochMillis = to.capturedAtEpochMillis,
-                    currentElapsedRealtimeNanos = to.capturedAtElapsedRealtimeNanos,
-                )
-                if (!timing.accepted || timing.breaksContinuity(longGapMillis)) return@forEachIndexed
-
-                val start = project(from.latitude, from.longitude)
-                val end = project(to.latitude, to.longitude)
-                val (segmentColor, segmentStroke) = segmentStyle(from, to)
-
-                if (!playbackMode) {
-                    drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
-                    return@forEachIndexed
-                }
-
-                drawLine(
-                    color = segmentColor.copy(alpha = .25f),
-                    start = start,
-                    end = end,
-                    strokeWidth = segmentStroke,
-                    cap = StrokeCap.Round,
-                )
-
-                val currentFrame = frame
-                when {
-                    currentFrame == null -> Unit
-                    index < currentFrame.currentSampleIndex ->
+                    val (segmentColor, segmentStroke) = segmentStyle(from, to)
+                    if (!playbackMode) {
                         drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
-                    index == currentFrame.currentSampleIndex &&
-                        currentFrame.nextSampleIndex == index + 1 &&
-                        !currentFrame.isLongGap -> {
-                        val fraction = currentFrame.segmentFraction.toFloat().coerceIn(0f, 1f)
-                        val partial = Offset(
-                            x = start.x + (end.x - start.x) * fraction,
-                            y = start.y + (end.y - start.y) * fraction,
-                        )
-                        drawLine(segmentColor, start, partial, segmentStroke, StrokeCap.Round)
+                        return@forEachIndexed
+                    }
+
+                    drawLine(
+                        color = segmentColor.copy(alpha = .22f),
+                        start = start,
+                        end = end,
+                        strokeWidth = segmentStroke,
+                        cap = StrokeCap.Round,
+                    )
+
+                    val currentFrame = frame
+                    when {
+                        currentFrame == null -> Unit
+                        index < currentFrame.currentSampleIndex ->
+                            drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
+                        index == currentFrame.currentSampleIndex &&
+                            currentFrame.nextSampleIndex == index + 1 &&
+                            !currentFrame.isLongGap -> {
+                            val fraction = currentFrame.segmentFraction.toFloat().coerceIn(0f, 1f)
+                            val partial = Offset(
+                                x = start.x + (end.x - start.x) * fraction,
+                                y = start.y + (end.y - start.y) * fraction,
+                            )
+                            drawLine(segmentColor, start, partial, segmentStroke, StrokeCap.Round)
+                        }
                     }
                 }
-            }
 
-            val startPoint = project(points.first().latitude, points.first().longitude)
-            val endPoint = project(points.last().latitude, points.last().longitude)
-            val markerSize = 6.dp.toPx()
-            val startTriangle = Path().apply {
-                moveTo(startPoint.x - markerSize * .45f, startPoint.y - markerSize)
-                lineTo(startPoint.x + markerSize, startPoint.y)
-                lineTo(startPoint.x - markerSize * .45f, startPoint.y + markerSize)
-                close()
-            }
-            drawPath(startTriangle, accent)
+                val startPoint = project(points.first().latitude, points.first().longitude)
+                val endPoint = project(points.last().latitude, points.last().longitude)
 
-            if (finalEndpoint) {
-                val poleHeight = 13.dp.toPx()
-                val flagWidth = 9.dp.toPx()
-                val flagHeight = 6.dp.toPx()
-                drawLine(
-                    endColor,
-                    endPoint,
-                    Offset(endPoint.x, endPoint.y - poleHeight),
-                    strokeWidth = 2.dp.toPx(),
-                    cap = StrokeCap.Round,
-                )
-                val flag = Path().apply {
-                    moveTo(endPoint.x, endPoint.y - poleHeight)
-                    lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight)
-                    lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight + flagHeight)
-                    lineTo(endPoint.x, endPoint.y - poleHeight + flagHeight)
-                    close()
-                }
-                drawPath(flag, endColor)
-            } else {
-                drawCircle(accent.copy(alpha = .22f), 6.dp.toPx(), endPoint)
-                drawCircle(accent, 3.dp.toPx(), endPoint)
-            }
+                drawCircle(accent.copy(alpha = .18f), 11.dp.toPx(), startPoint)
+                drawCircle(markerOutline, 7.dp.toPx(), startPoint)
+                drawCircle(accent, 5.dp.toPx(), startPoint)
 
-            if (playbackMode) {
-                frame?.let { current ->
-                    val currentOffset = project(current.latitude, current.longitude)
-                    val direction = current.bearingDegrees?.takeIf { it.isFinite() }?.toFloat() ?: 0f
-                    val vehicleSize = 7.dp.toPx()
-                    val vehicle = Path().apply {
-                        moveTo(currentOffset.x, currentOffset.y - vehicleSize)
-                        lineTo(currentOffset.x + vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
-                        lineTo(currentOffset.x, currentOffset.y + vehicleSize * .30f)
-                        lineTo(currentOffset.x - vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                if (finalEndpoint) {
+                    drawCircle(endColor.copy(alpha = .18f), 11.dp.toPx(), endPoint)
+                    drawCircle(markerOutline, 7.dp.toPx(), endPoint)
+                    drawCircle(endColor, 4.5.dp.toPx(), endPoint)
+                    val poleTop = Offset(endPoint.x, endPoint.y - 21.dp.toPx())
+                    drawLine(
+                        endColor,
+                        endPoint,
+                        poleTop,
+                        strokeWidth = 2.dp.toPx(),
+                        cap = StrokeCap.Round,
+                    )
+                    val flag = Path().apply {
+                        moveTo(poleTop.x, poleTop.y)
+                        lineTo(poleTop.x + 11.dp.toPx(), poleTop.y + 3.dp.toPx())
+                        lineTo(poleTop.x, poleTop.y + 7.dp.toPx())
                         close()
                     }
-                    rotate(degrees = direction, pivot = currentOffset) { drawPath(vehicle, accent) }
+                    drawPath(flag, endColor)
+                } else {
+                    drawCircle(accent.copy(alpha = .20f), 9.dp.toPx(), endPoint)
+                    drawCircle(accent, 4.dp.toPx(), endPoint)
+                }
+
+                if (playbackMode) {
+                    frame?.let { current ->
+                        val currentOffset = project(current.latitude, current.longitude)
+                        val direction = current.bearingDegrees?.takeIf { it.isFinite() }?.toFloat() ?: 0f
+                        val vehicleSize = 7.dp.toPx()
+                        val vehicle = Path().apply {
+                            moveTo(currentOffset.x, currentOffset.y - vehicleSize)
+                            lineTo(currentOffset.x + vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                            lineTo(currentOffset.x, currentOffset.y + vehicleSize * .30f)
+                            lineTo(currentOffset.x - vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                            close()
+                        }
+                        rotate(degrees = direction, pivot = currentOffset) { drawPath(vehicle, accent) }
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp, vertical = 10.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    GestureChipV07("拖动")
+                    GestureChipV07("双指缩放")
+                }
+                Surface(
+                    onClick = ::animateBackToFullRoute,
+                    enabled = viewportChanged,
+                    shape = RoundedCornerShape(999.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .90f),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .24f)),
+                ) {
+                    Text(
+                        "回到全程",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = if (viewportChanged) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .58f)
+                        },
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun GestureChipV07(text: String) {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .84f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .18f)),
+    ) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -380,11 +494,11 @@ internal fun trustedTripSpeedMpsV07(point: TripPointEntity): Double? {
 
 private fun trustedSpeedColorV07(speedKph: Double?): Color = when {
     speedKph == null || !speedKph.isFinite() -> SpeedUnknownV07
-    speedKph < 5.0 -> SpeedDeepRedV07
-    speedKph < 15.0 -> SpeedRedV07
-    speedKph < 30.0 -> SpeedAmberV07
-    speedKph < 50.0 -> SpeedYellowV07
-    speedKph < 70.0 -> SpeedGreenV07
-    speedKph < 90.0 -> SpeedBlueV07
-    else -> SpeedDeepBlueV07
+    speedKph < 5.0 -> SpeedLowV07
+    speedKph < 15.0 -> SpeedLowMidV07
+    speedKph < 30.0 -> SpeedMidV07
+    speedKph < 50.0 -> SpeedCruiseV07
+    speedKph < 70.0 -> SpeedFastV07
+    speedKph < 90.0 -> SpeedHighV07
+    else -> SpeedVeryHighV07
 }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripRouteViewportV07.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripRouteViewportV07.kt
@@ -1,0 +1,390 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.evchargebook.data.entity.TripPointEntity
+import com.evchargebook.domain.TripCaptureTimeRules
+import com.evchargebook.domain.TripContinuityRules
+import com.evchargebook.domain.TripPlaybackFrame
+import com.evchargebook.domain.TripSpeedTrustRules
+import com.evchargebook.domain.trip.TripGeoPoint
+import com.evchargebook.domain.trip.TripRouteGeometryBuilder
+import com.evchargebook.ui.theme.EVDesignTokens
+import kotlinx.coroutines.launch
+
+private val SpeedDeepRedV07 = Color(0xFFD32F2F)
+private val SpeedRedV07 = Color(0xFFE53935)
+private val SpeedAmberV07 = Color(0xFFFF9800)
+private val SpeedYellowV07 = Color(0xFFFDD835)
+private val SpeedGreenV07 = Color(0xFF43A047)
+private val SpeedBlueV07 = Color(0xFF1E88E5)
+private val SpeedDeepBlueV07 = Color(0xFF1565C0)
+private val SpeedUnknownV07 = Color(0xFF7A7F86)
+
+/**
+ * Shared completed-Trip route renderer used by both the normal route page and playback.
+ * Geometry is presentation-only and never mutates persisted TripPoint facts.
+ */
+@Composable
+internal fun TripRouteViewportV07(
+    points: List<TripPointEntity>,
+    modifier: Modifier = Modifier,
+    frame: TripPlaybackFrame? = null,
+    playbackMode: Boolean = false,
+    finalEndpoint: Boolean = true,
+    height: Dp = 190.dp,
+) {
+    val routePoints = remember(points) {
+        points.filter { it.latitude.isFinite() && it.longitude.isFinite() }
+    }
+    val geometry = remember(routePoints) {
+        TripRouteGeometryBuilder.build(
+            routePoints.map { point ->
+                TripGeoPoint(
+                    latitude = point.latitude,
+                    longitude = point.longitude,
+                    capturedAtEpochMillis = point.capturedAtEpochMillis,
+                    speedMps = trustedTripSpeedMpsV07(point),
+                    capturedAtElapsedRealtimeNanos = point.capturedAtElapsedRealtimeNanos,
+                )
+            }
+        )
+    }
+
+    if (geometry?.isDrawable != true) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        TripSpeedLegendV07()
+        InteractiveTripRouteCanvasV07(
+            points = routePoints,
+            frame = frame,
+            playbackMode = playbackMode,
+            finalEndpoint = finalEndpoint,
+            minLatitude = geometry.minLatitude,
+            maxLatitude = geometry.maxLatitude,
+            minLongitude = geometry.minLongitude,
+            maxLongitude = geometry.maxLongitude,
+            height = height,
+        )
+    }
+}
+
+@Composable
+internal fun TripSpeedLegendV07(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Text(
+            "可信 GPS 时速区间 · km/h",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SpeedLegendCellV07("0–5", SpeedDeepRedV07, Modifier.weight(1f))
+            SpeedLegendCellV07("5–15", SpeedRedV07, Modifier.weight(1f))
+            SpeedLegendCellV07("15–30", SpeedAmberV07, Modifier.weight(1f))
+            SpeedLegendCellV07("30–50", SpeedYellowV07, Modifier.weight(1f))
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            SpeedLegendCellV07("50–70", SpeedGreenV07, Modifier.weight(1f))
+            SpeedLegendCellV07("70–90", SpeedBlueV07, Modifier.weight(1f))
+            SpeedLegendCellV07("90+", SpeedDeepBlueV07, Modifier.weight(1f))
+            SpeedLegendCellV07("未知", SpeedUnknownV07, Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun SpeedLegendCellV07(label: String, color: Color, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Box(Modifier.size(7.dp).background(color, CircleShape))
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun InteractiveTripRouteCanvasV07(
+    points: List<TripPointEntity>,
+    frame: TripPlaybackFrame?,
+    playbackMode: Boolean,
+    finalEndpoint: Boolean,
+    minLatitude: Double,
+    maxLatitude: Double,
+    minLongitude: Double,
+    maxLongitude: Double,
+    height: Dp,
+) {
+    val accent = EVDesignTokens.Energy.green
+    val endColor = MaterialTheme.colorScheme.error
+    val viewportKey = points.firstOrNull()?.tripId
+    var zoom by remember(viewportKey) { mutableFloatStateOf(1f) }
+    var pan by remember(viewportKey) { mutableStateOf(Offset.Zero) }
+    val scope = rememberCoroutineScope()
+    val viewportChanged = zoom > 1.001f || pan != Offset.Zero
+
+    fun animateBackToFullRoute() {
+        val startZoom = zoom
+        val startPan = pan
+        scope.launch {
+            animate(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+            ) { fraction, _ ->
+                zoom = startZoom + (1f - startZoom) * fraction
+                pan = Offset(
+                    x = startPan.x * (1f - fraction),
+                    y = startPan.y * (1f - fraction),
+                )
+            }
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "双指缩放 · 单指拖动查看",
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (viewportChanged) {
+                TextButton(onClick = ::animateBackToFullRoute) {
+                    Text("回到全程", style = MaterialTheme.typography.labelSmall)
+                }
+            }
+        }
+
+        Canvas(
+            Modifier
+                .fillMaxWidth()
+                .height(height)
+                .pointerInput(viewportKey) {
+                    detectTransformGestures(panZoomLock = true) { centroid, gesturePan, gestureZoom, _ ->
+                        val oldZoom = zoom.coerceAtLeast(1f)
+                        val newZoom = (oldZoom * gestureZoom).coerceIn(1f, 6f)
+                        val ratio = newZoom / oldZoom
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val anchoredPan = Offset(
+                            x = centroid.x - center.x - (centroid.x - center.x - pan.x) * ratio,
+                            y = centroid.y - center.y - (centroid.y - center.y - pan.y) * ratio,
+                        )
+                        val maxPanX = size.width.toFloat() * (newZoom - 1f) * 0.5f
+                        val maxPanY = size.height.toFloat() * (newZoom - 1f) * 0.5f
+                        zoom = newZoom
+                        pan = Offset(
+                            x = (anchoredPan.x + gesturePan.x).coerceIn(-maxPanX, maxPanX),
+                            y = (anchoredPan.y + gesturePan.y).coerceIn(-maxPanY, maxPanY),
+                        )
+                    }
+                }
+                .semantics {
+                    contentDescription = when {
+                        playbackMode && frame?.isLongGap == true ->
+                            "可拖动缩放的行程轨迹回放；当前处于 GPS 缺口，车辆位置保持在最后真实定位点"
+                        playbackMode ->
+                            "可拖动缩放的行程轨迹回放；轨迹颜色表示可信 GPS 时速区间"
+                        else ->
+                            "可拖动缩放的真实行程轨迹；轨迹颜色表示可信 GPS 时速区间，断开表示 GPS 长缺口"
+                    }
+                },
+        ) {
+            if (points.isEmpty()) return@Canvas
+            val pad = 12.dp.toPx()
+            val width = (size.width - pad * 2).coerceAtLeast(1f)
+            val canvasHeight = (size.height - pad * 2).coerceAtLeast(1f)
+            val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.0 } ?: 1.0
+            val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.0 } ?: 1.0
+            val longGapMillis = TripContinuityRules.LONG_GAP_SECONDS * 1_000L
+            val center = Offset(size.width / 2f, size.height / 2f)
+
+            fun project(latitude: Double, longitude: Double): Offset {
+                val x = ((longitude - minLongitude) / lonSpan).toFloat().coerceIn(0f, 1f)
+                val y = (1.0 - (latitude - minLatitude) / latSpan).toFloat().coerceIn(0f, 1f)
+                val base = Offset(pad + x * width, pad + y * canvasHeight)
+                return Offset(
+                    x = center.x + (base.x - center.x) * zoom + pan.x,
+                    y = center.y + (base.y - center.y) * zoom + pan.y,
+                )
+            }
+
+            fun segmentStyle(from: TripPointEntity, to: TripPointEntity): Pair<Color, Float> {
+                val speedKph = (trustedTripSpeedMpsV07(to) ?: trustedTripSpeedMpsV07(from))?.times(3.6)
+                val normalized = speedKph?.let { (it / 120.0).toFloat().coerceIn(0f, 1f) } ?: 0f
+                return trustedSpeedColorV07(speedKph) to (2.7f + normalized * 1.7f).dp.toPx()
+            }
+
+            points.zipWithNext().forEachIndexed { index, (from, to) ->
+                val timing = TripCaptureTimeRules.between(
+                    previousEpochMillis = from.capturedAtEpochMillis,
+                    previousElapsedRealtimeNanos = from.capturedAtElapsedRealtimeNanos,
+                    currentEpochMillis = to.capturedAtEpochMillis,
+                    currentElapsedRealtimeNanos = to.capturedAtElapsedRealtimeNanos,
+                )
+                if (!timing.accepted || timing.breaksContinuity(longGapMillis)) return@forEachIndexed
+
+                val start = project(from.latitude, from.longitude)
+                val end = project(to.latitude, to.longitude)
+                val (segmentColor, segmentStroke) = segmentStyle(from, to)
+
+                if (!playbackMode) {
+                    drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
+                    return@forEachIndexed
+                }
+
+                drawLine(
+                    color = segmentColor.copy(alpha = .25f),
+                    start = start,
+                    end = end,
+                    strokeWidth = segmentStroke,
+                    cap = StrokeCap.Round,
+                )
+
+                val currentFrame = frame
+                when {
+                    currentFrame == null -> Unit
+                    index < currentFrame.currentSampleIndex ->
+                        drawLine(segmentColor, start, end, segmentStroke, StrokeCap.Round)
+                    index == currentFrame.currentSampleIndex &&
+                        currentFrame.nextSampleIndex == index + 1 &&
+                        !currentFrame.isLongGap -> {
+                        val fraction = currentFrame.segmentFraction.toFloat().coerceIn(0f, 1f)
+                        val partial = Offset(
+                            x = start.x + (end.x - start.x) * fraction,
+                            y = start.y + (end.y - start.y) * fraction,
+                        )
+                        drawLine(segmentColor, start, partial, segmentStroke, StrokeCap.Round)
+                    }
+                }
+            }
+
+            val startPoint = project(points.first().latitude, points.first().longitude)
+            val endPoint = project(points.last().latitude, points.last().longitude)
+            val markerSize = 6.dp.toPx()
+            val startTriangle = Path().apply {
+                moveTo(startPoint.x - markerSize * .45f, startPoint.y - markerSize)
+                lineTo(startPoint.x + markerSize, startPoint.y)
+                lineTo(startPoint.x - markerSize * .45f, startPoint.y + markerSize)
+                close()
+            }
+            drawPath(startTriangle, accent)
+
+            if (finalEndpoint) {
+                val poleHeight = 13.dp.toPx()
+                val flagWidth = 9.dp.toPx()
+                val flagHeight = 6.dp.toPx()
+                drawLine(
+                    endColor,
+                    endPoint,
+                    Offset(endPoint.x, endPoint.y - poleHeight),
+                    strokeWidth = 2.dp.toPx(),
+                    cap = StrokeCap.Round,
+                )
+                val flag = Path().apply {
+                    moveTo(endPoint.x, endPoint.y - poleHeight)
+                    lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight)
+                    lineTo(endPoint.x + flagWidth, endPoint.y - poleHeight + flagHeight)
+                    lineTo(endPoint.x, endPoint.y - poleHeight + flagHeight)
+                    close()
+                }
+                drawPath(flag, endColor)
+            } else {
+                drawCircle(accent.copy(alpha = .22f), 6.dp.toPx(), endPoint)
+                drawCircle(accent, 3.dp.toPx(), endPoint)
+            }
+
+            if (playbackMode) {
+                frame?.let { current ->
+                    val currentOffset = project(current.latitude, current.longitude)
+                    val direction = current.bearingDegrees?.takeIf { it.isFinite() }?.toFloat() ?: 0f
+                    val vehicleSize = 7.dp.toPx()
+                    val vehicle = Path().apply {
+                        moveTo(currentOffset.x, currentOffset.y - vehicleSize)
+                        lineTo(currentOffset.x + vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                        lineTo(currentOffset.x, currentOffset.y + vehicleSize * .30f)
+                        lineTo(currentOffset.x - vehicleSize * .68f, currentOffset.y + vehicleSize * .65f)
+                        close()
+                    }
+                    rotate(degrees = direction, pivot = currentOffset) { drawPath(vehicle, accent) }
+                }
+            }
+        }
+    }
+}
+
+internal fun trustedTripSpeedMpsV07(point: TripPointEntity): Double? {
+    val value = point.speedMps ?: return null
+    if (!value.isFinite() || value < 0.0) return null
+    return value.takeIf {
+        TripSpeedTrustRules.eligibleForMeasuredSpeed(
+            reportedSpeedMps = value,
+            provider = point.provider,
+            horizontalAccuracyMeters = point.horizontalAccuracyMeters,
+            speedAccuracyMps = point.speedAccuracyMps,
+        )
+    }
+}
+
+private fun trustedSpeedColorV07(speedKph: Double?): Color = when {
+    speedKph == null || !speedKph.isFinite() -> SpeedUnknownV07
+    speedKph < 5.0 -> SpeedDeepRedV07
+    speedKph < 15.0 -> SpeedRedV07
+    speedKph < 30.0 -> SpeedAmberV07
+    speedKph < 50.0 -> SpeedYellowV07
+    speedKph < 70.0 -> SpeedGreenV07
+    speedKph < 90.0 -> SpeedBlueV07
+    else -> SpeedDeepBlueV07
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripTrendPlotV06.kt
@@ -23,9 +23,12 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.evchargebook.domain.TripCaptureTimeRules
 import com.evchargebook.ui.theme.EVDesignTokens
@@ -94,15 +97,17 @@ internal fun buildTripTrendTimelineV06(
  * Interactive Compose-native trend plot used by active and completed Trip surfaces.
  *
  * The chart renders persisted samples only, never smooths across missing data and never bridges
- * long GPS gaps. X-axis intervals prefer persisted elapsedRealtimeNanos so wall-clock corrections
- * do not distort or reverse a healthy Trip. Epoch time is retained only for the human clock label.
+ * long GPS gaps. Optional area fill is built independently for each real continuous segment.
  */
 @Composable
 internal fun TripTrendPlotV06(
     samples: List<TripTrendSampleV06>,
     unit: String,
     longGapMs: Long,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    plotHeight: Dp = 104.dp,
+    fillArea: Boolean = false,
+    showInteractionHeader: Boolean = true,
 ) {
     if (samples.size < 2) return
 
@@ -133,6 +138,7 @@ internal fun TripTrendPlotV06(
     val maxValue = visibleValueSamples.maxOf { it.value }
     val valueRange = max(1.0, maxValue - minValue)
     val midValue = minValue + valueRange / 2.0
+    val averageValue = visibleValueSamples.map { it.value }.average()
     val selectedSample = selectedTimelineMillis?.let { selected ->
         timelineSamples.minByOrNull { abs(it.timelineMillis - selected) }
     }
@@ -143,29 +149,35 @@ internal fun TripTrendPlotV06(
     val currentStartFraction by rememberUpdatedState(clampedStartFraction)
 
     Column(modifier = modifier.fillMaxWidth()) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(
-                text = selectedSample?.let { sample -> formatSelectedTrendSample(sample, unit) }
-                    ?: "长按左右拖动读点 · 双指缩放/平移",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1
-            )
-            if (viewportChanged) {
-                TextButton(
-                    onClick = {
-                        zoom = 1f
-                        viewportStartFraction = 0f
+        if (showInteractionHeader || selectedSample != null || viewportChanged) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = selectedSample?.let { sample -> formatSelectedTrendSample(sample, unit) }
+                        ?: if (showInteractionHeader) {
+                            "长按左右拖动读点 · 双指缩放/平移"
+                        } else {
+                            "已调整查看区间"
+                        },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
+                if (viewportChanged) {
+                    TextButton(
+                        onClick = {
+                            zoom = 1f
+                            viewportStartFraction = 0f
+                        }
+                    ) {
+                        Text("全程", style = MaterialTheme.typography.labelSmall)
                     }
-                ) {
-                    Text("全程", style = MaterialTheme.typography.labelSmall)
                 }
             }
         }
 
         Row(modifier = Modifier.fillMaxWidth()) {
             Column(
-                modifier = Modifier.width(44.dp).height(104.dp),
+                modifier = Modifier.width(44.dp).height(plotHeight),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
                 AxisValue(formatTripTrendAxisValue(maxValue, unit))
@@ -176,7 +188,7 @@ internal fun TripTrendPlotV06(
             Canvas(
                 Modifier
                     .weight(1f)
-                    .height(104.dp)
+                    .height(plotHeight)
                     .pointerInput(viewportKey) {
                         detectTransformGestures(panZoomLock = true) { centroid, pan, gestureZoom, _ ->
                             val canvasWidth = size.width.toFloat().coerceAtLeast(1f)
@@ -255,15 +267,60 @@ internal fun TripTrendPlotV06(
                     return Offset(x, padY + (1f - normalized) * usableHeight)
                 }
 
+                if (fillArea) {
+                    val segments = mutableListOf<MutableList<TripTrendTimelineSampleV06>>()
+                    var currentSegment = mutableListOf<TripTrendTimelineSampleV06>()
+                    timelineSamples.forEach { sample ->
+                        if (sample.breakBefore && currentSegment.isNotEmpty()) {
+                            segments += currentSegment
+                            currentSegment = mutableListOf()
+                        }
+                        currentSegment += sample
+                    }
+                    if (currentSegment.isNotEmpty()) segments += currentSegment
+
+                    val baselineY = padY + usableHeight
+                    segments.forEach { segment ->
+                        if (segment.size < 2 ||
+                            segment.last().timelineMillis < visibleStartTime ||
+                            segment.first().timelineMillis > visibleEndTime
+                        ) return@forEach
+
+                        val first = point(segment.first())
+                        val fillPath = Path().apply {
+                            moveTo(first.x, baselineY)
+                            lineTo(first.x, first.y)
+                            segment.drop(1).forEach { sample ->
+                                val offset = point(sample)
+                                lineTo(offset.x, offset.y)
+                            }
+                            val last = point(segment.last())
+                            lineTo(last.x, baselineY)
+                            close()
+                        }
+                        drawPath(fillPath, color = accent.copy(alpha = .10f))
+                    }
+
+                    val normalizedAverage = ((averageValue - minValue) / valueRange).toFloat().coerceIn(0f, 1f)
+                    val averageY = padY + (1f - normalizedAverage) * usableHeight
+                    drawLine(
+                        color = accent.copy(alpha = .24f),
+                        start = Offset(0f, averageY),
+                        end = Offset(size.width, averageY),
+                        strokeWidth = 1.dp.toPx(),
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 5.dp.toPx())),
+                    )
+                }
+
                 timelineSamples.zipWithNext().forEach { (from, to) ->
                     if (!to.breakBefore &&
                         to.timelineMillis >= visibleStartTime && from.timelineMillis <= visibleEndTime
                     ) {
                         drawLine(
-                            color = accent.copy(alpha = 0.82f),
+                            color = accent.copy(alpha = 0.88f),
                             start = point(from),
                             end = point(to),
-                            strokeWidth = 2.dp.toPx(),
+                            strokeWidth = if (fillArea) 2.3.dp.toPx() else 2.dp.toPx(),
                             cap = StrokeCap.Round
                         )
                     }


### PR DESCRIPTION
## Summary

Fixes #318.

This implements the approved completed-Trip `轨迹` redesign instead of keeping the previous utility-style layout.

### `轨迹` tab
- remove the duplicate trajectory-playback card from `轨迹`; playback remains under `数据`
- make the trajectory card the primary visual surface with a dark non-geographic grid backdrop
- preserve one shared interactive viewport: single-finger pan, centroid-anchored pinch zoom 1x..6x, animated `回到全程`
- move gesture hints into compact overlay controls instead of a text instruction row
- use explicit trusted-speed ranges: 0–5 / 5–15 / 15–30 / 30–50 / 50–70 / 70–90 / 90+ km/h + unknown
- strengthen start/end markers and expose a compact long-gap badge
- render a real LONG_GAP/rebase only as a neutral dashed missing-section indicator; it is explicitly not road geometry and is never used for distance/speed interpolation
- add the approved compact summary strip using persisted Trip facts: trajectory distance, elapsed duration, average speed and trusted max speed
- replace the old mixed `趋势` surface with a focused `速度趋势` card
- enlarge the completed speed plot, add a restrained per-continuous-segment area fill and average guide, while preserving long-press readout and pan/zoom behavior

### `数据` tab / playback
- keep the trajectory-playback entry under `数据`
- playback opens as a full-screen surface instead of `ModalBottomSheet`, so route gestures do not compete with sheet collapse/dismiss
- normal trajectory and playback continue to share `TripRouteViewportV07`

## Truth boundary

- no basemap/provider claim: the subtle background grid is decorative only
- no road snapping or synthetic points
- no persisted TripPoint/TripSession mutation from gestures/playback
- no interpolation or area-fill bridging across LONG_GAP or capture-time rebase
- speed styling still requires `TripSpeedTrustRules`

## Validation

- branch normalized to current `main@6a5246a`
- Android Build #809 is Green on current head `e1ad1a5`
- build/test and Debug APK upload completed successfully
- no review submissions or unresolved review threads remain
- physical follow-up: test the merged `main` build on device at 320–360dp / fontScale 1.3 / Dark+Light, including real LONG_GAP, pan/pinch/reset and full-screen playback gesture checks under #145/#168/#193

## Design

Approved trajectory interaction/design reference is stored in ChatGPT Library under `EvChargeBook`.