### PR TITLE
fix(android): add direct home-widget pin flow

### DIFF
--- a/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
+++ b/android/app/src/main/java/com/evchargebook/ui/vehicle/VehicleScreen.kt
@@ -108,6 +108,20 @@ fun VehicleScreen(
 
             item { SettingsSectionTitle("连接与数据", "CONNECTION & DATA") }
             item { SettingsRow(Icons.Default.Bluetooth, "车载蓝牙", "连接指定设备时提醒开始行程", onBluetoothPrompt) }
+            item {
+                SettingsRow(
+                    Icons.Default.Home,
+                    "桌面小组件",
+                    "直接请求系统添加，不依赖 ColorOS 卡片中心"
+                ) {
+                    val result = com.evchargebook.widget.VehicleWidgetPinning.request(context)
+                    android.widget.Toast.makeText(
+                        context,
+                        com.evchargebook.widget.VehicleWidgetPinning.message(result),
+                        android.widget.Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
             item { SettingsRow(Icons.Default.UploadFile, "导出备份", "完整 JSON，可用于恢复车辆、充电记录和行程", onExportBackup) }
             item { SettingsRow(Icons.Default.TableView, "导出分析 CSV", "当前车辆充电账本，可用于 Excel / Python 分析", onExportCsv) }
             item { SettingsRow(Icons.Default.Download, "恢复备份", "从本地 JSON 备份恢复数据", onImportBackup) }

--- a/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetPinning.kt
+++ b/android/app/src/main/java/com/evchargebook/widget/VehicleWidgetPinning.kt
@@ -1,0 +1,54 @@
+package com.evchargebook.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Process
+
+enum class VehicleWidgetPinResult {
+    REQUESTED,
+    PROVIDER_UNAVAILABLE,
+    LAUNCHER_UNSUPPORTED,
+    REQUEST_REJECTED,
+}
+
+/**
+ * Requests that the current launcher pin the existing EV Charge Book AppWidget directly.
+ *
+ * This deliberately bypasses OEM-specific card catalogs (for example ColorOS 卡片中心):
+ * the home widget remains a standard Android AppWidget and the launcher decides whether it
+ * supports the platform pin request.
+ */
+object VehicleWidgetPinning {
+    fun request(context: Context): VehicleWidgetPinResult {
+        val appContext = context.applicationContext
+        val manager = AppWidgetManager.getInstance(appContext)
+        val provider = ComponentName(appContext, VehicleHomeWidgetProvider::class.java)
+
+        val providerRegistered = manager
+            .getInstalledProvidersForPackage(appContext.packageName, Process.myUserHandle())
+            .any { it.provider == provider }
+        if (!providerRegistered) return VehicleWidgetPinResult.PROVIDER_UNAVAILABLE
+
+        if (!manager.isRequestPinAppWidgetSupported) {
+            return VehicleWidgetPinResult.LAUNCHER_UNSUPPORTED
+        }
+
+        return if (manager.requestPinAppWidget(provider, null, null)) {
+            VehicleWidgetPinResult.REQUESTED
+        } else {
+            VehicleWidgetPinResult.REQUEST_REJECTED
+        }
+    }
+
+    fun message(result: VehicleWidgetPinResult): String = when (result) {
+        VehicleWidgetPinResult.REQUESTED ->
+            "已向桌面发起添加请求，请在系统弹窗中确认"
+        VehicleWidgetPinResult.PROVIDER_UNAVAILABLE ->
+            "系统暂未识别 EV Charge Book 小组件，请重新安装最新版本后重试"
+        VehicleWidgetPinResult.LAUNCHER_UNSUPPORTED ->
+            "当前桌面不支持应用内添加标准小组件，请使用桌面的标准小组件入口"
+        VehicleWidgetPinResult.REQUEST_REJECTED ->
+            "桌面拒绝了添加请求，请检查桌面锁定或应用锁后重试"
+    }
+}


### PR DESCRIPTION
Refs #301

Physical ColorOS acceptance still cannot find EV Charge Book inside the OEM `卡片中心`. Stop treating that vendor catalog as the standard Android widget picker and add a direct platform pin path from inside EV Charge Book.

## What changes

- add `VehicleWidgetPinning`, backed by `AppWidgetManager.requestPinAppWidget()`;
- verify the existing `VehicleHomeWidgetProvider` is registered for the current package/user before requesting pinning;
- distinguish provider unavailable / launcher unsupported / request rejected / request submitted;
- add `车辆 → 连接与数据 → 桌面小组件` so the user can request the system launcher to place the widget without going through ColorOS `卡片中心`;
- show a truthful toast result for each branch;
- no widget data/UI redesign, telemetry, Bluetooth, Room, or Trip authority changes.

## Why

`卡片中心` is an OEM-specific surface and does not prove the launcher failed to register our standard Android AppWidget. Android 8.0+ exposes `requestPinAppWidget()` specifically so apps can ask a compatible default launcher to pin their declared widget directly.

## Acceptance on ColorOS

1. install this build and open EV Charge Book;
2. go to `车辆 → 连接与数据 → 桌面小组件`;
3. tap it while the app is foreground;
4. if the launcher supports standard pinning, confirm the system add-to-home prompt;
5. verify the widget lands on the home screen and can resize compact/expanded;
6. if no prompt appears, report the toast text — it tells us whether the provider is missing, the launcher API is unsupported, or the request was rejected.

No Room schema change.