### PR TITLE
fix(charging): expire stale tariff auto fill

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicy.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicy.kt
@@ -12,16 +12,22 @@ internal data class ChargingPriceMemory(
 )
 
 internal object ChargingPriceSuggestionPolicy {
+    internal const val DEFAULT_AUTO_FILL_MAX_AGE_MILLIS = 30L * 24L * 60L * 60L * 1000L
+
     fun autoFillPrice(
         chargerType: String,
         location: String,
         memories: List<ChargingPriceMemory>,
+        nowEpochMillis: Long = System.currentTimeMillis(),
+        maxAgeMillis: Long = DEFAULT_AUTO_FILL_MAX_AGE_MILLIS,
     ): Double? {
+        require(maxAgeMillis >= 0L) { "maxAgeMillis must be non-negative" }
         val typeKey = normalizeType(chargerType) ?: return null
         val locationKey = normalizeLocation(location) ?: return null
         return memories
             .asSequence()
             .filter { it.isStoredTariff && it.pricePerKwh >= 0.0 }
+            .filter { isFreshForAutoFill(it.timestampEpochMillis, nowEpochMillis, maxAgeMillis) }
             .filter { normalizeType(it.chargerType) == typeKey }
             .filter { normalizeLocation(it.location) == locationKey }
             .sortedByDescending { it.timestampEpochMillis }
@@ -79,6 +85,16 @@ internal object ChargingPriceSuggestionPolicy {
         ?.replace(Regex("\\s+"), " ")
         ?.lowercase(Locale.ROOT)
         ?.takeIf { it.isNotEmpty() }
+
+    private fun isFreshForAutoFill(
+        timestampEpochMillis: Long,
+        nowEpochMillis: Long,
+        maxAgeMillis: Long,
+    ): Boolean {
+        if (timestampEpochMillis > nowEpochMillis) return false
+        val ageMillis = nowEpochMillis - timestampEpochMillis
+        return ageMillis >= 0L && ageMillis <= maxAgeMillis
+    }
 
     private fun normalizeType(value: String?): String? = value
         ?.trim()

--- a/android/app/src/test/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicyTest.kt
+++ b/android/app/src/test/java/com/evchargebook/ui/records/ChargingPriceSuggestionPolicyTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 class ChargingPriceSuggestionPolicyTest {
     @Test
-    fun `same normalized location and type may auto fill stored session tariff`() {
+    fun `same normalized location and type may auto fill fresh stored session tariff`() {
         val memories = listOf(
             memory(1.20, "家充", " 上海  奉贤 ", 100, storedTariff = true),
             memory(1.35, "家充", "上海 奉贤", 200, storedTariff = true),
@@ -17,6 +17,8 @@ class ChargingPriceSuggestionPolicyTest {
             chargerType = " 家充 ",
             location = "上海   奉贤",
             memories = memories,
+            nowEpochMillis = 300,
+            maxAgeMillis = 500,
         )
 
         assertEquals(1.35, result!!, 0.000001)
@@ -32,6 +34,8 @@ class ChargingPriceSuggestionPolicyTest {
             chargerType = "家充",
             location = "家",
             memories = memories,
+            nowEpochMillis = 300,
+            maxAgeMillis = 500,
         )
         val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
             chargerType = "家充",
@@ -53,6 +57,8 @@ class ChargingPriceSuggestionPolicyTest {
             chargerType = "公共快充",
             location = "站点 A",
             memories = memories,
+            nowEpochMillis = 400,
+            maxAgeMillis = 500,
         )
         val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
             chargerType = "公共快充",
@@ -62,6 +68,65 @@ class ChargingPriceSuggestionPolicyTest {
 
         assertNull(auto)
         assertEquals(listOf(1.18), suggestions)
+    }
+
+    @Test
+    fun `stored tariff older than thirty days is suggestion only`() {
+        val now = 100L * DAY_MILLIS
+        val staleTimestamp = now - 31L * DAY_MILLIS
+        val memories = listOf(
+            memory(0.61, "家充", "家", staleTimestamp, storedTariff = true),
+        )
+
+        val auto = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+            nowEpochMillis = now,
+        )
+        val suggestions = ChargingPriceSuggestionPolicy.suggestionPrices(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+        )
+
+        assertNull(auto)
+        assertEquals(listOf(0.61), suggestions)
+    }
+
+    @Test
+    fun `stored tariff at freshness boundary may auto fill`() {
+        val now = 100L * DAY_MILLIS
+        val boundaryTimestamp = now - ChargingPriceSuggestionPolicy.DEFAULT_AUTO_FILL_MAX_AGE_MILLIS
+        val memories = listOf(
+            memory(0.58, "家充", "家", boundaryTimestamp, storedTariff = true),
+        )
+
+        val auto = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+            nowEpochMillis = now,
+        )
+
+        assertEquals(0.58, auto!!, 0.000001)
+    }
+
+    @Test
+    fun `future timestamp never becomes silent auto fill authority`() {
+        val now = 100L * DAY_MILLIS
+        val memories = listOf(
+            memory(0.66, "家充", "家", now + DAY_MILLIS, storedTariff = true),
+        )
+
+        val auto = ChargingPriceSuggestionPolicy.autoFillPrice(
+            chargerType = "家充",
+            location = "家",
+            memories = memories,
+            nowEpochMillis = now,
+        )
+
+        assertNull(auto)
     }
 
     @Test
@@ -121,4 +186,8 @@ class ChargingPriceSuggestionPolicyTest {
         timestampEpochMillis = timestamp,
         isStoredTariff = storedTariff,
     )
+
+    private companion object {
+        const val DAY_MILLIS = 24L * 60L * 60L * 1000L
+    }
 }


### PR DESCRIPTION
Implementation is complete on exact head `0d7d1e7d52121e47f86dee579bc4ed410bb96183`.

Final gate:
- base `main@a0a5c5407c0778e9a8fc83a7c0ff4a117c403165`
- ahead 1 / behind 0
- exactly 2 intended files
- GitHub mergeable=true
- Android Build #800 Green including Build/Test + Debug APK
- no review threads/comments/reviews

Draft -> Ready failed only on the known connected GitHub GraphQL wrapper defect: `Repository.fullDatabaseId` does not exist.

This Draft PR is closed **only for metadata normalization**. A non-Draft replacement will reuse the exact same branch/head/base/diff; no implementation is duplicated or rewritten.

Parent hardening: #321.