### PR TITLE
fix(android): expose home widget provider to launcher

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
         <receiver android:name=".autotrip.AutoTripActionReceiver" android:exported="false" />
         <receiver
             android:name=".widget.VehicleHomeWidgetProvider"
-            android:exported="false">
+            android:exported="true"
+            android:label="EV Charge Book">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>


### PR DESCRIPTION
Refs #301

The ColorOS card/widget picker did not list EV Charge Book during physical acceptance.

Root cause candidate on current main: `VehicleHomeWidgetProvider` was declared with `android:exported="false"`. Android's current widget guidance registers the AppWidget receiver as exported so launcher/widget hosts can discover and bind the provider.

This PR makes the smallest manifest-only correction:

- set `VehicleHomeWidgetProvider` to `android:exported="true"`;
- give the receiver an explicit `EV Charge Book` label for launcher presentation;
- no changes to Bluetooth receivers, telemetry, widget data model, Room schema, or UI logic.

Acceptance after merge:

- install/update the latest main APK;
- open the app once;
- re-enter ColorOS desktop card/widget picker;
- verify EV Charge Book appears and can be placed;
- resize to confirm compact/expanded layouts still work.
