### PR TITLE
feat(android): redesign truthful vehicle home widget

### DIFF
--- a/android/app/src/main/java/com/evchargebook/widget/VehicleHomeWidget.kt
+++ b/android/app/src/main/java/com/evchargebook/widget/VehicleHomeWidget.kt
@@ -6,9 +6,12 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
 import android.widget.RemoteViews
 import com.evchargebook.MainActivity
 import com.evchargebook.R
+import com.evchargebook.bluetooth.VehicleBluetoothBindingPreferences
 import com.evchargebook.data.database.AppDatabase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -27,20 +30,31 @@ data class VehicleWidgetSnapshot(
     val stateUpdatedAtEpochMillis: Long? = null,
     val activeTrip: Boolean = false,
     val activeCharging: Boolean = false,
+    val bluetoothDetectionEnabled: Boolean = false,
+    val bluetoothDeviceName: String? = null,
+    val autoStartOnConnect: Boolean = false,
 )
 
 /**
  * Reads only local app facts. Rated range/battery capacity are deliberately not used as live state.
+ *
+ * Bluetooth fields describe the user's configured detection rule only. They do not claim that the
+ * vehicle is currently connected; live/presence truth remains owned by the presence pipeline.
  */
 class VehicleWidgetSnapshotReader(context: Context) {
-    private val database = AppDatabase.getInstance(context.applicationContext)
+    private val appContext = context.applicationContext
+    private val database = AppDatabase.getInstance(appContext)
+    private val bindingPreferences = VehicleBluetoothBindingPreferences(appContext)
 
     suspend fun read(): VehicleWidgetSnapshot {
-        val vehicle = database.vehicleDao().observeActive().first().firstOrNull()
+        val vehicles = database.vehicleDao().observeActive().first()
+        val vehicle = vehicles.firstOrNull { it.isDefault } ?: vehicles.firstOrNull()
             ?: return VehicleWidgetSnapshot()
         val state = database.vehicleStateDao().get(vehicle.id)
         val activeTrip = database.tripDao().getActive()?.vehicleId == vehicle.id
         val activeCharging = database.chargingSessionDao().getActiveForVehicle(vehicle.id) != null
+        val bluetoothBinding = bindingPreferences.bindings.first()
+            .firstOrNull { it.vehicleId == vehicle.id }
 
         return VehicleWidgetSnapshot(
             vehicleId = vehicle.id,
@@ -50,12 +64,32 @@ class VehicleWidgetSnapshotReader(context: Context) {
             stateUpdatedAtEpochMillis = state?.updatedAtEpochMillis,
             activeTrip = activeTrip,
             activeCharging = activeCharging,
+            bluetoothDetectionEnabled = bluetoothBinding?.enabled == true,
+            bluetoothDeviceName = bluetoothBinding?.deviceName,
+            autoStartOnConnect = bluetoothBinding?.autoStartOnConnect == true,
         )
     }
 }
 
 class VehicleHomeWidgetProvider : AppWidgetProvider() {
     override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        updateAsync(context, appWidgetManager, appWidgetIds)
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle,
+    ) {
+        updateAsync(context, appWidgetManager, intArrayOf(appWidgetId))
+    }
+
+    private fun updateAsync(
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: IntArray,
@@ -73,6 +107,13 @@ class VehicleHomeWidgetProvider : AppWidgetProvider() {
             }
         }
     }
+}
+
+object VehicleWidgetSizePolicy {
+    private const val EXPANDED_MIN_WIDTH_DP = 300
+
+    fun isCompact(minWidthDp: Int): Boolean =
+        minWidthDp <= 0 || minWidthDp < EXPANDED_MIN_WIDTH_DP
 }
 
 object VehicleHomeWidgetUpdater {
@@ -94,51 +135,72 @@ object VehicleHomeWidgetUpdater {
     ) {
         val snapshot = VehicleWidgetSnapshotReader(context).read()
         appWidgetIds.forEach { appWidgetId ->
+            val minWidthDp = appWidgetManager.getAppWidgetOptions(appWidgetId)
+                .getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 0)
+            val layoutId = if (VehicleWidgetSizePolicy.isCompact(minWidthDp)) {
+                R.layout.widget_vehicle_home
+            } else {
+                R.layout.widget_vehicle_home_expanded
+            }
             appWidgetManager.updateAppWidget(
                 appWidgetId,
-                render(context, snapshot),
+                render(context, snapshot, layoutId),
             )
         }
     }
 
