### PR TITLE
fix(charging): invalidate corrected session tariff memory

### DIFF
--- a/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
+++ b/android/app/src/main/java/com/evchargebook/data/dao/ChargingSessionDao.kt
@@ -22,7 +22,44 @@ interface ChargingSessionDao {
     @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC")
     suspend fun getPendingForVehicle(vehicleId: Long): List<ChargingSessionEntity>
 
-    @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status IN ('COMPLETED', 'PENDING_DETAILS') AND unitPricePerKwh IS NOT NULL AND unitPricePerKwh >= 0 ORDER BY COALESCE(endedAtEpochMillis, startedAtEpochMillis) DESC, updatedAtEpochMillis DESC")
+    /**
+     * Stored session tariff memories that are still truthful enough to reuse.
+     *
+     * Pending sessions remain their own current facts. A completed session is eligible only while
+     * its linked, non-deleted ChargingRecord still matches the reusable completion context. If the
+     * user later corrects or deletes the historical record, the old session tariff stops being an
+     * automatic/suggestion source instead of silently surviving that correction.
+     */
+    @Query(
+        """
+        SELECT s.*
+        FROM charging_sessions AS s
+        WHERE s.vehicleId = :vehicleId
+          AND s.unitPricePerKwh IS NOT NULL
+          AND s.unitPricePerKwh >= 0
+          AND (
+            s.status = 'PENDING_DETAILS'
+            OR (
+              s.status = 'COMPLETED'
+              AND s.completedRecordId IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM charging_records AS r
+                WHERE r.id = s.completedRecordId
+                  AND r.isDeleted = 0
+                  AND r.vehicleId = s.vehicleId
+                  AND r.chargeTimeEpochMillis = s.startedAtEpochMillis
+                  AND ABS(r.energyKwh - s.pendingMeterEnergyKwh) <= 0.000001
+                  AND ABS(r.cost - s.pendingTotalCost) <= 0.000001
+                  AND LOWER(TRIM(COALESCE(r.chargerType, ''))) = LOWER(TRIM(COALESCE(s.chargerType, '')))
+                  AND LOWER(TRIM(COALESCE(r.location, ''))) = LOWER(TRIM(COALESCE(s.location, '')))
+              )
+            )
+          )
+        ORDER BY COALESCE(s.endedAtEpochMillis, s.startedAtEpochMillis) DESC,
+                 s.updatedAtEpochMillis DESC
+        """
+    )
     fun observePricedForVehicle(vehicleId: Long): Flow<List<ChargingSessionEntity>>
 
     @Query("SELECT * FROM charging_sessions WHERE vehicleId = :vehicleId AND status = 'PENDING_DETAILS' AND endSoc IS NOT NULL ORDER BY endedAtEpochMillis DESC, startedAtEpochMillis DESC LIMIT 1")


### PR DESCRIPTION
Implementation is complete on exact head `04d498771443fccf2cef5ea90d2d0ecdf16b17f0`.

Final gate:
- base `main@2c7a11d379bbd41262db50cfe42679fa5c356fae`
- ahead 1 / behind 0
- exactly 1 intended DAO file
- GitHub mergeable=true
- Android Build #805 Green including Build/Test + Debug APK; Room/KSP accepts the correlated tariff-memory query
- no review threads/comments/reviews

Draft -> Ready failed only on the known connected GitHub GraphQL wrapper defect: `Repository.fullDatabaseId` does not exist.

This Draft PR is closed **only for metadata normalization**. A non-Draft replacement will reuse the exact same branch/head/base/diff; no implementation is duplicated or rewritten.

Parent hardening: #321.