### PR TITLE
feat(android): converge Trip list, ready, active and overview

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveVehicleHeroV08.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripActiveVehicleHeroV08.kt
@@ -1,0 +1,136 @@
+package com.evchargebook.ui.trip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import com.evchargebook.data.database.AppDatabase
+import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.ui.theme.EVDesignTokens
+import com.evchargebook.ui.theme.LocalAppThemeController
+import com.evchargebook.ui.vehicle.HeroArtworkManifestRepository
+import com.evchargebook.ui.vehicle.OfficialVehicleImageCatalog
+import kotlinx.coroutines.flow.flowOf
+
+/** Active Trip reuses the same managed HERO artwork source as Dashboard, without Dashboard telemetry. */
+@Composable
+internal fun TripActiveVehicleHeroV08(
+    vehicle: VehicleEntity?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val appTheme = LocalAppThemeController.current
+    val media = EVDesignTokens.Media.forTheme(appTheme.darkTheme)
+    val catalogId = vehicle?.catalogVehicleId?.trim()?.takeIf { it.isNotEmpty() }
+    val artworkKey by remember(catalogId, context.applicationContext) {
+        catalogId?.let {
+            AppDatabase.getInstance(context.applicationContext)
+                .vehicleCatalogDao()
+                .observeHeroArtworkKey(it)
+        } ?: flowOf(null)
+    }.collectAsState(initial = null)
+    val artwork = remember(vehicle, artworkKey) {
+        OfficialVehicleImageCatalog.resolve(vehicle, artworkKey)
+    }
+    var remoteArtwork by remember(artwork?.key, appTheme.darkTheme) {
+        mutableStateOf<HeroArtworkManifestRepository.RemoteArtwork?>(null)
+    }
+
+    LaunchedEffect(artwork?.key, appTheme.darkTheme) {
+        remoteArtwork = artwork?.let {
+            HeroArtworkManifestRepository.resolve(
+                context = context,
+                artworkKey = it.key,
+                preferLight = !appTheme.darkTheme,
+            )
+        }
+    }
+
+    val imageUrl = remoteArtwork?.url ?: artwork?.remoteFallbackUrl
+    val cacheVersion = remoteArtwork?.version ?: 0
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(210.dp)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(media.stageTop, media.stageMiddle, media.stageBottom)
+                    )
+                )
+        ) {
+            Icon(
+                imageVector = Icons.Default.DirectionsCar,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = .32f),
+                modifier = Modifier.align(Alignment.Center).fillMaxSize(.32f),
+            )
+            if (imageUrl != null && artwork != null) {
+                val cacheKey = "trip-active-hero:${artwork.key}:v$cacheVersion"
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(imageUrl)
+                        .memoryCacheKey(cacheKey)
+                        .diskCacheKey(cacheKey)
+                        .memoryCachePolicy(CachePolicy.ENABLED)
+                        .diskCachePolicy(CachePolicy.ENABLED)
+                        .networkCachePolicy(CachePolicy.ENABLED)
+                        .build(),
+                    contentDescription = "${vehicle?.brand.orEmpty()} ${vehicle?.model.orEmpty()} 车型图",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center,
+                )
+            }
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(media.scrimStrong, media.scrimSoft, androidx.compose.ui.graphics.Color.Transparent, media.scrimBottom)
+                        )
+                    )
+            )
+            Text(
+                text = vehicle?.displayName ?: "EV Charge Book",
+                modifier = Modifier.align(Alignment.TopStart).padding(horizontal = 16.dp, vertical = 12.dp),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = media.primaryText,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripAddressDisplayV08.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripAddressDisplayV08.kt
@@ -1,0 +1,39 @@
+package com.evchargebook.ui.trip
+
+/**
+ * Presentation-only address compaction for Trip surfaces.
+ *
+ * Reverse-geocoded strings remain the source of truth. We only remove a shared leading city
+ * context when both endpoints are inside the same city. Cross-city trips keep their city/province
+ * prefix so the direction remains unambiguous.
+ */
+internal data class TripEndpointDisplayV08(
+    val start: String,
+    val end: String,
+)
+
+internal fun compactTripEndpointDisplayV08(start: String, end: String): TripEndpointDisplayV08 {
+    val startCityPrefix = cityPrefixV08(start)
+    val endCityPrefix = cityPrefixV08(end)
+    if (startCityPrefix == null || startCityPrefix != endCityPrefix) {
+        return TripEndpointDisplayV08(start = start, end = end)
+    }
+
+    val compactStart = start.removePrefix(startCityPrefix).ifBlank { start }
+    val compactEnd = end.removePrefix(endCityPrefix).ifBlank { end }
+    return TripEndpointDisplayV08(start = compactStart, end = compactEnd)
+}
+
+private fun cityPrefixV08(address: String): String? {
+    if (address.isBlank() || address.contains(',')) return null
+    val cityIndex = address.indexOf('市')
+    if (cityIndex !in 1..11) return null
+
+    val leading = address.substring(0, cityIndex + 1)
+    val provinceIndex = leading.indexOf('省')
+    return when {
+        provinceIndex >= 0 -> leading
+        leading.length >= 3 -> leading
+        else -> null
+    }
+}

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripDetailScreenV06.kt
@@ -2,7 +2,6 @@ package com.evchargebook.ui.trip
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -15,12 +14,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Route
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -41,7 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -67,10 +70,9 @@ private enum class TripDetailSectionV06(val label: String) {
 }
 
 /**
- * v0.6 completed/selected Trip detail.
+ * Completed/selected Trip detail.
  *
- * Overview, route and diagnostics stay separate reading surfaces. Route rendering is delegated to
- * the shared interactive viewport used by playback so pan/zoom/speed semantics cannot drift.
+ * Route and data surfaces intentionally stay isolated. This revision only compacts Overview.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -155,14 +157,14 @@ internal fun TripDetailScreenV06(
             when (selectedSection) {
                 TripDetailSectionV06.OVERVIEW -> {
                     item {
-                        CompletedTripSummaryCardV06(
+                        CompletedTripOverviewV08(
                             trip = trip,
                             vehicle = vehicle,
                             averageSpeedMps = displayAverageSpeed
                         )
                     }
                     item {
-                        CompletedTripEndpointCardV06(
+                        CompletedTripEndpointCardV08(
                             trip = trip,
                             startPoint = firstPoint,
                             endPoint = lastPoint,
@@ -279,8 +281,10 @@ private fun DetailUnavailableCardV06(title: String, detail: String) {
     }
 }
 
+private data class OverviewMetricV08(val label: String, val value: String)
+
 @Composable
-private fun CompletedTripSummaryCardV06(
+private fun CompletedTripOverviewV08(
     trip: TripSessionEntity,
     vehicle: VehicleEntity?,
     averageSpeedMps: Double?
@@ -292,12 +296,12 @@ private fun CompletedTripSummaryCardV06(
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+            verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Column(Modifier.weight(1f)) {
+                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
-                        vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}",
+                        vehicle?.displayName ?: vehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${trip.vehicleId}",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold
                     )
@@ -317,25 +321,34 @@ private fun CompletedTripSummaryCardV06(
                 }
             }
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md),
-                verticalAlignment = Alignment.Bottom
-            ) {
-                SummaryPrimaryMetricV06("距离", formatV06Distance(trip.distanceMeters), Modifier.weight(1f))
-                SummaryPrimaryMetricV06("耗时", formatV06Duration(trip.elapsedSeconds), Modifier.weight(1f))
-            }
+            OverviewMetricGroupV08(
+                title = "行程摘要",
+                icon = Icons.Default.Route,
+                metrics = buildList {
+                    add(OverviewMetricV08("距离", formatV06Distance(trip.distanceMeters)))
+                    add(OverviewMetricV08("耗时", formatV06Duration(trip.elapsedSeconds)))
+                    add(OverviewMetricV08("平均速度", averageSpeedMps?.let(::formatV06Speed) ?: "--"))
+                    if (trip.status == TripStatus.COMPLETED) {
+                        add(OverviewMetricV08("估算能耗", formatV06Consumption(trip.averageConsumptionKwhPer100Km)))
+                    }
+                }
+            )
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .28f))
+            OverviewMetricGroupV08(
+                title = "车辆变化",
+                icon = Icons.Default.DirectionsCar,
+                metrics = listOf(
+                    OverviewMetricV08("SOC 变化", formatV06SocRange(trip.startSoc, trip.endSoc)),
+                    OverviewMetricV08("里程变化", formatV06MileageRange(trip.startMileageKm, trip.endMileageKm))
+                )
+            )
 
-            SummaryMetricGridV06(
-                listOf(
-                    SummaryMetricV06("平均速度", averageSpeedMps?.let(::formatV06Speed) ?: "--"),
-                    SummaryMetricV06("估算能耗", formatV06Consumption(trip.averageConsumptionKwhPer100Km)),
-                    SummaryMetricV06("SOC", formatV06SocRange(trip.startSoc, trip.endSoc)),
-                    SummaryMetricV06("总里程", formatV06MileageRange(trip.startMileageKm, trip.endMileageKm)),
-                    SummaryMetricV06("最高速度", trip.maxSpeedMps?.let(::formatV06Speed) ?: "--"),
-                    SummaryMetricV06("移动时间", trip.movingSeconds?.let(::formatV06Duration) ?: "--")
+            OverviewMetricGroupV08(
+                title = "行驶状态",
+                icon = Icons.Default.Speed,
+                metrics = listOf(
+                    OverviewMetricV08("最高速度", trip.maxSpeedMps?.let(::formatV06Speed) ?: "--"),
+                    OverviewMetricV08("移动时间", trip.movingSeconds?.let(::formatV06Duration) ?: "--")
                 )
             )
         }
@@ -343,7 +356,50 @@ private fun CompletedTripSummaryCardV06(
 }
 
 @Composable
-private fun CompletedTripEndpointCardV06(
+private fun OverviewMetricGroupV08(
+    title: String,
+    icon: ImageVector,
+    metrics: List<OverviewMetricV08>
+) {
+    val accent = EVDesignTokens.Energy.green
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .42f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = .14f))
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 11.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Surface(shape = CircleShape, color = accent.copy(alpha = .10f)) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.padding(6.dp).size(15.dp)
+                    )
+                }
+                Text(title, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold)
+            }
+            metrics.chunked(2).forEach { rowMetrics ->
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    rowMetrics.forEach { metric ->
+                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(metric.label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(metric.value, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        }
+                    }
+                    if (rowMetrics.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompletedTripEndpointCardV08(
     trip: TripSessionEntity,
     startPoint: TripPointEntity?,
     endPoint: TripPointEntity?,
@@ -353,6 +409,14 @@ private fun CompletedTripEndpointCardV06(
 ) {
     val accent = EVDesignTokens.Energy.green
     val finalEndpoint = trip.status == TripStatus.COMPLETED
+    val displayPair = remember(startAddress, endAddress) {
+        if (!startAddress.isNullOrBlank() && !endAddress.isNullOrBlank()) {
+            compactTripEndpointDisplayV08(startAddress, endAddress)
+        } else {
+            TripEndpointDisplayV08(startAddress.orEmpty(), endAddress.orEmpty())
+        }
+    }
+
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -365,17 +429,12 @@ private fun CompletedTripEndpointCardV06(
             EndpointLineV06(
                 label = "起点",
                 point = startPoint,
-                address = startAddress,
+                address = displayPair.start.takeIf { it.isNotBlank() },
                 resolving = resolving,
                 recording = trip.status == TripStatus.RECORDING,
                 recordingText = "行程进行中，结束后解析地址",
                 icon = {
-                    Icon(
-                        Icons.Default.PlayArrow,
-                        contentDescription = null,
-                        tint = accent,
-                        modifier = Modifier.size(18.dp)
-                    )
+                    Icon(Icons.Default.PlayArrow, contentDescription = null, tint = accent, modifier = Modifier.size(18.dp))
                 }
             )
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .22f))
@@ -383,33 +442,23 @@ private fun CompletedTripEndpointCardV06(
                 EndpointLineV06(
                     label = "终点",
                     point = endPoint,
-                    address = endAddress,
+                    address = displayPair.end.takeIf { it.isNotBlank() },
                     resolving = resolving,
                     recording = false,
                     icon = {
-                        Icon(
-                            Icons.Default.Flag,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(17.dp)
-                        )
+                        Icon(Icons.Default.Flag, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(17.dp))
                     }
                 )
             } else {
                 EndpointLineV06(
                     label = if (trip.status == TripStatus.RECORDING) "当前点" else "最后记录点",
                     point = endPoint,
-                    address = endAddress,
+                    address = displayPair.end.takeIf { it.isNotBlank() },
                     resolving = resolving,
                     recording = trip.status == TripStatus.RECORDING,
                     recordingText = "当前最新定位点",
                     icon = {
-                        Icon(
-                            Icons.Default.LocationOn,
-                            contentDescription = null,
-                            tint = accent,
-                            modifier = Modifier.size(17.dp)
-                        )
+                        Icon(Icons.Default.LocationOn, contentDescription = null, tint = accent, modifier = Modifier.size(17.dp))
                     }
                 )
             }
@@ -458,40 +507,6 @@ private fun EndpointLineV06(
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            }
-        }
-    }
-}
-
-private data class SummaryMetricV06(val label: String, val value: String)
-
-@Composable
-private fun SummaryPrimaryMetricV06(label: String, value: String, modifier: Modifier) {
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-    }
-}
-
-@Composable
-private fun SummaryMetricGridV06(metrics: List<SummaryMetricV06>) {
-    BoxWithConstraints(Modifier.fillMaxWidth()) {
-        val compact = maxWidth < 360.dp || LocalConfiguration.current.fontScale >= 1.3f
-        val columns = if (compact) 2 else 3
-        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            metrics.chunked(columns).forEach { rowMetrics ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-                ) {
-                    rowMetrics.forEach { metric ->
-                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                            Text(metric.label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            Text(metric.value, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                        }
-                    }
-                    repeat(columns - rowMetrics.size) { Spacer(Modifier.weight(1f)) }
-                }
             }
         }
     }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripHistoryCardV06.kt
@@ -54,6 +54,9 @@ internal fun TripHistoryCardV06(
     onDelete: () -> Unit
 ) {
     val endpoints = rememberTripEndpointLabels(trip)
+    val displayEndpoints = remember(endpoints) {
+        compactTripEndpointDisplayV08(endpoints.start, endpoints.end)
+    }
     val validity = remember(trip) { TripValidityRules.assess(trip) }
     val accent = EVDesignTokens.Energy.green
     val statusLabel = when (validity.status) {
@@ -114,8 +117,8 @@ internal fun TripHistoryCardV06(
                     )
                 }
 
-                EndpointHistoryLineV06("起", endpoints.start)
-                EndpointHistoryLineV06("终", endpoints.end)
+                EndpointHistoryLineV06("起", displayEndpoints.start)
+                EndpointHistoryLineV06("终", displayEndpoints.end)
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripReadyScreen.kt
@@ -1,5 +1,6 @@
 package com.evchargebook.ui.trip
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -16,11 +17,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -34,8 +38,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -43,6 +47,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.VehicleEntity
+import com.evchargebook.ui.dashboard.HeroVehicleCard
 import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.text.SimpleDateFormat
@@ -93,34 +98,35 @@ fun TripReadyScreen(
                         }
                     }
                 },
-                actions = {
-                    if (!preparing) {
-                        TextButton(
-                            onClick = { preparing = true },
-                            enabled = vehicle != null
-                        ) {
-                            Text("开始行程", color = if (vehicle != null) accent else MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
-                    }
-                },
                 windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
+        },
+        floatingActionButton = {
+            if (!preparing) {
+                FloatingActionButton(
+                    onClick = { if (vehicle != null) preparing = true },
+                    containerColor = if (vehicle != null) accent else MaterialTheme.colorScheme.surfaceContainerHigh,
+                    contentColor = if (vehicle != null) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                ) {
+                    Icon(Icons.Default.PlayArrow, contentDescription = "开始行程")
+                }
+            }
         }
     ) { padding ->
         if (preparing) {
-            TripPreparationContentV06(
+            TripPreparationContentV08(
                 modifier = Modifier.fillMaxSize().padding(padding),
                 vehicle = vehicle,
                 currentSoc = currentSoc,
                 currentMileageKm = currentMileageKm,
+                latestTrip = orderedTrips.firstOrNull(),
                 onStart = onStart
             )
         } else {
-            TripHomeContentV06(
+            TripHomeContentV08(
                 modifier = Modifier.fillMaxSize().padding(padding),
                 orderedTrips = orderedTrips,
-                onStartPreparation = { preparing = true },
                 canStart = vehicle != null,
                 onOpenDetail = onOpenDetail,
                 onDelete = { deleteTarget = it }
@@ -133,9 +139,7 @@ fun TripReadyScreen(
             onDismissRequest = { deleteTarget = null },
             title = { Text("删除这条行程？") },
             text = {
-                Text(
-                    "行程及关联轨迹点会一并删除，删除后无法恢复。若这条行程提供了最新 SOC 或里程，车辆当前状态会根据剩余记录重新计算。"
-                )
+                Text("行程及关联轨迹点会一并删除，删除后无法恢复。若这条行程提供了最新 SOC 或里程，车辆当前状态会根据剩余记录重新计算。")
             },
             confirmButton = {
                 TextButton(
@@ -143,9 +147,7 @@ fun TripReadyScreen(
                         onDelete(trip)
                         deleteTarget = null
                     }
-                ) {
-                    Text("确认删除", color = MaterialTheme.colorScheme.error)
-                }
+                ) { Text("确认删除", color = MaterialTheme.colorScheme.error) }
             },
             dismissButton = {
                 TextButton(onClick = { deleteTarget = null }) { Text("取消") }
@@ -155,17 +157,23 @@ fun TripReadyScreen(
 }
 
 @Composable
-private fun TripHomeContentV06(
+private fun TripHomeContentV08(
     modifier: Modifier,
     orderedTrips: List<TripSessionEntity>,
     canStart: Boolean,
-    onStartPreparation: () -> Unit,
     onOpenDetail: (Long) -> Unit,
     onDelete: (TripSessionEntity) -> Unit
 ) {
+    var expanded by rememberSaveable { mutableStateOf(true) }
+
     LazyColumn(
         modifier = modifier,
-        contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
+        contentPadding = PaddingValues(
+            start = MaterialTheme.spacing.md,
+            end = MaterialTheme.spacing.md,
+            top = MaterialTheme.spacing.sm,
+            bottom = 96.dp
+        ),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
     ) {
         orderedTrips.firstOrNull()?.let { latest ->
@@ -179,23 +187,32 @@ private fun TripHomeContentV06(
 
         item {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.Bottom
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(enabled = orderedTrips.isNotEmpty()) { expanded = !expanded }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text("最近行程", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
                     Text(
-                        if (orderedTrips.isEmpty()) "完成第一段行程后会显示在这里" else "共 ${orderedTrips.size} 条 · 点击查看轨迹与明细",
+                        when {
+                            orderedTrips.isEmpty() -> "完成第一段行程后会显示在这里"
+                            expanded -> "共 ${orderedTrips.size} 条 · 点击收起"
+                            else -> "共 ${orderedTrips.size} 条 · 点击展开"
+                        },
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                if (!canStart) {
-                    Text(
-                        "请先选择车辆",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                if (orderedTrips.isNotEmpty()) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (expanded) "收起最近行程" else "展开最近行程",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                } else if (!canStart) {
+                    Text("请先选择车辆", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
@@ -209,21 +226,18 @@ private fun TripHomeContentV06(
                 ) {
                     Column(
                         modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
-                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         Text("还没有行程记录", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                         Text(
-                            "开始后只记录真实 GPS 轨迹；不会预设终点或虚构路线。",
+                            "右下角开始行程后，只记录真实 GPS 轨迹，不预设终点或虚构路线。",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        TextButton(onClick = onStartPreparation, enabled = canStart) {
-                            Text("准备开始行程")
-                        }
                     }
                 }
             }
-        } else {
+        } else if (expanded) {
             items(orderedTrips, key = { it.id }) { trip ->
                 TripHistoryCardV06(
                     trip = trip,
@@ -232,7 +246,6 @@ private fun TripHomeContentV06(
                 )
             }
         }
-        item { Spacer(Modifier.height(16.dp)) }
     }
 }
 
@@ -256,11 +269,7 @@ private fun LatestTripSummaryV06(trip: TripSessionEntity, onClick: () -> Unit) {
                     verticalArrangement = Arrangement.spacedBy(1.dp)
                 ) {
                     Text("最近一次", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    Text(
-                        formatHomeTripTime(trip.startedAtEpochMillis),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    Text(formatHomeTripTime(trip.startedAtEpochMillis), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 }
                 Text("已完成", style = MaterialTheme.typography.labelSmall, color = accent)
             }
@@ -273,20 +282,14 @@ private fun LatestTripSummaryV06(trip: TripSessionEntity, onClick: () -> Unit) {
                 val compact = maxWidth < 360.dp || LocalConfiguration.current.fontScale >= 1.3f
                 if (compact) {
                     Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-                        ) {
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
                             HomeMetricV06("距离", formatHomeDistance(trip.distanceMeters), Modifier.weight(1f))
                             HomeMetricV06("耗时", formatHomeDuration(trip.elapsedSeconds), Modifier.weight(1f))
                         }
                         HomeMetricV06("能耗", energyText, Modifier.fillMaxWidth())
                     }
                 } else {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)
-                    ) {
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
                         HomeMetricV06("距离", formatHomeDistance(trip.distanceMeters), Modifier.weight(1f))
                         HomeMetricV06("耗时", formatHomeDuration(trip.elapsedSeconds), Modifier.weight(1f))
                         HomeMetricV06("能耗", energyText, Modifier.weight(1f))
@@ -294,12 +297,11 @@ private fun LatestTripSummaryV06(trip: TripSessionEntity, onClick: () -> Unit) {
                 }
             }
 
-            val socText = when {
+            when {
                 trip.startSoc != null && trip.endSoc != null -> "SOC ${trip.startSoc}% → ${trip.endSoc}%"
                 trip.startSoc != null -> "SOC ${trip.startSoc}% → --"
                 else -> null
-            }
-            socText?.let {
+            }?.let {
                 Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
@@ -315,11 +317,12 @@ private fun HomeMetricV06(label: String, value: String, modifier: Modifier) {
 }
 
 @Composable
-private fun TripPreparationContentV06(
+private fun TripPreparationContentV08(
     modifier: Modifier,
     vehicle: VehicleEntity?,
     currentSoc: Int?,
     currentMileageKm: Double?,
+    latestTrip: TripSessionEntity?,
     onStart: () -> Unit
 ) {
     LazyColumn(
@@ -328,15 +331,16 @@ private fun TripPreparationContentV06(
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
     ) {
         item {
-            ReadyVehicleSnapshotCard(
+            HeroVehicleCard(
                 vehicle = vehicle,
                 currentSoc = currentSoc,
-                currentMileageKm = currentMileageKm
+                currentMileageKm = currentMileageKm,
+                latestTrip = latestTrip,
+                vehicleSwitchEnabled = false
             )
         }
-        item {
-            TripBackgroundRecordingGuidance()
-        }
+        item { ReadyGpsTruthCardV08() }
+        item { TripBackgroundRecordingGuidance() }
         item {
             TripSlideAction(
                 label = "滑动开始行程",
@@ -364,103 +368,30 @@ private fun TripPreparationContentV06(
 }
 
 @Composable
-private fun ReadyVehicleSnapshotCard(
-    vehicle: VehicleEntity?,
-    currentSoc: Int?,
-    currentMileageKm: Double?
-) {
+private fun ReadyGpsTruthCardV08() {
     val accent = EVDesignTokens.Energy.green
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.surfaceContainerLow
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = MaterialTheme.spacing.md, vertical = 14.dp),
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
         ) {
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-                    Text(
-                        vehicle?.let { "${it.brand} ${it.model}" } ?: "请选择车辆",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    Text(
-                        "开始时记录当前车辆状态",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                if (vehicle != null) {
-                    Text("READY", style = MaterialTheme.typography.labelMedium, color = accent)
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.lg),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                ReadySnapshotMetric(
-                    label = "当前 SOC",
-                    value = currentSoc?.let { "$it%" } ?: "--",
-                    modifier = Modifier.weight(1f)
-                )
-                ReadySnapshotMetric(
-                    label = "当前里程",
-                    value = currentMileageKm?.let { "${formatReadyMileage(it)} km" } ?: "--",
-                    modifier = Modifier.weight(1f)
-                )
-            }
-
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = .22f))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
-            ) {
-                Icon(
-                    Icons.Default.LocationOn,
-                    contentDescription = null,
-                    tint = accent,
-                    modifier = Modifier.size(18.dp)
-                )
-                Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-                    Text("GPS 实录", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Medium)
-                    Text(
-                        "开始后记录真实定位；不预设终点，也不会虚构路线。",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-
-            if (currentSoc == null && vehicle != null) {
+            Icon(Icons.Default.LocationOn, contentDescription = null, tint = accent, modifier = Modifier.size(22.dp))
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text("GPS 实录", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 Text(
-                    "当前 SOC 未维护：仍可记录真实行程，但不会据此估算行驶能耗。",
-                    style = MaterialTheme.typography.labelSmall,
+                    "开始后记录真实定位；不预设终点，也不会虚构路线。",
+                    style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
     }
 }
-
-@Composable
-private fun ReadySnapshotMetric(label: String, value: String, modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(2.dp)
-    ) {
-        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
-    }
-}
-
-private fun formatReadyMileage(value: Double): String =
-    if (value % 1.0 == 0.0) value.toLong().toString() else String.format(Locale.US, "%.1f", value)
 
 private fun formatHomeTripTime(epochMillis: Long): String =
     SimpleDateFormat("MM-dd HH:mm", Locale.SIMPLIFIED_CHINESE).format(Date(epochMillis))
@@ -473,7 +404,7 @@ private fun formatHomeDuration(seconds: Long): String {
     val hours = seconds / 3600
     val minutes = (seconds % 3600) / 60
     return when {
-        hours > 0 -> "${hours}h${minutes}m"
+        hours > 0 -> "${hours}h ${minutes}m"
         minutes > 0 -> "${minutes}m"
         else -> "<1m"
     }

--- a/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/trip/TripScreen.kt
@@ -1,9 +1,7 @@
 package com.evchargebook.ui.trip
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -15,15 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -40,24 +33,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.evchargebook.data.entity.TripPointEntity
 import com.evchargebook.data.entity.TripSessionEntity
 import com.evchargebook.data.entity.TripStatus
 import com.evchargebook.data.entity.VehicleEntity
-import com.evchargebook.ui.theme.EVDesignTokens
 import com.evchargebook.ui.theme.spacing
 import java.util.Locale
 import kotlinx.coroutines.delay
 
-/**
- * Trip router + active v0.6 cockpit.
- *
- * The no-active state is owned by TripReadyScreen. Selected/completed detail is intentionally
- * isolated in TripDetailScreen.kt so detail/map/diagnostics can evolve without destabilizing live tracking.
- */
+/** Trip router + compact active Trip experience. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TripScreen(
@@ -91,26 +77,14 @@ fun TripScreen(
 
     val activeVehicle = vehicles.firstOrNull { it.id == activeTrip.vehicleId } ?: vehicle
     val interrupted = activeTrip.status == TripStatus.INTERRUPTED
-    val telemetry = remember(selectedTripPoints) { summarizeActiveTripTelemetry(selectedTripPoints) }
     val liveElapsedSeconds = rememberLiveTripElapsedSeconds(activeTrip)
-    val accent = EVDesignTokens.Energy.green
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
-                title = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text("行程进行中", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                        Spacer(Modifier.width(8.dp))
-                        Box(
-                            Modifier
-                                .size(7.dp)
-                                .background(if (interrupted) MaterialTheme.colorScheme.error else accent, CircleShape)
-                        )
-                    }
-                },
+                title = { Text("行程中", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold) },
                 windowInsets = WindowInsets(0, 0, 0, 0),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
@@ -121,6 +95,8 @@ fun TripScreen(
             contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.md, vertical = MaterialTheme.spacing.sm),
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
         ) {
+            item { TripActiveVehicleHeroV08(vehicle = activeVehicle) }
+
             item {
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
@@ -131,58 +107,48 @@ fun TripScreen(
                         modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
                         verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
                     ) {
-                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                            Column(Modifier.weight(1f)) {
-                                Text(
-                                    activeVehicle?.let { "${it.brand} ${it.model}" } ?: "车辆 #${activeTrip.vehicleId}",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                Text(
-                                    if (interrupted) "定位已中断，等待用户恢复" else "真实 GPS 持续记录",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                            ActiveStatusPill(
-                                text = if (interrupted) "需恢复" else "记录中",
-                                warning = interrupted
-                            )
-                        }
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md),
-                            verticalAlignment = Alignment.Bottom
-                        ) {
-                            ActivePrimaryMetric(
-                                label = "行程距离",
-                                value = if (activeTrip.distanceMeters > 0.0) formatActiveDistance(activeTrip.distanceMeters) else "--",
-                                modifier = Modifier.weight(1f)
-                            )
-                            ActivePrimaryMetric(
-                                label = "当前速度",
-                                value = telemetry.trustedLatestSpeedMps?.let(::formatActiveSpeed) ?: "--",
-                                modifier = Modifier.weight(1f)
-                            )
-                        }
-
-                        HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f))
-
-                        ActiveMetricGrid(
-                            listOf(
-                                ActiveMetric("已记录", formatActiveDuration(liveElapsedSeconds)),
-                                ActiveMetric("行驶均速", activeTrip.averageSpeedMps?.let(::formatActiveSpeed) ?: "--"),
-                                ActiveMetric("最高速度", activeTrip.maxSpeedMps?.let(::formatActiveSpeed) ?: "--"),
-                                ActiveMetric("起始 SOC", activeTrip.startSoc?.let { "$it%" } ?: "--")
-                            )
+                        Text(
+                            if (interrupted) "记录已中断" else "行程进行中",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = if (interrupted) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+                        )
+                        ActiveMetricRowsV08(
+                            elapsedSeconds = liveElapsedSeconds,
+                            distanceMeters = activeTrip.distanceMeters,
+                            averageSpeedMps = activeTrip.averageSpeedMps,
+                            maxSpeedMps = activeTrip.maxSpeedMps
                         )
                     }
                 }
             }
 
             item {
-                TripActiveTelemetryV06(points = selectedTripPoints)
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.surfaceContainerLow
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
+                        verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)
+                    ) {
+                        Text("实时轨迹", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                        if (selectedTripPoints.size >= 2) {
+                            TripRouteViewportV07(
+                                points = selectedTripPoints,
+                                finalEndpoint = false,
+                                height = 190.dp
+                            )
+                        } else {
+                            Text(
+                                "正在等待足够的可信 GPS 点绘制轨迹…",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
             }
 
             if (interrupted) {
@@ -190,7 +156,7 @@ fun TripScreen(
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
                         shape = MaterialTheme.shapes.large,
-                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.08f)
+                        color = MaterialTheme.colorScheme.error.copy(alpha = .08f)
                     ) {
                         Column(
                             modifier = Modifier.fillMaxWidth().padding(MaterialTheme.spacing.md),
@@ -213,17 +179,6 @@ fun TripScreen(
             }
 
             item {
-                OutlinedButton(
-                    onClick = { onOpenDetail(activeTrip.id) },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Icon(Icons.Default.Route, contentDescription = null)
-                    Spacer(Modifier.width(MaterialTheme.spacing.xs))
-                    Text("查看完整轨迹与诊断")
-                }
-            }
-
-            item {
                 TripSlideAction(
                     label = if (interrupted) "滑动结束已中断行程" else "滑动结束行程",
                     enabled = true,
@@ -232,7 +187,7 @@ fun TripScreen(
                     releaseLabel = "松开结束"
                 )
                 Text(
-                    "滑动后进入结束确认；返回可继续记录，保存后结束本次行程。",
+                    "结束确认后才计算本次能耗等完成态数据；进行中不展示临时估算。",
                     modifier = Modifier.padding(top = 6.dp),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -241,6 +196,33 @@ fun TripScreen(
 
             item { Spacer(Modifier.size(MaterialTheme.spacing.md)) }
         }
+    }
+}
+
+@Composable
+private fun ActiveMetricRowsV08(
+    elapsedSeconds: Long,
+    distanceMeters: Double,
+    averageSpeedMps: Double?,
+    maxSpeedMps: Double?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            ActiveMetricV08("行驶时长", formatActiveDuration(elapsedSeconds), Modifier.weight(1f))
+            ActiveMetricV08("行驶里程", formatActiveDistance(distanceMeters), Modifier.weight(1f))
+        }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
+            ActiveMetricV08("平均速度", averageSpeedMps?.let(::formatActiveSpeed) ?: "--", Modifier.weight(1f))
+            ActiveMetricV08("最高速度", maxSpeedMps?.let(::formatActiveSpeed) ?: "--", Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun ActiveMetricV08(label: String, value: String, modifier: Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
     }
 }
 
@@ -262,61 +244,10 @@ private fun rememberLiveTripElapsedSeconds(trip: TripSessionEntity): Long {
     return maxOf(trip.elapsedSeconds, wallClockElapsed)
 }
 
-private data class ActiveMetric(val label: String, val value: String)
-
-@Composable
-private fun ActivePrimaryMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.SemiBold)
-    }
-}
-
-@Composable
-private fun ActiveMetricGrid(metrics: List<ActiveMetric>) {
-    BoxWithConstraints(Modifier.fillMaxWidth()) {
-        val compact = maxWidth < 360.dp || LocalConfiguration.current.fontScale >= 1.3f
-        val columns = if (compact) 2 else 3
-        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.sm)) {
-            metrics.chunked(columns).forEach { rowMetrics ->
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.md)) {
-                    rowMetrics.forEach { metric ->
-                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                            Text(metric.label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            Text(metric.value, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                        }
-                    }
-                    repeat(columns - rowMetrics.size) { Spacer(Modifier.weight(1f)) }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ActiveStatusPill(text: String, warning: Boolean) {
-    val accent = EVDesignTokens.Energy.green
-    val color = if (warning) MaterialTheme.colorScheme.error else accent
-    Surface(shape = CircleShape, color = color.copy(alpha = 0.10f)) {
-        Row(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Icon(
-                imageVector = if (warning) Icons.Default.WarningAmber else Icons.Default.CheckCircle,
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.size(14.dp)
-            )
-            Text(text, style = MaterialTheme.typography.labelSmall, color = color)
-        }
-    }
-}
-
 private fun formatActiveDistance(meters: Double): String =
     if (meters >= 1000.0) String.format(Locale.US, "%.2f km", meters / 1000.0)
-    else String.format(Locale.US, "%.0f m", meters)
+    else if (meters >= 0.0) String.format(Locale.US, "%.0f m", meters)
+    else "--"
 
 private fun formatActiveSpeed(mps: Double): String =
     String.format(Locale.US, "%.0f km/h", mps * 3.6)
@@ -326,8 +257,7 @@ private fun formatActiveDuration(seconds: Long): String {
     val minutes = (seconds % 3600) / 60
     val secs = seconds % 60
     return when {
-        hours > 0 -> "${hours}h ${minutes}m"
-        minutes > 0 -> "${minutes}m ${secs}s"
-        else -> "${secs}s"
+        hours > 0 -> "%02d:%02d:%02d".format(hours, minutes, secs)
+        else -> "%02d:%02d".format(minutes, secs)
     }
 }


### PR DESCRIPTION
Closes #331

Supersedes closed draft #333 only because the connector could not transition that draft to Ready; this is the same branch/head and same code.

## Scope
- 行程列表：开始行程改为右下角 FAB；最近行程支持收纳；同城地址压缩行政前缀。
- 开始行程：直接复用 Dashboard `HeroVehicleCard`，保留 GPS 实录、后台记录保护和滑动开始。
- 行程中：复用同一 managed HERO 资源；只展示行驶时长/里程/平均速度/最高速度；不展示 SOC，不在完成前计算/展示能耗；下方直接复用现有 `TripRouteViewportV07` 展示实时轨迹。
- 行程详情·概览：参数按「行程摘要 / 车辆变化 / 行驶状态」分组，降低信息块尺寸；地址同城简写；能耗仅完成态展示。

## Frozen / intentionally unchanged
- 行程详情·轨迹 UI/交互与数据语义
- 行程详情·数据的海拔/诊断/回放逻辑
- `TripRouteViewportV07`, MapLibre, playback, diagnostics, trend implementation

Android Build #830 is green on this exact head SHA.