-    internal fun render(context: Context, snapshot: VehicleWidgetSnapshot): RemoteViews =
-        RemoteViews(context.packageName, R.layout.widget_vehicle_home).apply {
-            setTextViewText(R.id.widget_vehicle_name, snapshot.displayName)
-            setTextViewText(R.id.widget_soc, VehicleWidgetTruthText.soc(snapshot))
-            setTextViewText(
-                R.id.widget_mileage,
-                snapshot.currentMileageKm?.let(::formatMileage) ?: "-- km",
-            )
-            setTextViewText(
-                R.id.widget_state_label,
-                VehicleWidgetTruthText.stateLabel(snapshot) { timestamp ->
-                    DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
-                        .format(Date(timestamp))
-                },
-            )
-            setTextViewText(R.id.widget_trip_action, VehicleWidgetTruthText.tripAction(snapshot))
-            setTextViewText(R.id.widget_app_action, VehicleWidgetTruthText.appAction(snapshot))
+    internal fun render(
+        context: Context,
+        snapshot: VehicleWidgetSnapshot,
+        layoutId: Int,
+    ): RemoteViews = RemoteViews(context.packageName, layoutId).apply {
+        setTextViewText(R.id.widget_vehicle_name, snapshot.displayName)
+        setTextViewText(R.id.widget_status_badge, VehicleWidgetTruthText.statusHeadline(snapshot))
+        setTextViewText(R.id.widget_status_detail, VehicleWidgetTruthText.statusDetail(snapshot))
+        setTextColor(R.id.widget_status_badge, statusColor(snapshot))
+        setTextViewText(R.id.widget_soc, VehicleWidgetTruthText.soc(snapshot))
+        setTextViewText(
+            R.id.widget_mileage,
+            snapshot.currentMileageKm?.let(::formatMileage) ?: "-- km",
+        )
+        setTextViewText(
+            R.id.widget_state_label,
+            VehicleWidgetTruthText.stateLabel(snapshot) { timestamp ->
+                DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
+                    .format(Date(timestamp))
+            },
+        )
+        setTextViewText(R.id.widget_trip_action, VehicleWidgetTruthText.tripAction(snapshot))
+        setTextViewText(R.id.widget_app_action, VehicleWidgetTruthText.appAction(snapshot))
 
-            val openApp = PendingIntent.getActivity(
-                context,
-                REQUEST_OPEN_APP,
-                Intent(context, MainActivity::class.java)
-                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-            )
-            val openTrip = PendingIntent.getActivity(
-                context,
-                REQUEST_OPEN_TRIP,
-                Intent(context, MainActivity::class.java)
-                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-                    .putExtra(MainActivity.EXTRA_OPEN_ACTIVE_TRIP, true),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-            )
+        val openApp = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_APP,
+            Intent(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val openTrip = PendingIntent.getActivity(
+            context,
+            REQUEST_OPEN_TRIP,
+            Intent(context, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra(MainActivity.EXTRA_OPEN_ACTIVE_TRIP, true),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
 
-            setOnClickPendingIntent(R.id.widget_root, openApp)
-            setOnClickPendingIntent(R.id.widget_trip_action, openTrip)
-            setOnClickPendingIntent(R.id.widget_app_action, openApp)
+        setOnClickPendingIntent(R.id.widget_root, openApp)
+        setOnClickPendingIntent(R.id.widget_trip_action, openTrip)
+        setOnClickPendingIntent(R.id.widget_app_action, openApp)
+    }
+
+    private fun statusColor(snapshot: VehicleWidgetSnapshot): Int = Color.parseColor(
+        when {
+            snapshot.vehicleId == null -> "#8D989A"
+            snapshot.activeTrip || snapshot.activeCharging || snapshot.bluetoothDetectionEnabled -> "#52F58B"
+            else -> "#8EB7FF"
         }
+    )
 
     private fun formatMileage(value: Double): String =
         String.format(Locale.getDefault(), "%,.0f km", value)

--- a/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetTruthText.kt
+++ b/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetTruthText.kt
@@ -1,9 +1,29 @@
 package com.evchargebook.widget
 
-/** Pure presentation rules that keep the Stage 1 widget honest about local vs live vehicle state. */
+/** Pure presentation rules that keep the widget honest about local vs live vehicle state. */
 object VehicleWidgetTruthText {
     fun soc(snapshot: VehicleWidgetSnapshot): String =
         snapshot.currentSoc?.let { "$it%" } ?: "--"
+
+    fun statusHeadline(snapshot: VehicleWidgetSnapshot): String = when {
+        snapshot.activeTrip -> "● 行程记录中"
+        snapshot.activeCharging -> "● 充电记录中"
+        snapshot.bluetoothDetectionEnabled && snapshot.autoStartOnConnect -> "● 自动行程已就绪"
+        snapshot.bluetoothDetectionEnabled -> "● 蓝牙检测已开启"
+        snapshot.vehicleId != null -> "● 车辆已就绪"
+        else -> "尚未添加车辆"
+    }
+
+    fun statusDetail(snapshot: VehicleWidgetSnapshot): String = when {
+        snapshot.activeTrip -> "本地 Trip 正在记录"
+        snapshot.activeCharging -> "本地充电记录正在进行"
+        snapshot.bluetoothDetectionEnabled && snapshot.autoStartOnConnect ->
+            "连接${deviceLabel(snapshot)}后尝试自动开始行程"
+        snapshot.bluetoothDetectionEnabled ->
+            "连接${deviceLabel(snapshot)}后提醒确认行程"
+        snapshot.vehicleId != null -> "未开启蓝牙行程检测"
+        else -> "打开 App 添加车辆"
+    }
 
     fun stateLabel(
         snapshot: VehicleWidgetSnapshot,
@@ -14,7 +34,7 @@ object VehicleWidgetTruthText {
         snapshot.stateUpdatedAtEpochMillis != null ->
             "上次记录 · ${formatTime(snapshot.stateUpdatedAtEpochMillis)}"
         snapshot.vehicleId != null -> "尚无车辆状态记录"
-        else -> "打开 App 添加车辆"
+        else -> "等待添加车辆"
     }
 
     fun tripAction(snapshot: VehicleWidgetSnapshot): String =
@@ -22,4 +42,7 @@ object VehicleWidgetTruthText {
 
     fun appAction(snapshot: VehicleWidgetSnapshot): String =
         if (snapshot.activeCharging) "充电记录中" else "打开 App"
+
+    private fun deviceLabel(snapshot: VehicleWidgetSnapshot): String =
+        snapshot.bluetoothDeviceName?.takeIf { it.isNotBlank() } ?: "目标车载蓝牙"
 }

--- a/android/app/src/main/res/drawable/widget_action_primary_background.xml
+++ b/android/app/src/main/res/drawable/widget_action_primary_background.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#1B211F" />
+    <solid android:color="#12301E" />
     <corners android:radius="15dp" />
     <stroke
         android:width="1dp"
-        android:color="#303936" />
+        android:color="#28573A" />
 </shape>

--- a/android/app/src/main/res/drawable/widget_status_background.xml
+++ b/android/app/src/main/res/drawable/widget_status_background.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#1B211F" />
-    <corners android:radius="15dp" />
+    <solid android:color="#142019" />
+    <corners android:radius="14dp" />
     <stroke
         android:width="1dp"
-        android:color="#303936" />
+        android:color="#284333" />
 </shape>

--- a/android/app/src/main/res/drawable/widget_vehicle_background.xml
+++ b/android/app/src/main/res/drawable/widget_vehicle_background.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#151718" />
-    <corners android:radius="24dp" />
+    <gradient
+        android:angle="315"
+        android:centerColor="#111714"
+        android:endColor="#171D1A"
+        android:startColor="#090D0B"
+        android:type="linear" />
+    <corners android:radius="26dp" />
     <stroke
         android:width="1dp"
-        android:color="#2B2F31" />
+        android:color="#2A332F" />
 </shape>

--- a/android/app/src/main/res/layout/widget_vehicle_home.xml
+++ b/android/app/src/main/res/layout/widget_vehicle_home.xml
@@ -5,23 +5,59 @@
     android:layout_height="match_parent"
     android:background="@drawable/widget_vehicle_background"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:padding="14dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:text="EV CHARGE BOOK"
+        android:textColor="#68F59A"
+        android:textSize="10sp" />
 
     <TextView
         android:id="@+id/widget_vehicle_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
         android:ellipsize="end"
         android:fontFamily="sans-serif-medium"
         android:maxLines="1"
         android:text="EV Charge Book"
-        android:textColor="#F4F6F6"
-        android:textSize="15sp" />
+        android:textColor="#F5F7F6"
+        android:textSize="19sp" />
+
+    <TextView
+        android:id="@+id/widget_status_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:background="@drawable/widget_status_background"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:paddingLeft="10dp"
+        android:paddingTop="5dp"
+        android:paddingRight="10dp"
+        android:paddingBottom="5dp"
+        android:text="● 车辆已就绪"
+        android:textColor="#52F58B"
+        android:textSize="11sp" />
+
+    <TextView
+        android:id="@+id/widget_status_detail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="未开启蓝牙行程检测"
+        android:textColor="#8E9A95"
+        android:textSize="10sp" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="6dp"
+        android:layout_marginTop="7dp"
         android:layout_weight="1"
         android:gravity="center_vertical"
         android:orientation="horizontal">
@@ -33,8 +69,8 @@
             android:layout_weight="1"
             android:fontFamily="sans-serif-medium"
             android:text="--"
-            android:textColor="#F4F6F6"
-            android:textSize="34sp" />
+            android:textColor="#F5F7F6"
+            android:textSize="30sp" />
 
         <TextView
             android:id="@+id/widget_mileage"
@@ -44,8 +80,8 @@
             android:gravity="end"
             android:maxLines="1"
             android:text="-- km"
-            android:textColor="#B7C0C1"
-            android:textSize="14sp" />
+            android:textColor="#C2CBC7"
+            android:textSize="12sp" />
     </LinearLayout>
 
     <TextView
@@ -55,37 +91,37 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:text="尚无车辆状态记录"
-        android:textColor="#8D989A"
-        android:textSize="12sp" />
+        android:textColor="#7E8984"
+        android:textSize="10sp" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="40dp"
-        android:layout_marginTop="10dp"
+        android:layout_height="36dp"
+        android:layout_marginTop="9dp"
         android:orientation="horizontal">
 
         <TextView
             android:id="@+id/widget_trip_action"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_marginEnd="5dp"
+            android:layout_marginEnd="4dp"
             android:layout_weight="1"
-            android:background="@drawable/widget_action_background"
+            android:background="@drawable/widget_action_primary_background"
             android:gravity="center"
             android:text="行程"
-            android:textColor="#32F080"
-            android:textSize="13sp" />
+            android:textColor="#70F79D"
+            android:textSize="12sp" />
 
         <TextView
             android:id="@+id/widget_app_action"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_marginStart="5dp"
+            android:layout_marginStart="4dp"
             android:layout_weight="1"
             android:background="@drawable/widget_action_background"
             android:gravity="center"
             android:text="打开 App"
-            android:textColor="#DCE1E2"
-            android:textSize="13sp" />
+            android:textColor="#E0E5E2"
+            android:textSize="12sp" />
     </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/widget_vehicle_home_expanded.xml
+++ b/android/app/src/main/res/layout/widget_vehicle_home_expanded.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_vehicle_background"
+    android:orientation="vertical"
+    android:padding="18dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="sans-serif-medium"
+            android:text="EV CHARGE BOOK"
+            android:textColor="#68F59A"
+            android:textSize="10sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="LOCAL FIRST"
+            android:textColor="#65716C"
+            android:textSize="9sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_vehicle_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-medium"
+        android:maxLines="1"
+        android:text="EV Charge Book"
+        android:textColor="#F5F7F6"
+        android:textSize="24sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/widget_status_badge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/widget_status_background"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingLeft="11dp"
+            android:paddingTop="6dp"
+            android:paddingRight="11dp"
+            android:paddingBottom="6dp"
+            android:text="● 车辆已就绪"
+            android:textColor="#52F58B"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/widget_status_detail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="未开启蓝牙行程检测"
+            android:textColor="#8E9A95"
+            android:textSize="11sp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="11dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="SOC"
+                android:textColor="#69746F"
+                android:textSize="9sp" />
+
+            <TextView
+                android:id="@+id/widget_soc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:text="--"
+                android:textColor="#F5F7F6"
+                android:textSize="36sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="APP 当前里程记录"
+                android:textColor="#69746F"
+                android:textSize="9sp" />
+
+            <TextView
+                android:id="@+id/widget_mileage"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:maxLines="1"
+                android:text="-- km"
+                android:textColor="#DCE2DF"
+                android:textSize="17sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_state_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="尚无车辆状态记录"
+        android:textColor="#7E8984"
+        android:textSize="11sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginTop="11dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/widget_trip_action"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/widget_action_primary_background"
+            android:gravity="center"
+            android:text="行程"
+            android:textColor="#70F79D"
+            android:textSize="13sp" />
+
+        <TextView
+            android:id="@+id/widget_app_action"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_marginStart="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/widget_action_background"
+            android:gravity="center"
+            android:text="打开 App"
+            android:textColor="#E0E5E2"
+            android:textSize="13sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/xml/vehicle_widget_info.xml
+++ b/android/app/src/main/res/xml/vehicle_widget_info.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/widget_vehicle_home"
-    android:minWidth="250dp"
-    android:minHeight="140dp"
+    android:minWidth="180dp"
+    android:minHeight="130dp"
     android:minResizeWidth="180dp"
-    android:minResizeHeight="110dp"
+    android:minResizeHeight="120dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />

--- a/android/app/src/test/java/com/evchargebook/widget/VehicleWidgetTruthTextTest.kt
+++ b/android/app/src/test/java/com/evchargebook/widget/VehicleWidgetTruthTextTest.kt
@@ -2,6 +2,7 @@ package com.evchargebook.widget
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VehicleWidgetTruthTextTest {
@@ -36,12 +37,32 @@ class VehicleWidgetTruthTextTest {
     }
 
     @Test
+    fun `bluetooth configuration is shown as a rule not a live connection claim`() {
+        val promptOnly = VehicleWidgetSnapshot(
+            vehicleId = 7L,
+            bluetoothDetectionEnabled = true,
+            bluetoothDeviceName = "C16",
+        )
+        val autoStart = promptOnly.copy(autoStartOnConnect = true)
+
+        val promptHeadline = VehicleWidgetTruthText.statusHeadline(promptOnly)
+        assertEquals("● 蓝牙检测已开启", promptHeadline)
+        assertFalse(promptHeadline.contains("车辆已连接"))
+        assertEquals("连接C16后提醒确认行程", VehicleWidgetTruthText.statusDetail(promptOnly))
+
+        assertEquals("● 自动行程已就绪", VehicleWidgetTruthText.statusHeadline(autoStart))
+        assertEquals("连接C16后尝试自动开始行程", VehicleWidgetTruthText.statusDetail(autoStart))
+    }
+
+    @Test
     fun `active trip and charging labels describe app bookkeeping only`() {
         val trip = VehicleWidgetSnapshot(vehicleId = 7L, activeTrip = true)
         val charging = VehicleWidgetSnapshot(vehicleId = 7L, activeCharging = true)
 
+        assertEquals("● 行程记录中", VehicleWidgetTruthText.statusHeadline(trip))
         assertEquals("行程记录中 · 本地状态", VehicleWidgetTruthText.stateLabel(trip) { "16:06" })
         assertEquals("打开行程", VehicleWidgetTruthText.tripAction(trip))
+        assertEquals("● 充电记录中", VehicleWidgetTruthText.statusHeadline(charging))
         assertEquals("充电记录中 · 本地状态", VehicleWidgetTruthText.stateLabel(charging) { "16:06" })
         assertEquals("充电记录中", VehicleWidgetTruthText.appAction(charging))
     }
@@ -50,6 +71,14 @@ class VehicleWidgetTruthTextTest {
     fun `empty app state asks user to add vehicle`() {
         val snapshot = VehicleWidgetSnapshot()
 
-        assertEquals("打开 App 添加车辆", VehicleWidgetTruthText.stateLabel(snapshot) { "16:06" })
+        assertEquals("尚未添加车辆", VehicleWidgetTruthText.statusHeadline(snapshot))
+        assertEquals("等待添加车辆", VehicleWidgetTruthText.stateLabel(snapshot) { "16:06" })
+    }
+
+    @Test
+    fun `widget size policy keeps compact layout until a real expanded width exists`() {
+        assertTrue(VehicleWidgetSizePolicy.isCompact(0))
+        assertTrue(VehicleWidgetSizePolicy.isCompact(299))
+        assertFalse(VehicleWidgetSizePolicy.isCompact(300))
     }
 }


### PR DESCRIPTION
Refs #301

## Summary

Turn the existing Stage-1 home widget into the dark, status-first design discussed for main-device testing while preserving the Local First truth boundary.

- add compact vs expanded RemoteViews layouts selected from the launcher-provided widget width;
- refresh layout immediately when the widget is resized;
- keep SOC/mileage sourced only from existing local VehicleState;
- surface configured Bluetooth auto-trip behavior as `蓝牙检测已开启` / `自动行程已就绪`, **not** as a live `车辆已连接` claim;
- read the active vehicle's existing per-vehicle Bluetooth binding without creating a second settings model;
- retain active Trip / active Charging as higher-priority status;
- upgrade the visual system to dark gradient cards, restrained green status treatment, and primary/secondary action surfaces;
- keep actions inside existing app/Trip authority; no background service, polling, remote controls, OEM range, location, or fake live state;
- add JVM coverage for Bluetooth wording and compact/expanded size policy.

## Truth boundary

This PR intentionally does **not** show `车辆已连接`, `车辆在线`, remote location, remaining range, lock/HVAC, or other OEM telemetry. The current Presence pipeline is event-oriented and the widget does not yet have a persisted/reconciled live-presence read model. Until that exists, the widget only describes the user's configured Bluetooth rule.

## Layout behavior

- compact: default below 300dp launcher-reported minimum width;
- expanded: 300dp+;
- both remain resizeable and use the same truthful snapshot/actions.

## Validation

- [x] Android Build #821 / JVM tests
- [x] Debug APK uploaded by Android Build #821
- [x] unknown SOC/mileage truth rules covered by JVM tests
- [x] Bluetooth enabled wording never claims current connection
- [x] active Trip/Charging status precedence covered by JVM tests
- [ ] ColorOS add/remove + resize compact/expanded

No Room schema change.

This PR can land on `main` specifically for launcher/device acceptance; keep #301 open until the physical matrix is checked.