### PR TITLE
fix(charging): prevent same-vehicle trip and charging overlap

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
+++ b/android/app/src/main/java/com/evchargebook/data/repository/ChargingSessionRepository.kt
@@ -8,6 +8,7 @@ import com.evchargebook.data.entity.ChargingSessionStatus
 import com.evchargebook.data.entity.VehicleStateEntity
 import com.evchargebook.data.entity.VehicleStateUpdateSource
 import com.evchargebook.domain.ChargingRecordRules
+import com.evchargebook.domain.VehicleActivityConflictPolicy
 import kotlinx.coroutines.flow.Flow
 
 /** Inputs known when the user explicitly chooses `开始充电`. */
@@ -119,6 +120,10 @@ class ChargingSessionRepository(private val database: AppDatabase) {
             require(chargingSessionDao.getActiveForVehicle(request.vehicleId) == null) {
                 "这辆车已有进行中的充电"
             }
+            VehicleActivityConflictPolicy.chargingStartBlockReason(
+                vehicleId = request.vehicleId,
+                activeTripVehicleId = tripDao.getActive()?.vehicleId,
+            )?.let { reason -> error(reason) }
 
             val now = System.currentTimeMillis()
             val session = ChargingSessionEntity(

--- a/android/app/src/main/java/com/evchargebook/domain/VehicleActivityConflictPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/domain/VehicleActivityConflictPolicy.kt
@@ -1,0 +1,27 @@
+package com.evchargebook.domain
+
+/**
+ * Cross-flow truth guard for one physical vehicle.
+ *
+ * A vehicle cannot truthfully be driving and actively charging at the same time. Keep this policy
+ * independent from UI so manual, Bluetooth and automatic Trip starts share the same rule.
+ */
+object VehicleActivityConflictPolicy {
+    fun chargingStartBlockReason(
+        vehicleId: Long,
+        activeTripVehicleId: Long?,
+    ): String? = if (activeTripVehicleId == vehicleId) {
+        "这辆车有进行中的行程，请先结束行程"
+    } else {
+        null
+    }
+
+    fun tripStartBlockReason(
+        vehicleId: Long,
+        activeChargingVehicleId: Long?,
+    ): String? = if (activeChargingVehicleId == vehicleId) {
+        "这辆车正在充电，请先结束或取消充电"
+    } else {
+        null
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/trip/TripStartCoordinator.kt
+++ b/android/app/src/main/java/com/evchargebook/trip/TripStartCoordinator.kt
@@ -6,6 +6,7 @@ import com.evchargebook.autotrip.AutoTripDetectionState
 import com.evchargebook.data.database.AppDatabase
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
+import com.evchargebook.domain.VehicleActivityConflictPolicy
 import kotlinx.coroutines.flow.first
 
 sealed interface TripStartSource {
@@ -32,10 +33,10 @@ sealed interface TripStartResult {
  * Single authority for creating a new Trip.
  *
  * UI, Bluetooth prompt actions and automatic Bluetooth starts converge here so the active Trip
- * guard, VehicleState snapshot and detection-session linkage are evaluated in one Room
- * transaction. Tracking service startup happens only after the Trip is persisted; if Android
- * rejects service startup, the Trip becomes INTERRUPTED and an associated detection session
- * becomes START_FAILED rather than silently retrying or creating another Trip.
+ * guard, same-vehicle charging guard, VehicleState snapshot and detection-session linkage are
+ * evaluated in one Room transaction. Tracking service startup happens only after the Trip is
+ * persisted; if Android rejects service startup, the Trip becomes INTERRUPTED and an associated
+ * detection session becomes START_FAILED rather than silently retrying or creating another Trip.
  */
 class TripStartCoordinator(
     private val database: AppDatabase,
@@ -44,6 +45,7 @@ class TripStartCoordinator(
     private val tripDao = database.tripDao()
     private val vehicleDao = database.vehicleDao()
     private val vehicleStateDao = database.vehicleStateDao()
+    private val chargingSessionDao = database.chargingSessionDao()
     private val detectionDao = database.autoTripDetectionDao()
 
     suspend fun start(request: TripStartRequest): TripStartResult {
@@ -55,6 +57,13 @@ class TripStartCoordinator(
 
             val vehicle = vehicleDao.observeActive().first().firstOrNull { it.id == request.vehicleId }
                 ?: return@withTransaction PreparedResult.Blocked("当前车辆不可用")
+
+            VehicleActivityConflictPolicy.tripStartBlockReason(
+                vehicleId = vehicle.id,
+                activeChargingVehicleId = chargingSessionDao.getActiveForVehicle(vehicle.id)?.vehicleId,
+            )?.let { reason ->
+                return@withTransaction PreparedResult.Blocked(reason)
+            }
 
             val detectionSession = when (val source = request.source) {
                 TripStartSource.ManualUi -> null

--- a/android/app/src/test/java/com/evchargebook/domain/VehicleActivityConflictPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/domain/VehicleActivityConflictPolicyTest.kt
@@ -1,0 +1,53 @@
+package com.evchargebook.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VehicleActivityConflictPolicyTest {
+    @Test
+    fun `charging is blocked only by a trip for the same vehicle`() {
+        assertEquals(
+            "这辆车有进行中的行程，请先结束行程",
+            VehicleActivityConflictPolicy.chargingStartBlockReason(
+                vehicleId = 7L,
+                activeTripVehicleId = 7L,
+            ),
+        )
+        assertNull(
+            VehicleActivityConflictPolicy.chargingStartBlockReason(
+                vehicleId = 7L,
+                activeTripVehicleId = 8L,
+            )
+        )
+        assertNull(
+            VehicleActivityConflictPolicy.chargingStartBlockReason(
+                vehicleId = 7L,
+                activeTripVehicleId = null,
+            )
+        )
+    }
+
+    @Test
+    fun `trip is blocked only by active charging for the same vehicle`() {
+        assertEquals(
+            "这辆车正在充电，请先结束或取消充电",
+            VehicleActivityConflictPolicy.tripStartBlockReason(
+                vehicleId = 11L,
+                activeChargingVehicleId = 11L,
+            ),
+        )
+        assertNull(
+            VehicleActivityConflictPolicy.tripStartBlockReason(
+                vehicleId = 11L,
+                activeChargingVehicleId = 12L,
+            )
+        )
+        assertNull(
+            VehicleActivityConflictPolicy.tripStartBlockReason(
+                vehicleId = 11L,
+                activeChargingVehicleId = null,
+            )
+        )
+    }
+}


### PR DESCRIPTION
Replacement for closed Draft #322; exact same branch/head/base/diff. No code is duplicated or rewritten.

Parent hardening: #321

Delivered:
- same physical vehicle cannot start ACTIVE Charging while its Trip is RECORDING/INTERRUPTED;
- manual/Bluetooth/verified-auto Trip start cannot proceed while the same vehicle has ACTIVE Charging;
- checks live inside the existing Room transaction authorities;
- different-vehicle charging behavior and existing global single-Trip policy remain unchanged;
- focused JVM policy tests cover same-vehicle block and different-vehicle allow.

Final evidence on identical head/base:
- base `main@4ceacf3f27038a7e4bba4113596937ae2a6369fb`
- head `9b384c021f8ac014d540c10fa95c9363f6e52138`
- ahead 4 / behind 0
- exactly 4 intended files
- Android Build #793 Green including Build/Test + Debug APK
- no review threads/comments/reviews

Related: #251 #253 #289 #321 #322.